### PR TITLE
Fix CI pipeline failures: YAML syntax and test regression

### DIFF
--- a/blueprints/includes/elasticsearch.yml
+++ b/blueprints/includes/elasticsearch.yml
@@ -6,19 +6,19 @@ services:
   {{ if or (eq $search "elasticsearch") (eq $search "opensearch") }}
   elasticsearch:
     image: >-
-      {{- if eq .Config.Recipe "magento2" -}}
+      {{ if eq .Config.Recipe "magento2" -}}
         {{- if eq $search "elasticsearch" -}}
           govard/elasticsearch:{{ $searchVersion }}
         {{- else -}}
           govard/opensearch:{{ $searchVersion }}
         {{- end -}}
-      {{- else -}}
+      {{ else -}}
         {{- if eq $search "elasticsearch" -}}
           docker.elastic.co/elasticsearch/elasticsearch:{{ $searchVersion }}
         {{- else -}}
           opensearchproject/opensearch:{{ $searchVersion }}
         {{- end -}}
-      {{- end -}}
+      {{ end -}}
 
     environment:
       - discovery.type=single-node

--- a/tests/blueprint_features_test.go
+++ b/tests/blueprint_features_test.go
@@ -59,7 +59,7 @@ func TestRenderBlueprintWithOpensearch(t *testing.T) {
 		},
 	})
 
-	if !strings.Contains(content, "opensearchproject/opensearch:2.19.0") {
+	if !strings.Contains(content, "govard/opensearch:2.19.0") {
 		t.Fatalf("Expected opensearch image with default version")
 	}
 }


### PR DESCRIPTION
The CI pipeline was failing due to a YAML syntax error in the Elasticsearch blueprint template and a subsequent test failure.

1. In `blueprints/includes/elasticsearch.yml`, the use of `{{-` was trimming the newline immediately after `image: >-`, which resulted in invalid YAML. I removed the leading dashes from the top-level template tags in that block to ensure the newline and indentation are preserved.
2. `TestRenderBlueprintWithOpensearch` was failing because it expected the official OpenSearch image while the blueprint for the `magento2` recipe uses a custom `govard/opensearch` image. I updated the test to reflect this requirement.

These changes fix the unit tests and should restore the CI pipeline.

---
*PR created automatically by Jules for task [3232528061962154337](https://jules.google.com/task/3232528061962154337) started by @ddtcorex*