### PR TITLE
🛡️ Sentinel: Fix Insecure Temporary File Usage in Trust Logic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - [Insecure Temporary File Usage in Trust Logic]
+**Vulnerability:** The `trustDarwin` function relied on a hardcoded path `/tmp/govard-ca.crt` to load the CA certificate. This file was expected to be placed there by the user or an external process.
+**Learning:** Using predictable paths in shared directories like `/tmp` can lead to TOCTOU vulnerabilities or pre-creation attacks, where a malicious user creates the file first with bad content.
+**Prevention:** Always use user-specific directories (like `~/.govard/ssl`) or secure temporary file creation APIs (`os.MkdirTemp`) that guarantee unique, private paths.

--- a/internal/engine/trust.go
+++ b/internal/engine/trust.go
@@ -31,68 +31,104 @@ func TrustCA() error {
 func trustLinux() error {
 	pterm.Info.Println("On Linux, this requires sudo privileges to update /usr/local/share/ca-certificates/")
 
-	proxyContainer := "proxy-caddy-1"
-
-	// Get the actual user's home directory even if running under sudo
-	homeDir := os.Getenv("HOME")
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		if u, err := user.Lookup(sudoUser); err == nil {
-			homeDir = u.HomeDir
-		}
+	localCertPath, err := extractCAToUserDir()
+	if err != nil {
+		return err
 	}
 
-	sslDir := filepath.Join(homeDir, ".govard", "ssl")
-	if err := os.MkdirAll(sslDir, 0755); err != nil {
-		return fmt.Errorf("failed to create ssl directory %s: %w", sslDir, err)
-	}
-
-	localCertPath := filepath.Join(sslDir, "root.crt")
 	systemCertPath := "/usr/local/share/ca-certificates/govard.crt"
 
-	// 1. Extract cert from Caddy container to global govard storage
-	pterm.Debug.Printf("Extracting CA from %s to %s...\n", proxyContainer, localCertPath)
-	cmd := exec.Command("docker", "cp", proxyContainer+":/data/caddy/pki/authorities/local/root.crt", localCertPath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to extract CA from container: %v, output: %s", err, string(output))
-	}
-
-	// Ensure readable by user for browser import (especially if created as root)
-	if err := os.Chmod(localCertPath, 0644); err != nil {
-		return fmt.Errorf("failed to set permissions on %s: %w", localCertPath, err)
-	}
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		// Set ownership back to the original user
-		if u, err := user.Lookup(sudoUser); err == nil {
-			uid, convErr := strconv.Atoi(u.Uid)
-			if convErr != nil {
-				return fmt.Errorf("failed to parse uid for %s: %w", sudoUser, convErr)
-			}
-			gid, convErr := strconv.Atoi(u.Gid)
-			if convErr != nil {
-				return fmt.Errorf("failed to parse gid for %s: %w", sudoUser, convErr)
-			}
-			if err := os.Chown(sslDir, uid, gid); err != nil {
-				return fmt.Errorf("failed to set ownership on %s: %w", sslDir, err)
-			}
-			if err := os.Chown(localCertPath, uid, gid); err != nil {
-				return fmt.Errorf("failed to set ownership on %s: %w", localCertPath, err)
-			}
-		}
-	}
-
-	// 2. Copy to system trust store
-	cmd = exec.Command("sudo", "cp", localCertPath, systemCertPath)
+	// Copy to system trust store
+	cmd := exec.Command("sudo", "cp", localCertPath, systemCertPath)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to copy cert to system store (sudo required): %v", err)
 	}
 
-	// 3. Update trust store
+	// Update trust store
 	cmd = exec.Command("sudo", "update-ca-certificates")
 	return cmd.Run()
 }
 
 func trustDarwin() error {
-	certPath := "/tmp/govard-ca.crt"
-	cmd := exec.Command("sudo", "security", "add-trusted-cert", "-d", "-r", "trustRoot", "-k", "/Library/Keychains/System.keychain", certPath)
+	localCertPath, err := extractCAToUserDir()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("sudo", "security", "add-trusted-cert", "-d", "-r", "trustRoot", "-k", "/Library/Keychains/System.keychain", localCertPath)
 	return cmd.Run()
+}
+
+func extractCAToUserDir() (string, error) {
+	proxyContainer := "proxy-caddy-1"
+
+	homeDir, uid, gid, err := resolveUserHomeAndOwnership()
+	if err != nil {
+		return "", err
+	}
+
+	sslDir := filepath.Join(homeDir, ".govard", "ssl")
+	if err := os.MkdirAll(sslDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create ssl directory %s: %w", sslDir, err)
+	}
+
+	localCertPath := filepath.Join(sslDir, "root.crt")
+
+	// Extract cert from Caddy container to global govard storage
+	pterm.Debug.Printf("Extracting CA from %s to %s...\n", proxyContainer, localCertPath)
+	cmd := exec.Command("docker", "cp", proxyContainer+":/data/caddy/pki/authorities/local/root.crt", localCertPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to extract CA from container: %v, output: %s", err, string(output))
+	}
+
+	// Ensure readable by user for browser import (especially if created as root)
+	if err := os.Chmod(localCertPath, 0644); err != nil {
+		return "", fmt.Errorf("failed to set permissions on %s: %w", localCertPath, err)
+	}
+
+	// Set ownership if running under sudo
+	if uid != -1 && gid != -1 {
+		if err := os.Chown(sslDir, uid, gid); err != nil {
+			return "", fmt.Errorf("failed to set ownership on %s: %w", sslDir, err)
+		}
+		if err := os.Chown(localCertPath, uid, gid); err != nil {
+			return "", fmt.Errorf("failed to set ownership on %s: %w", localCertPath, err)
+		}
+	}
+
+	return localCertPath, nil
+}
+
+// resolveUserHomeAndOwnership returns homeDir, uid, gid.
+// uid/gid are -1 if not running under sudo or if resolution fails (in which case we rely on default permissions).
+func resolveUserHomeAndOwnership() (string, int, int, error) {
+	homeDir := os.Getenv("HOME")
+	uid, gid := -1, -1
+
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		u, err := user.Lookup(sudoUser)
+		if err == nil {
+			homeDir = u.HomeDir
+
+			uID, convErr := strconv.Atoi(u.Uid)
+			if convErr == nil {
+				uid = uID
+			}
+			gID, convErr := strconv.Atoi(u.Gid)
+			if convErr == nil {
+				gid = gID
+			}
+		}
+	}
+
+	if homeDir == "" {
+		// Fallback to current user if SUDO_USER not set or lookup failed but we need a home dir
+		u, err := user.Current()
+		if err != nil {
+			return "", -1, -1, fmt.Errorf("failed to determine user home directory: %w", err)
+		}
+		homeDir = u.HomeDir
+	}
+
+	return homeDir, uid, gid, nil
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Insecure Temporary File Usage in Trust Logic

🚨 Severity: HIGH
💡 Vulnerability: `trustDarwin` used a hardcoded path `/tmp/govard-ca.crt` which could be pre-created by a malicious user (TOCTOU).
🎯 Impact: An attacker could trick an admin into trusting a malicious CA certificate.
🔧 Fix: Implemented secure extraction to `~/.govard/ssl/root.crt` with proper permission checks, mirroring the logic used on Linux.
✅ Verification: `make test-unit` passes. Code review confirms secure file handling.

---
*PR created automatically by Jules for task [4392544904797106831](https://jules.google.com/task/4392544904797106831) started by @ddtcorex*