### PR TITLE
Add ARIA labels to icon-only buttons in desktop frontend

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-02-18 - Missing ARIA Labels on Icon-Only Buttons
+**Learning:** The application uses several icon-only buttons (notifications, settings, profile, search, etc.) which lack `aria-label` attributes. This makes them inaccessible to screen reader users who would only hear "button" or "unlabeled button".
+**Action:** Always verify that icon-only buttons have an accessible name using `aria-label` or `aria-labelledby`.
+
+## 2025-02-18 - Label in Name (WCAG 2.5.3)
+**Learning:** Adding `aria-label` to an element with visible text overrides the visible text in the accessibility tree. This can be problematic if the visible text is "John Dev" but the accessible name becomes "User profile", potentially confusing speech recognition users.
+**Action:** Avoid overriding visible text with `aria-label` unless necessary. Ensure the accessible name contains the visible text.

--- a/desktop/frontend/index.html
+++ b/desktop/frontend/index.html
@@ -290,6 +290,7 @@
                   >
                 </div>
                 <input
+                  aria-label="Search"
                   class="block w-full pl-10 pr-12 py-2 bg-[#1a3322] border border-transparent focus:border-primary/30 text-white placeholder-[#5d856b] rounded-lg focus:outline-none focus:ring-1 focus:ring-primary/30 sm:text-sm transition-all"
                   placeholder="Search in Govard..."
                   type="text"
@@ -306,6 +307,7 @@
             </div>
             <div class="flex items-center gap-4 ml-6">
               <button
+                aria-label="Notifications"
                 class="relative p-2 text-[#90cba4] hover:text-white hover:bg-[#22492f] rounded-lg transition-colors"
               >
                 <span class="material-symbols-outlined">notifications</span>
@@ -314,6 +316,7 @@
                 ></span>
               </button>
               <button
+                aria-label="Settings"
                 class="p-2 text-[#90cba4] hover:text-white hover:bg-[#22492f] rounded-lg transition-colors"
                 id="openSettings"
                 data-action="open-settings"
@@ -440,6 +443,7 @@
                     Restart
                   </button>
                   <button
+                    aria-label="Stop environment"
                     data-action="env-stop"
                     id="heroStopBtn"
                     class="h-12 w-12 bg-[#1a3322] text-[#90cba4] hover:text-white border border-[#2e573a] rounded-lg hover:bg-red-500/20 hover:border-red-500/30 transition-all active:scale-95 flex items-center justify-center"
@@ -1142,6 +1146,7 @@
                         />
                       </div>
                       <button
+                        aria-label="Clear logs"
                         data-action="clear-logs"
                         class="text-[#90cba4] hover:text-primary transition-colors"
                         title="Clear Logs"
@@ -1151,6 +1156,7 @@
                         >
                       </button>
                       <button
+                        aria-label="Download logs"
                         data-action="download-logs"
                         class="text-[#90cba4] hover:text-primary transition-colors"
                         title="Download Logs"
@@ -1346,6 +1352,7 @@ Select an environment to view logs.</pre
               </div>
             </div>
             <button
+              aria-label="Close"
               data-action="close-onboarding"
               class="text-slate-400 hover:text-white transition-colors"
             >
@@ -1785,6 +1792,7 @@ Select an environment to view logs.</pre
           >
             <h3 class="text-white text-lg font-bold">Govard Settings</h3>
             <button
+              aria-label="Close settings"
               class="p-2 rounded hover:bg-white/5 text-slate-400 hover:text-white flex items-center justify-center h-9 w-9"
               id="closeSettings"
               type="button"


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to icon-only buttons

💡 What:
Added `aria-label` attributes to several icon-only buttons in the desktop frontend (`desktop/frontend/index.html`).

🎯 Why:
To improve accessibility for screen reader users. Previously, these buttons were announced as "button" or "unlabeled button", providing no context about their function.

Changes:
- Added `aria-label="Notifications"` to the notifications button.
- Added `aria-label="Settings"` to the settings button.
- Added `aria-label="Search"` to the search input.
- Added `aria-label="Stop environment"` to the stop button.
- Added `aria-label="Clear logs"` to the clear logs button.
- Added `aria-label="Download logs"` to the download logs button.
- Added `aria-label="Close"` to the onboarding modal close button.
- Added `aria-label="Close settings"` to the settings drawer close button.

Note: The User Profile button was intentionally left without an `aria-label` because it contains visible text ("John Dev") on larger screens, and adding `aria-label` would override this text, violating WCAG 2.5.3 (Label in Name).

♿ Accessibility:
This change significantly improves the experience for users relying on assistive technologies by ensuring all interactive elements have accessible names.

Testing:
- Verified changes by reading `desktop/frontend/index.html`.
- Ran `make test-frontend` (passed).
- Ran `make build` (passed).
- Verified ARIA labels presence using a Playwright script.


---
*PR created automatically by Jules for task [11147123041772089161](https://jules.google.com/task/11147123041772089161) started by @ddtcorex*