### PR TITLE
⚡ Bolt: optimize docker container list in check port

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-23 - [Docker List Optimization]
+**Learning:** ContainerList fetches all containers by default. In a system with many containers, this is slow.
+**Action:** Always use filters.Args to narrow down the search when looking for specific containers.

--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 )
 
@@ -64,7 +65,12 @@ func isPortBoundByGovardProxy(port string) bool {
 		_ = cli.Close()
 	}()
 
-	containers, err := cli.ContainerList(ctx, container.ListOptions{})
+	// Optimize: only fetch containers that match our proxy names
+	args := filters.NewArgs()
+	args.Add("name", "proxy-caddy-1")
+	args.Add("name", "govard-proxy-caddy")
+
+	containers, err := cli.ContainerList(ctx, container.ListOptions{Filters: args})
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
💡 What: Optimized `isPortBoundByGovardProxy` to use Docker API filters.
🎯 Why: `cli.ContainerList` was fetching all containers, which is slow when many containers are running.
📊 Impact: Reduces overhead of port checks by fetching only 0-2 containers instead of N.
🔬 Measurement: Verified with `make test-unit`.


---
*PR created automatically by Jules for task [14793616445019941528](https://jules.google.com/task/14793616445019941528) started by @ddtcorex*