### PR TITLE
Change sidebar environment click to selection behavior

### DIFF
--- a/desktop/frontend/main.js
+++ b/desktop/frontend/main.js
@@ -133,6 +133,33 @@ const showToast = (message, type = "success") => {
   toast.show(message, type);
 };
 
+const switchTab = (tabId) => {
+  const tabLinks = document.querySelectorAll('[data-action="switch-tab"]');
+  const tabContents = document.querySelectorAll(".tab-content");
+
+  tabLinks.forEach((l) => {
+    l.classList.remove("border-primary", "text-primary");
+    l.classList.add("border-transparent", "text-[#90cba4]");
+    if (l instanceof HTMLElement && l.dataset.tab === tabId) {
+      l.classList.remove("border-transparent", "text-[#90cba4]");
+      l.classList.add("border-primary", "text-primary");
+    }
+  });
+
+  tabContents.forEach((c) => {
+    c.classList.remove("active", "flex", "block");
+    c.classList.add("hidden");
+  });
+
+  const content = byId("tab-" + tabId);
+  if (content) {
+    content.classList.remove("hidden");
+    content.classList.add("active");
+    if (tabId === "logs") content.classList.add("flex");
+    else content.classList.add("block");
+  }
+};
+
 const showSystemNotification = (title, body) => {
   if (
     typeof window === "undefined" ||
@@ -230,8 +257,9 @@ const loadDashboard = async () => {
 };
 
 const syncProjectState = () => {
+  const state = getState();
   const selectedProject =
-    refs.envSelector?.value || refs.logSelector?.value || "";
+    refs.envSelector?.value || refs.logSelector?.value || state.selectedProject || "";
   setState({ selectedProject });
 };
 
@@ -313,7 +341,11 @@ const refreshDashboard = async (options = {}) => {
   const dashboard = await loadDashboard();
   setMetricText(dashboard, refs);
   renderWarnings(refs.warningList, dashboard.warnings);
-  renderEnvironmentList(refs.envList, dashboard.environments);
+  renderEnvironmentList(
+    refs.envList,
+    dashboard.environments,
+    getState().selectedProject,
+  );
 
   const previousProject = getState().selectedProject;
   syncProjectSelectors(
@@ -322,7 +354,7 @@ const refreshDashboard = async (options = {}) => {
     previousProject,
   );
 
-  const selectedProject = refs.envSelector?.value || "";
+  const selectedProject = refs.envSelector?.value || getState().selectedProject || "";
   setState({ environments: dashboard.environments, selectedProject });
   if (!selectedProject && dashboard.environments.length > 0) {
     setState({ selectedProject: projectKey(dashboard.environments[0]) });
@@ -344,6 +376,11 @@ const refreshDashboard = async (options = {}) => {
   refreshServiceSelector();
   refreshSeveritySelector();
   syncLogFiltersState();
+  renderEnvironmentList(
+    refs.envList,
+    dashboard.environments,
+    getState().selectedProject,
+  );
   renderProjectHero(refs, dashboard.environments, getState().selectedProject);
   await metricsController.refresh({ silent: true });
   await remotesController.refresh({ silent: true });
@@ -391,10 +428,12 @@ document.addEventListener("click", async (event) => {
 
   if (action === "select-environment") {
     const project = targetElement.dataset.env || "";
+    setState({ selectedProject: project });
     if (refs.envSelector) refs.envSelector.value = project;
     if (refs.logSelector) refs.logSelector.value = project;
+    switchTab("dashboard");
     await syncProjectSelectorsFrom("env");
-    await refreshDashboard();
+    await refreshDashboard({ silent: true });
     return;
   }
 
@@ -494,29 +533,7 @@ document.addEventListener("click", async (event) => {
 
   if (action === "switch-tab") {
     const tabId = targetElement.dataset.tab;
-    const tabLinks = document.querySelectorAll('[data-action="switch-tab"]');
-    const tabContents = document.querySelectorAll(".tab-content");
-
-    tabLinks.forEach((l) => {
-      l.classList.remove("border-primary", "text-primary");
-      l.classList.add("border-transparent", "text-[#90cba4]");
-    });
-
-    targetElement.classList.remove("border-transparent", "text-[#90cba4]");
-    targetElement.classList.add("border-primary", "text-primary");
-
-    tabContents.forEach((c) => {
-      c.classList.remove("active", "flex", "block");
-      c.classList.add("hidden");
-    });
-
-    const content = byId("tab-" + tabId);
-    if (content) {
-      content.classList.remove("hidden");
-      content.classList.add("active");
-      if (tabId === "logs") content.classList.add("flex");
-      else content.classList.add("block");
-    }
+    if (tabId) switchTab(tabId);
     return;
   }
 

--- a/desktop/frontend/modules/dashboard.js
+++ b/desktop/frontend/modules/dashboard.js
@@ -89,7 +89,11 @@ export const renderEnvironmentSkeletons = (container) => {
   container.innerHTML = header + items;
 };
 
-export const renderEnvironmentList = (container, environments = []) => {
+export const renderEnvironmentList = (
+  container,
+  environments = [],
+  selectedProject = "",
+) => {
   if (!container) {
     return;
   }
@@ -106,6 +110,7 @@ export const renderEnvironmentList = (container, environments = []) => {
       .map((env) => {
         const key = projectKey(env);
         const domain = domainLabel(env);
+        const isSelected = key === selectedProject;
         const status = String(
           env.Status || env.status || "stopped",
         ).toLowerCase();
@@ -117,40 +122,39 @@ export const renderEnvironmentList = (container, environments = []) => {
             ? "Running"
             : "Stopped";
 
+        const itemClass = isSelected
+          ? "w-full mb-1 flex items-center gap-3 px-3 py-2.5 rounded-lg bg-[#22492f] border border-primary/30 group transition-all relative overflow-hidden shadow-[0_0_15px_rgba(13,242,89,0.1)]"
+          : "w-full mb-1 flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-[#22492f]/50 border border-transparent transition-all relative overflow-hidden group";
+
+        const selectionIndicator = isSelected
+          ? `<div class="absolute inset-y-0 left-0 w-1 bg-primary"></div>`
+          : "";
+
+        let iconClass = "text-slate-400";
+        let iconName = "stop_circle";
+
         if (running) {
-          return `
-          <button data-action="env-open" data-env="${escapeHTML(key)}" class="w-full mb-1 flex items-center gap-3 px-3 py-2.5 rounded-lg bg-[#22492f] border border-[#366b47]/50 group transition-all relative overflow-hidden" title="Click to open, or double-click to toggle">
-            <div class="absolute inset-y-0 left-0 w-1 bg-primary"></div>
-            <span data-action="toggle-env" data-env="${escapeHTML(key)}" class="material-symbols-outlined text-primary fill-1 hover:text-white transition-colors z-10" style="font-variation-settings: 'FILL' 1;">play_circle</span>
-            <div class="flex flex-col items-start min-w-0" data-action="env-open" data-env="${escapeHTML(key)}">
-              <span class="text-white text-sm font-medium truncate w-full text-left" data-action="env-open" data-env="${escapeHTML(key)}">${escapeHTML(domain)}</span>
-              <span class="text-xs text-primary" data-action="env-open" data-env="${escapeHTML(key)}">${statusText}</span>
-            </div>
-          </button>
-         `;
+          iconClass = "text-primary fill-1";
+          iconName = "play_circle";
+        } else if (warning) {
+          iconClass = "text-amber-500";
+          iconName = "warning";
         }
 
-        if (warning) {
-          return `
-          <button data-action="env-open" data-env="${escapeHTML(key)}" class="w-full mb-1 flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-[#22492f]/50 transition-colors group" title="Click to open, or double-click to toggle">
-            <span data-action="toggle-env" data-env="${escapeHTML(key)}" class="material-symbols-outlined text-amber-500 hover:text-primary transition-colors z-10">warning</span>
-            <div class="flex flex-col items-start min-w-0" data-action="env-open" data-env="${escapeHTML(key)}">
-              <span class="text-slate-300 text-sm font-medium group-hover:text-white truncate w-full text-left" data-action="env-open" data-env="${escapeHTML(key)}">${escapeHTML(domain)}</span>
-              <span class="text-xs text-amber-500" data-action="env-open" data-env="${escapeHTML(key)}">${statusText}</span>
-            </div>
-          </button>
-          `;
-        }
+        const iconStyle = running
+          ? "style=\"font-variation-settings: 'FILL' 1;\""
+          : "";
 
         return `
-        <button data-action="env-open" data-env="${escapeHTML(key)}" class="w-full mb-1 flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-[#22492f]/50 transition-colors group" title="Click to open, or double-click to toggle">
-          <span data-action="toggle-env" data-env="${escapeHTML(key)}" class="material-symbols-outlined text-slate-400 hover:text-primary transition-colors z-10">stop_circle</span>
-          <div class="flex flex-col items-start min-w-0" data-action="env-open" data-env="${escapeHTML(key)}">
-            <span class="text-slate-300 text-sm font-medium group-hover:text-white truncate w-full text-left" data-action="env-open" data-env="${escapeHTML(key)}">${escapeHTML(domain)}</span>
-            <span class="text-xs text-slate-500" data-action="env-open" data-env="${escapeHTML(key)}">${statusText}</span>
-          </div>
-        </button>
-      `;
+          <button data-action="select-environment" data-env="${escapeHTML(key)}" class="${itemClass}" title="Select ${escapeHTML(domain)}">
+            ${selectionIndicator}
+            <span data-action="toggle-env" data-env="${escapeHTML(key)}" class="material-symbols-outlined ${iconClass} hover:text-white transition-colors z-10" ${iconStyle}>${iconName}</span>
+            <div class="flex flex-col items-start min-w-0 pointer-events-none">
+              <span class="text-white text-sm font-medium truncate w-full text-left">${escapeHTML(domain)}</span>
+              <span class="text-xs ${running ? "text-primary" : warning ? "text-amber-500" : "text-slate-500"}">${statusText}</span>
+            </div>
+          </button>
+        `;
       })
       .join("");
 };


### PR DESCRIPTION
This change improves the desktop app UX by making the sidebar environment items act as selectors rather than external links. When clicked, the environment is highlighted, its details are loaded into the Dashboard view, and the app automatically switches to the Dashboard tab if the user was on another tab.

---
*PR created automatically by Jules for task [3810259502655345340](https://jules.google.com/task/3810259502655345340) started by @ddtcorex*