### PR TITLE
Refactor Help Commands and UI Documentation for Improved Usability

### DIFF
--- a/desktop/frontend/index.html
+++ b/desktop/frontend/index.html
@@ -1020,6 +1020,31 @@
                   <section
                     class="rounded-xl border border-[#2e573a] bg-[#1a3322]/50 p-4 space-y-4"
                   >
+                    <h4 class="text-sm font-medium text-white">Common Scenarios</h4>
+                    <div class="space-y-4">
+                      <div>
+                        <h5 class="text-xs font-bold text-primary mb-1 uppercase tracking-tight">Daily Data Refresh</h5>
+                        <p class="text-[11px] text-slate-400 leading-relaxed">
+                          Pull the latest database and media from staging to stay in sync with real content. Recommended with <b>Sanitization</b> enabled.
+                        </p>
+                      </div>
+                      <div>
+                        <h5 class="text-xs font-bold text-primary mb-1 uppercase tracking-tight">Media Sync Only</h5>
+                        <p class="text-[11px] text-slate-400 leading-relaxed">
+                          Fetch product images from production without affecting your local code or database. Saves bandwidth by skipping heavy tables.
+                        </p>
+                      </div>
+                      <div>
+                        <h5 class="text-xs font-bold text-primary mb-1 uppercase tracking-tight">Quick Hotfix Push</h5>
+                        <p class="text-[11px] text-slate-400 leading-relaxed">
+                          Push a single file/folder to a dev remote to verify a fix in a real environment. Requires <b>unprotecting</b> the remote temporarily.
+                        </p>
+                      </div>
+                    </div>
+                  </section>
+                  <section
+                    class="rounded-xl border border-[#2e573a] bg-[#1a3322]/50 p-4 space-y-4"
+                  >
                     <h4 class="text-sm font-medium text-white">Sync Flow</h4>
                     <p class="text-xs text-slate-400 leading-relaxed">
                       Data flows strictly from
@@ -1529,6 +1554,23 @@ Select an environment to view logs.</pre
                     </div>
                   </div>
                 </section>
+
+                <div class="bg-primary/10 border border-primary/20 rounded-lg p-4">
+                    <h4 class="text-xs font-bold text-primary uppercase mb-2 flex items-center gap-2">
+                        <span class="material-symbols-outlined text-[14px]">info</span>
+                        Recipe Guide & Best Practices
+                    </h4>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <ul class="text-[11px] text-slate-400 space-y-1 list-disc pl-4">
+                            <li><b>Magento 2:</b> Best with PHP 8.1/8.2 and MariaDB 10.6. Varnish & Redis highly recommended for performance.</li>
+                            <li><b>Laravel:</b> Optimized for PHP 8.3. Supports Vite hot-reloading out of the box.</li>
+                        </ul>
+                        <ul class="text-[11px] text-slate-400 space-y-1 list-disc pl-4">
+                            <li><b>WordPress:</b> Pre-configured with WP-CLI and optimized Nginx rules.</li>
+                            <li><b>Custom:</b> Mix and match any services. Ideal for specialized microservices.</li>
+                        </ul>
+                    </div>
+                </div>
 
                 <hr class="border-slate-200 dark:border-white/5" />
 

--- a/internal/cmd/bootstrap.go
+++ b/internal/cmd/bootstrap.go
@@ -78,8 +78,31 @@ var bootstrapRemoteDirExists = func(remoteName string, remoteCfg engine.RemoteCo
 }
 
 var bootstrapCmd = &cobra.Command{
-	Use:   "bootstrap",
+	Use:   "bootstrap [flags]",
 	Short: "Bootstrap local project setup and clone a remote environment",
+	Long: `Quickly set up a project by cloning from a remote environment or creating a fresh installation.
+Ideal for onboarding new team members or starting a new project from scratch.
+
+Framework Specifics:
+- Magento 2: Automates auth.json, env.php, database import, media sync, and admin user creation.
+- Symfony/Laravel: Handles .env generation and composer install.
+- WordPress: Configures wp-config.php and imports database.
+
+Case Studies:
+- New Team Member: Run 'govard bootstrap --environment staging' to get a carbon copy of the staging site.
+- Fresh Start: Run 'govard bootstrap --fresh --version 2.4.7' to start a clean Magento 2.4.7 project.
+- Fast Sync: Use --code-only to skip DB and media if you only need the source code.`,
+	Example: `  # Clone from staging environment (auto-detects framework)
+  govard bootstrap --environment staging
+
+  # Fresh Magento 2.4.7 install with sample data
+  govard bootstrap --fresh --version 2.4.7 --include-sample
+
+  # Clone from production but skip media files
+  govard bootstrap --environment prod --no-media
+
+  # Clone code only (skip DB and media)
+  govard bootstrap --code-only`,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		pterm.DefaultHeader.Println("Govard Bootstrap")
 		startedAt := time.Now()
@@ -747,21 +770,21 @@ func init() {
 	bootstrapCmd.Flags().BoolVar(&bootstrapSkipDB, "no-db", false, "Skip database import")
 	bootstrapCmd.Flags().BoolVar(&bootstrapSkipMedia, "no-media", false, "Skip media sync")
 	bootstrapCmd.Flags().BoolVar(&bootstrapSkipComposer, "no-composer", false, "Skip composer install")
-	bootstrapCmd.Flags().BoolVar(&bootstrapSkipAdmin, "no-admin", false, "Skip admin user creation")
+	bootstrapCmd.Flags().BoolVar(&bootstrapSkipAdmin, "no-admin", false, "Skip admin user creation (Magento only)")
 	bootstrapCmd.Flags().BoolVar(&bootstrapNoStreamDB, "no-stream-db", false, "Disable stream-db import mode")
-	bootstrapCmd.Flags().StringVar(&bootstrapVersion, "version", "", "Magento version for fresh install")
+	bootstrapCmd.Flags().StringVar(&bootstrapVersion, "version", "", "Framework version for fresh install (e.g. 2.4.7 for Magento, 11 for Laravel)")
 	bootstrapCmd.Flags().StringVarP(&bootstrapEnv, "environment", "e", "dev", "Source environment")
 	bootstrapCmd.Flags().StringVar(&bootstrapEnv, "remote", "dev", "Alias for --environment")
 	bootstrapCmd.Flags().StringVarP(&bootstrapRecipe, "recipe", "r", "", "Recipe to use when init is required")
 	bootstrapCmd.Flags().StringVar(&bootstrapFrameworkVersion, "framework-version", "", "Framework version when init is required")
 	bootstrapCmd.Flags().BoolVar(&bootstrapSkipUp, "skip-up", false, "Skip starting local containers before bootstrap steps")
-	bootstrapCmd.Flags().StringVarP(&bootstrapMetaPackage, "meta-package", "p", defaultBootstrapMetaPackage, "Magento package for fresh install")
+	bootstrapCmd.Flags().StringVarP(&bootstrapMetaPackage, "meta-package", "p", defaultBootstrapMetaPackage, "Composer meta-package for fresh install (Magento only)")
 	bootstrapCmd.Flags().StringVar(&bootstrapDBDump, "db-dump", "", "Import database from a local dump file")
 	bootstrapCmd.Flags().BoolVar(&bootstrapFixDeps, "fix-deps", false, "Run project custom fix-deps command before bootstrap")
-	bootstrapCmd.Flags().BoolVar(&bootstrapHyvaInstall, "hyva-install", false, "Install Hyva default theme on fresh install")
-	bootstrapCmd.Flags().StringVar(&bootstrapHyvaToken, "hyva-token", defaultBootstrapHyvaToken, "Hyva repository token")
-	bootstrapCmd.Flags().StringVar(&bootstrapMageUsername, "mage-username", "", "Magento repo username for auth.json bootstrap")
-	bootstrapCmd.Flags().StringVar(&bootstrapMagePassword, "mage-password", "", "Magento repo password for auth.json bootstrap")
+	bootstrapCmd.Flags().BoolVar(&bootstrapHyvaInstall, "hyva-install", false, "Install Hyva default theme (Magento only)")
+	bootstrapCmd.Flags().StringVar(&bootstrapHyvaToken, "hyva-token", defaultBootstrapHyvaToken, "Hyva repository token (Magento only)")
+	bootstrapCmd.Flags().StringVar(&bootstrapMageUsername, "mage-username", "", "Magento repo username for auth.json bootstrap (Magento only)")
+	bootstrapCmd.Flags().StringVar(&bootstrapMagePassword, "mage-password", "", "Magento repo password for auth.json bootstrap (Magento only)")
 	bootstrapCmd.Flags().BoolVarP(&bootstrapAssumeYes, "yes", "y", false, "Assume yes for non-critical bootstrap prompts")
 	bootstrapCmd.Flags().BoolVar(&bootstrapIncludeProduct, "include-product", false, "Include catalog product images during media sync (Magento only)")
 }

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -23,7 +23,29 @@ import (
 var dbCmd = &cobra.Command{
 	Use:   "db [connect|import|dump]",
 	Short: "Interact with the database container",
-	Args:  cobra.ExactArgs(1),
+	Long: `Manage your project's database. Supports connecting to the container shell,
+importing SQL dumps, and creating backups. Works for both local and remote environments.
+
+Case Studies:
+- Remote Debugging: Connect directly to the staging database to inspect live data.
+- Quick Backup: Create a local SQL dump before performing risky operations.
+- Data Refresh: Stream a database dump from production directly into your local DB.
+- Sanitized Backup: Use --exclude-sensitive-data to remove DEFINER and GTID from dumps.`,
+	Example: `  # Open an interactive MySQL shell locally
+  govard db connect
+
+  # Connect to the staging database via SSH tunnel
+  govard db connect --environment staging
+
+  # Import a local SQL file
+  govard db import --file backup.sql
+
+  # Stream a dump from production into your local database (Wipe local DB first)
+  govard db import --stream-db --environment prod
+
+  # Create a database dump with routines and triggers
+  govard db dump --full --file my_backup.sql`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		subcommand := strings.ToLower(strings.TrimSpace(args[0]))
 		if err := runDBSubcommand(cmd, subcommand); err != nil {

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -30,6 +30,19 @@ type downOptions struct {
 var downCmd = &cobra.Command{
 	Use:   "down",
 	Short: "Tear down project containers and networks",
+	Long: `Stops and removes containers, networks, and optionally volumes created by 'govard up'.
+This is a destructive operation that completely cleans up the Docker resources
+associated with the current project.
+
+Case Studies:
+- Fresh Start: Use 'govard down -v' to wipe out all local data (including database and media) for a clean reinstall.
+- Troubleshooting: If networks or containers are in a ghost state, 'govard down' ensures they are fully purged.
+- Workspace Cleanup: Use 'govard down' when you are finished with a project to free up system resources.`,
+	Example: `  # Tear down containers and networks
+  govard down
+
+  # Wipe everything including database/media volumes
+  govard down --volumes`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pterm.DefaultHeader.Println("Tearing Down Govard Environment")
 

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -12,9 +12,28 @@ import (
 )
 
 var envCmd = &cobra.Command{
-	Use:   "env",
+	Use:   "env [command]",
 	Short: "Control project environment via docker compose",
-	Long:  "Project-scoped environment lifecycle and service commands.",
+	Long: `Manage the lifecycle and services of your project's development environment.
+All commands are scoped to the project in the current working directory.
+It provides wrappers around common Docker Compose operations and specialized service interactions.
+
+Case Studies:
+- Maintenance: Use 'govard env stop' to pause work and 'govard env start' to resume later.
+- Troubleshooting: Check 'govard env ps' and 'govard env logs' to identify failing services.
+- Cache Management: Run 'govard env redis-cli flushall' to clear local cache.
+- Cleanup: Run 'govard env down -v' to completely remove the environment and its data.`,
+	Example: `  # Start the project environment
+  govard env up
+
+  # List running containers for this project
+  govard env ps
+
+  # View real-time logs for all services
+  govard env logs
+
+  # Enter a Redis shell for the current project
+  govard env redis`,
 }
 
 var envUpCmd = &cobra.Command{

--- a/internal/cmd/frameworks.go
+++ b/internal/cmd/frameworks.go
@@ -20,9 +20,25 @@ type RecipeCommand struct {
 }
 
 var toolCmd = &cobra.Command{
-	Use:   "tool",
+	Use:   "tool [command]",
 	Short: "Run framework/tooling commands inside project containers",
-	Long:  "Project-scoped wrappers for framework CLIs and common package manager commands.",
+	Long: `Run framework CLIs and common package manager commands directly inside the project containers.
+This eliminates the need to install PHP, Composer, or Node.js on your host machine.
+Govard automatically routes commands to the correct container (usually PHP) and
+executes them as the appropriate user (e.g., www-data).
+
+Case Studies:
+- Clean Workspace: Run 'govard tool magento setup:upgrade' without needing PHP/MySQL on your laptop.
+- Unified Workflow: Use the same command regardless of which PHP version the project requires.
+- Package Management: Use 'govard tool composer install' to ensure dependencies match the container environment.`,
+	Example: `  # Run Magento CLI
+  govard tool magento cache:flush
+
+  # Install a composer package
+  govard tool composer require monolog/monolog
+
+  # Run npm install
+  govard tool npm install`,
 }
 
 var frameworkCommands = []RecipeCommand{
@@ -125,9 +141,15 @@ var frameworkCommands = []RecipeCommand{
 
 func initFrameworkCommands() {
 	for _, fc := range frameworkCommands {
+		usage := fmt.Sprintf("%s [args]", fc.Name)
+		longDesc := fc.Short
+		if fc.Recipe != "" {
+			longDesc = fmt.Sprintf("%s (Requires %s project)", fc.Short, fc.Recipe)
+		}
 		cmd := &cobra.Command{
-			Use:                fmt.Sprintf("%s [args]", fc.Name),
+			Use:                usage,
 			Short:              fc.Short,
+			Long:               longDesc,
 			DisableFlagParsing: true,
 			RunE: func(c *cobra.Command, args []string) error {
 				// Find which command we are running

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -14,8 +14,33 @@ import (
 )
 
 var initCmd = &cobra.Command{
-	Use:   "init",
+	Use:   "init [flags]",
 	Short: "Initialize a new project configuration",
+	Long: `Initialize a Govard project configuration in the current directory.
+It automatically detects the framework (Magento, Laravel, Symfony, etc.) and generates a .govard.yml file.
+If detection fails, it falls back to a 'custom' recipe with interactive prompts.
+
+Common Framework Versions:
+- Magento: 2.4.4, 2.4.5, 2.4.6, 2.4.7
+- Laravel: 10, 11
+- Symfony: 6.4, 7.0
+- Shopware: 6.5, 6.6
+
+Case Studies:
+- New Project: Run 'govard init' in an empty folder to start a new app from scratch.
+- Existing Project: Run 'govard init' to containerize an existing codebase.
+- Migrate from DDEV: Use --migrate-from ddev to import settings from an existing DDEV setup.`,
+	Example: `  # Auto-detect framework and initialize
+  govard init
+
+  # Explicitly set the framework/recipe
+  govard init --recipe magento2
+
+  # Initialize from a DDEV configuration
+  govard init --migrate-from ddev
+
+  # Specify framework version during init
+  govard init --recipe laravel --framework-version 11`,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		pterm.DefaultHeader.Println("Govard Initialization")
 		startedAt := time.Now()

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -15,6 +15,18 @@ var errorFilter bool
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "View project logs",
+	Long: `Streams real-time logs from all services in the current project environment.
+It automatically aggregates logs from PHP, Web, MySQL, Redis, and other active containers.
+
+Case Studies:
+- Real-time Debugging: Watch the log stream while browsing the site to catch errors as they happen.
+- Post-Mortem: Check the last 100 lines (default) to see why a container crashed.
+- Error Hunting: Use --errors to filter out noise and only show critical failure messages.`,
+	Example: `  # Follow all project logs
+  govard logs
+
+  # Show only error messages
+  govard logs --errors`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pterm.DefaultHeader.Println("Govard Log Stream")
 		config := loadConfig()

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -14,7 +14,32 @@ var openEnvironment string
 var openCmd = &cobra.Command{
 	Use:   "open [target]",
 	Short: "Open common service URLs",
-	Args:  cobra.ExactArgs(1),
+	Long: `Quickly open web interfaces for various services in your default browser.
+Supported targets: admin, db (PMA/TablePlus), mail (Mailpit), sftp, elasticsearch, opensearch.
+
+Targets:
+- admin: The web application's admin panel.
+- db/pma: PHPMyAdmin (local) or local DB client (remote).
+- mail: Mailpit web UI for inspecting outgoing emails.
+- sftp: SFTP connection details (remote).
+- elasticsearch/opensearch: Search engine endpoint info.
+
+Case Studies:
+- Fast Login: Use 'govard open admin' to jump straight to the login page.
+- Remote Debugging: Open SFTP details for a remote environment to check logs or config files.
+- Database Inspection: Quickly open PHPMyAdmin locally or get connection strings for remote DBs.`,
+	Example: `  # Open the local admin panel
+  govard open admin
+
+  # Open Mailpit to check emails
+  govard open mail
+
+  # Open the staging admin panel
+  govard open admin --environment staging
+
+  # View local PHPMyAdmin
+  govard open pma`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := loadFullConfig()
 		target := strings.ToLower(strings.TrimSpace(args[0]))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,7 +12,19 @@ var Version = "1.4.0"
 
 var rootCmd = &cobra.Command{
 	Use:   "govard",
-	Short: "Govard is a high-performance local development orchestrator",
+	Short: "Govard: Professional local development orchestrator for PHP & Web projects",
+	Long: `Govard is a high-performance orchestrator designed to manage complex containerized environments.
+It replaces legacy bash-based tools with a native Go binary, focusing on stability, speed,
+and a premium developer experience.
+
+Main Features:
+- Zero-config startup for Magento, Laravel, Symfony, Drupal, and more.
+- Automated SSL (HTTPS) for all .test domains.
+- Deep integration with Xdebug 3.
+- Fast file/database synchronization with remote environments.
+- Built-in desktop dashboard for visual management.
+
+Documentation: https://github.com/ddtcorex/govard`,
 	CompletionOptions: cobra.CompletionOptions{
 		DisableDefaultCmd: true,
 	},
@@ -49,6 +61,11 @@ func init() {
 	rootCmd.AddCommand(dbCmd)
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(desktopCmd)
+
+	rootCmd.AddCommand(upCmd)
+	rootCmd.AddCommand(stopCmd)
+	rootCmd.AddCommand(downCmd)
+	rootCmd.AddCommand(logsCmd)
 
 	// Framework & Tooling Shortcuts
 	initFrameworkCommands()

--- a/internal/cmd/stop.go
+++ b/internal/cmd/stop.go
@@ -14,6 +14,16 @@ import (
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop project containers",
+	Long: `Stops all running containers for the current project without removing them.
+It also unregisters the project domain from the Govard Proxy and removes host entries.
+Use this to pause work and free up CPU/RAM while preserving your local data (volumes).
+
+Case Studies:
+- End of Day: Run 'govard stop' to shut down the project before turning off your computer.
+- Switching Projects: Stop the current project to avoid port conflicts or resource contention when starting another.
+- Battery Saving: Stop the environment when working on non-code tasks to extend laptop battery life.`,
+	Example: `  # Stop the environment
+  govard stop`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pterm.DefaultHeader.Println("Stopping Govard Environment")
 

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -17,8 +17,37 @@ import (
 )
 
 var syncCmd = &cobra.Command{
-	Use:   "sync",
+	Use:   "sync [flags]",
 	Short: "Synchronize files, media, and databases between environments",
+	Long: `Synchronize your local development environment with a remote server (e.g., staging, production).
+This command uses rsync for file/media transfers and mysqldump/mysql for database synchronization.
+It supports bi-directional sync (local to remote, remote to local), but prevents accidental
+overwrites on protected remotes.
+
+Framework Notes:
+- Magento 2: Media sync defaults to 'pub/media', excluding large generated/cache directories.
+- Laravel: File sync includes 'storage/app/public' if media is requested.
+- General: You can use --include/--exclude to fine-tune rsync behavior.
+
+Case Studies:
+- Daily Data Refresh: Fetch the latest DB and media from staging to work on a fresh dataset.
+- Single File Fix: Push a hotfix file to a dev remote for quick verification.
+- Media Sync Only: Sync product images from production without affecting your local code or DB.
+- Full Onboarding: Use --full to get code, media, and DB in one command.`,
+	Example: `  # Sync everything from staging to local (default behavior)
+  govard sync --source staging --full
+
+  # Sync only the database from production
+  govard sync --source prod --db
+
+  # Sync media from dev, but exclude specific folders
+  govard sync --source dev --media --exclude "catalog/product/cache/*"
+
+  # Sync a specific path (e.g., a theme folder) from local to dev
+  govard sync --destination dev --file --path "app/design/frontend/MyTheme"
+
+  # Dry-run: Show what would be synced without actually doing it
+  govard sync --source staging --full --plan`,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		startedAt := time.Now()
 		config := loadFullConfig()

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -15,8 +15,28 @@ import (
 )
 
 var upCmd = &cobra.Command{
-	Use:   "up",
+	Use:   "up [flags]",
 	Short: "Start the development environment",
+	Long: `Starts all Docker containers required for the current project.
+It automatically handles framework detection, configuration validation,
+Docker Compose blueprint rendering, host mapping, and proxy registration.
+
+The startup process follows these stages:
+1. Detect: Identifies framework context from project files.
+2. Validate: Checks Docker status, port conflicts, and layered config.
+3. Render: Generates the specialized Docker Compose file.
+4. Start: Runs 'docker compose up' in detached mode.
+5. Verify: Maps the .test domain to 127.0.0.1 and registers it with the Govard Proxy.
+
+Case Studies:
+- Standard Startup: Simply run 'govard up' to get your full stack running.
+- Low Resource Mode: Use --quickstart if you have limited RAM or only need PHP/Web server.
+- Fresh Install Recovery: If containers are broken, 'govard up' re-renders and restarts them.`,
+	Example: `  # Start the environment normally
+  govard up
+
+  # Fast startup: skip heavy services like Elasticsearch, Varnish, Redis
+  govard up --quickstart`,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		updater.CheckForUpdates(Version)
 		pterm.DefaultHeader.Println("Govard Environment Liftoff")


### PR DESCRIPTION
I have refactored all help commands in the Govard CLI and enhanced the Desktop UI to provide a much better onboarding and usage experience.

Specifically:
- All core commands (`sync`, `bootstrap`, `db`, `open`, `init`, etc.) now feature detailed descriptions, practical code examples, and real-world case studies in their `--help` output.
- Options that are specific to certain frameworks (like Magento's `--hyva-install`) are now clearly marked in the help text.
- The Desktop UI has been updated with a "Common Scenarios" section for remotes and a "Recipe Guide" for project creation to match the CLI's improved helpfulness.
- Lifecycle commands like `up`, `stop`, and `down` are now correctly listed in the main `govard --help` menu.

This ensures that both new and experienced users have immediate access to best practices and framework-specific guidance directly within the tool.

---
*PR created automatically by Jules for task [13282848251920318502](https://jules.google.com/task/13282848251920318502) started by @ddtcorex*