### PR TITLE
Improve Warden Migration and Remote Configuration Precedence

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -189,6 +189,9 @@ Case Studies:
 		if migrated.PHPVersion != "" {
 			config.Stack.PHPVersion = migrated.PHPVersion
 		}
+		if migrated.NodeVersion != "" {
+			config.Stack.NodeVersion = migrated.NodeVersion
+		}
 		if migrated.DBType != "" {
 			config.Stack.DBType = migrated.DBType
 		}
@@ -198,6 +201,25 @@ Case Studies:
 		if migrated.WebRoot != "" {
 			config.Stack.WebRoot = migrated.WebRoot
 		}
+		if migrated.SearchService != "" {
+			config.Stack.Services.Search = migrated.SearchService
+			config.Stack.SearchVersion = migrated.SearchVersion
+		}
+		if migrated.CacheService != "" {
+			config.Stack.Services.Cache = migrated.CacheService
+			config.Stack.CacheVersion = migrated.CacheVersion
+		}
+		if migrated.QueueService != "" {
+			config.Stack.Services.Queue = migrated.QueueService
+			config.Stack.QueueVersion = migrated.QueueVersion
+		}
+		if migrated.VarnishEnabled {
+			config.Stack.Features.Varnish = true
+			if migrated.VarnishVersion != "" {
+				config.Stack.VarnishVersion = migrated.VarnishVersion
+			}
+		}
+
 		if len(migrated.Remotes) > 0 {
 			config.Remotes = migrated.Remotes
 		}
@@ -206,6 +228,45 @@ Case Studies:
 			config.Stack.DBVersion = ""
 		}
 		if hasExistingConfig {
+			if existingConfig.ProjectName != "" {
+				config.ProjectName = existingConfig.ProjectName
+				config.Domain = existingConfig.Domain
+			}
+			if existingConfig.Stack.PHPVersion != "" {
+				config.Stack.PHPVersion = existingConfig.Stack.PHPVersion
+			}
+			if existingConfig.Stack.NodeVersion != "" {
+				config.Stack.NodeVersion = existingConfig.Stack.NodeVersion
+			}
+			if existingConfig.Stack.DBType != "" {
+				config.Stack.DBType = existingConfig.Stack.DBType
+			}
+			if existingConfig.Stack.DBVersion != "" {
+				config.Stack.DBVersion = existingConfig.Stack.DBVersion
+			}
+			if existingConfig.Stack.WebRoot != "" {
+				config.Stack.WebRoot = existingConfig.Stack.WebRoot
+			}
+			if existingConfig.Stack.Services.WebServer != "" {
+				config.Stack.Services.WebServer = existingConfig.Stack.Services.WebServer
+			}
+			if existingConfig.Stack.Services.Search != "" {
+				config.Stack.Services.Search = existingConfig.Stack.Services.Search
+				config.Stack.SearchVersion = existingConfig.Stack.SearchVersion
+			}
+			if existingConfig.Stack.Services.Cache != "" {
+				config.Stack.Services.Cache = existingConfig.Stack.Services.Cache
+				config.Stack.CacheVersion = existingConfig.Stack.CacheVersion
+			}
+			if existingConfig.Stack.Services.Queue != "" {
+				config.Stack.Services.Queue = existingConfig.Stack.Services.Queue
+				config.Stack.QueueVersion = existingConfig.Stack.QueueVersion
+			}
+			if existingConfig.Stack.Features.Varnish {
+				config.Stack.Features.Varnish = true
+				config.Stack.VarnishVersion = existingConfig.Stack.VarnishVersion
+			}
+
 			if existingConfig.Remotes != nil {
 				if config.Remotes == nil {
 					config.Remotes = make(map[string]engine.RemoteConfig)

--- a/internal/cmd/open_targets.go
+++ b/internal/cmd/open_targets.go
@@ -200,6 +200,10 @@ func ensureOpenRemote(config engine.Config, name string, capability string) (eng
 }
 
 func buildRemoteAdminURL(remoteCfg engine.RemoteConfig, adminPath string) string {
+	if remoteCfg.URL != "" {
+		return joinURLWithPath(remoteCfg.URL, adminPath)
+	}
+
 	base := strings.TrimSpace(remoteCfg.Host)
 	if base == "" {
 		base = "localhost"

--- a/internal/engine/migrate.go
+++ b/internal/engine/migrate.go
@@ -4,19 +4,29 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 type MigrationResult struct {
-	ProjectName string
-	Recipe      string
-	PHPVersion  string
-	DBType      string
-	DBVersion   string
-	WebRoot     string
-	Remotes     map[string]RemoteConfig
+	ProjectName    string
+	Recipe         string
+	PHPVersion     string
+	NodeVersion    string
+	DBType         string
+	DBVersion      string
+	SearchService  string
+	SearchVersion  string
+	CacheService   string
+	CacheVersion   string
+	QueueService   string
+	QueueVersion   string
+	VarnishEnabled bool
+	VarnishVersion string
+	WebRoot        string
+	Remotes        map[string]RemoteConfig
 }
 
 func MigrateFromDDEV(root string) (MigrationResult, error) {
@@ -64,10 +74,14 @@ func MigrateFromWarden(root string) (MigrationResult, error) {
 	}
 
 	result := MigrationResult{
-		ProjectName: env["WARDEN_ENV_NAME"],
-		Recipe:      mapWardenTypeToRecipe(env["WARDEN_ENV_TYPE"]),
-		WebRoot:     env["WARDEN_WEB_ROOT"],
-		Remotes:     make(map[string]RemoteConfig),
+		ProjectName:    env["WARDEN_ENV_NAME"],
+		Recipe:         mapWardenTypeToRecipe(env["WARDEN_ENV_TYPE"]),
+		PHPVersion:     env["PHP_VERSION"],
+		NodeVersion:    env["NODE_VERSION"],
+		DBVersion:      env["MYSQL_DISTRIBUTION_VERSION"],
+		VarnishVersion: env["VARNISH_VERSION"],
+		WebRoot:        env["WARDEN_WEB_ROOT"],
+		Remotes:        make(map[string]RemoteConfig),
 	}
 
 	if result.ProjectName == "" {
@@ -77,21 +91,99 @@ func MigrateFromWarden(root string) (MigrationResult, error) {
 		result.Recipe = mapWardenTypeToRecipe(warden.WardenEnvType)
 	}
 
-	// Try to extract remote info from .env
+	if env["MYSQL_DISTRIBUTION"] != "" {
+		result.DBType = strings.ToLower(env["MYSQL_DISTRIBUTION"])
+	}
+	if env["WARDEN_DB"] == "0" {
+		result.DBType = "none"
+	}
+
+	if env["WARDEN_REDIS"] == "1" {
+		result.CacheService = "redis"
+		result.CacheVersion = env["REDIS_VERSION"]
+	}
+	if env["WARDEN_RABBITMQ"] == "1" {
+		result.QueueService = "rabbitmq"
+		result.QueueVersion = env["RABBITMQ_VERSION"]
+	}
+	if env["WARDEN_VARNISH"] == "1" {
+		result.VarnishEnabled = true
+	}
+
+	if env["WARDEN_OPENSEARCH"] == "1" {
+		result.SearchService = "opensearch"
+		result.SearchVersion = env["OPENSEARCH_VERSION"]
+	} else if env["WARDEN_ELASTICSEARCH"] == "1" {
+		result.SearchService = "elasticsearch"
+		result.SearchVersion = env["ELASTICSEARCH_VERSION"]
+	}
+
+	// Legacy Warden SSH variables
 	if host := env["WARDEN_SSH_HOST"]; host != "" {
-		remote := RemoteConfig{
+		result.Remotes["production"] = RemoteConfig{
 			Host:        host,
 			User:        env["WARDEN_SSH_USER"],
 			Path:        env["WARDEN_SSH_PATH"],
 			Environment: "production",
 			Capabilities: RemoteCapabilities{
-				Files:  true,
-				Media:  true,
-				DB:     true,
-				Deploy: false,
+				Files: true, Media: true, DB: true, Deploy: false,
 			},
 		}
-		result.Remotes["production"] = remote
+	}
+
+	// Modern Warden Custom Commands remote variables
+	// Format: REMOTE_{ENV}_{PROPERTY} where PROPERTY is HOST, USER, PORT, PATH, URL
+	remotes := make(map[string]*RemoteConfig)
+	for key, value := range env {
+		if !strings.HasPrefix(key, "REMOTE_") {
+			continue
+		}
+		parts := strings.Split(key, "_")
+		if len(parts) < 3 {
+			continue
+		}
+
+		envName := strings.ToLower(parts[1])
+		switch envName {
+		case "prod":
+			envName = "production"
+		case "staging":
+			envName = "staging"
+		case "dev":
+			envName = "development"
+		}
+
+		property := parts[len(parts)-1]
+		if _, ok := remotes[envName]; !ok {
+			remotes[envName] = &RemoteConfig{
+				Environment: envName,
+				Port:        22,
+				Capabilities: RemoteCapabilities{
+					Files: true, Media: true, DB: true, Deploy: false,
+				},
+			}
+		}
+
+		switch property {
+		case "HOST":
+			remotes[envName].Host = value
+		case "USER":
+			remotes[envName].User = value
+		case "PORT":
+			if port, err := strconv.Atoi(value); err == nil {
+				remotes[envName].Port = port
+			}
+		case "PATH":
+			remotes[envName].Path = value
+		case "URL":
+			remotes[envName].URL = value
+		}
+	}
+
+	for name, cfg := range remotes {
+		if cfg.Host != "" {
+			result.Remotes[name] = *cfg
+		}
 	}
 
 	return result, nil

--- a/internal/engine/remote_config.go
+++ b/internal/engine/remote_config.go
@@ -31,6 +31,7 @@ type RemoteConfig struct {
 	User         string             `yaml:"user"`
 	Port         int                `yaml:"port"`
 	Path         string             `yaml:"path"`
+	URL          string             `yaml:"url,omitempty"`
 	Environment  string             `yaml:"environment"`
 	Protected    bool               `yaml:"protected"`
 	Capabilities RemoteCapabilities `yaml:"capabilities"`


### PR DESCRIPTION
Improved the Warden migration logic to handle modern remote configuration formats and a wider range of service settings from `.env`. Also ensured that existing Govard configurations are preserved when migrating, adhering to the principle of prioritizing user-defined Govard settings.

---
*PR created automatically by Jules for task [10348317428594473581](https://jules.google.com/task/10348317428594473581) started by @ddtcorex*