### PR TITLE
🛡️ Sentinel: Fix insecure certificate handling on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,13 +224,7 @@ govard doctor trust
 
 macOS note:
 
-`govard doctor trust` currently expects the Caddy root certificate at `/tmp/govard-ca.crt`.
-Export it from the proxy container first:
-
-```bash
-docker cp proxy-caddy-1:/data/caddy/pki/authorities/local/root.crt /tmp/govard-ca.crt
-govard doctor trust
-```
+This command will automatically extract the certificate from the proxy container and prompt for your password to add it to the System Keychain.
 
 ### 3. Browser Configuration (Chrome/Edge/Brave)
 

--- a/docs/user/commands.md
+++ b/docs/user/commands.md
@@ -503,8 +503,7 @@ govard doctor trust
 ```
 
 Notes:
-- On Linux, this exports certs to `~/.govard/ssl/root.crt`.
-- On macOS, export the cert first: `docker cp proxy-caddy-1:/data/caddy/pki/authorities/local/root.crt /tmp/govard-ca.crt`.
+- On Linux and macOS, this automatically exports certs to `~/.govard/ssl/root.crt` before adding to the trust store.
 
 ## Utility Commands
 

--- a/docs/user/ssl-https.md
+++ b/docs/user/ssl-https.md
@@ -102,13 +102,7 @@ This installs the Caddy root certificate into your system trust store.
 
 macOS note:
 
-`govard doctor trust` currently expects the Caddy root certificate at `/tmp/govard-ca.crt`.
-Export it from the proxy container first:
-
-```bash
-docker cp proxy-caddy-1:/data/caddy/pki/authorities/local/root.crt /tmp/govard-ca.crt
-govard doctor trust
-```
+This command will automatically extract the certificate from the proxy container and prompt for your password to add it to the System Keychain.
 
 ### 2. Browser Configuration (Chrome/Edge/Brave)
 
@@ -142,10 +136,12 @@ Linux:
     └── root.crt    # Root CA certificate
 ```
 
-macOS (current trust flow):
+macOS:
 
 ```
-/tmp/govard-ca.crt
+~/.govard/
+└── ssl/
+    └── root.crt
 ```
 
 ### Troubleshooting
@@ -155,9 +151,8 @@ macOS (current trust flow):
 **Solutions**:
 1. Ensure proxy is running: `govard svc up`
 2. Run `govard doctor trust` again
-3. On macOS, re-export `/tmp/govard-ca.crt` then rerun `govard doctor trust`
-4. Manually import the certificate in your browser (see step 2 above)
-5. On Linux, check that `~/.govard/ssl/root.crt` exists after `govard doctor trust`
+3. Manually import the certificate in your browser (see step 2 above)
+4. Check that `~/.govard/ssl/root.crt` exists after `govard doctor trust`
 
 **Issue**: Certificate not generated
 

--- a/internal/engine/trust.go
+++ b/internal/engine/trust.go
@@ -31,68 +31,118 @@ func TrustCA() error {
 func trustLinux() error {
 	pterm.Info.Println("On Linux, this requires sudo privileges to update /usr/local/share/ca-certificates/")
 
-	proxyContainer := "proxy-caddy-1"
-
-	// Get the actual user's home directory even if running under sudo
-	homeDir := os.Getenv("HOME")
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		if u, err := user.Lookup(sudoUser); err == nil {
-			homeDir = u.HomeDir
-		}
+	localCertPath, err := extractRootCA("proxy-caddy-1")
+	if err != nil {
+		return err
 	}
 
-	sslDir := filepath.Join(homeDir, ".govard", "ssl")
-	if err := os.MkdirAll(sslDir, 0755); err != nil {
-		return fmt.Errorf("failed to create ssl directory %s: %w", sslDir, err)
-	}
-
-	localCertPath := filepath.Join(sslDir, "root.crt")
 	systemCertPath := "/usr/local/share/ca-certificates/govard.crt"
 
-	// 1. Extract cert from Caddy container to global govard storage
-	pterm.Debug.Printf("Extracting CA from %s to %s...\n", proxyContainer, localCertPath)
-	cmd := exec.Command("docker", "cp", proxyContainer+":/data/caddy/pki/authorities/local/root.crt", localCertPath)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to extract CA from container: %v, output: %s", err, string(output))
-	}
-
-	// Ensure readable by user for browser import (especially if created as root)
-	if err := os.Chmod(localCertPath, 0644); err != nil {
-		return fmt.Errorf("failed to set permissions on %s: %w", localCertPath, err)
-	}
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		// Set ownership back to the original user
-		if u, err := user.Lookup(sudoUser); err == nil {
-			uid, convErr := strconv.Atoi(u.Uid)
-			if convErr != nil {
-				return fmt.Errorf("failed to parse uid for %s: %w", sudoUser, convErr)
-			}
-			gid, convErr := strconv.Atoi(u.Gid)
-			if convErr != nil {
-				return fmt.Errorf("failed to parse gid for %s: %w", sudoUser, convErr)
-			}
-			if err := os.Chown(sslDir, uid, gid); err != nil {
-				return fmt.Errorf("failed to set ownership on %s: %w", sslDir, err)
-			}
-			if err := os.Chown(localCertPath, uid, gid); err != nil {
-				return fmt.Errorf("failed to set ownership on %s: %w", localCertPath, err)
-			}
-		}
-	}
-
-	// 2. Copy to system trust store
-	cmd = exec.Command("sudo", "cp", localCertPath, systemCertPath)
+	// Copy to system trust store
+	cmd := exec.Command("sudo", "cp", localCertPath, systemCertPath)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to copy cert to system store (sudo required): %v", err)
 	}
 
-	// 3. Update trust store
+	// Update trust store
 	cmd = exec.Command("sudo", "update-ca-certificates")
 	return cmd.Run()
 }
 
 func trustDarwin() error {
-	certPath := "/tmp/govard-ca.crt"
+	pterm.Info.Println("On macOS, this requires sudo privileges to update the System Keychain.")
+
+	certPath, err := extractRootCA("proxy-caddy-1")
+	if err != nil {
+		return err
+	}
+
 	cmd := exec.Command("sudo", "security", "add-trusted-cert", "-d", "-r", "trustRoot", "-k", "/Library/Keychains/System.keychain", certPath)
 	return cmd.Run()
+}
+
+func extractRootCA(proxyContainer string) (string, error) {
+	homeDir, err := getRealHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	govardDir := filepath.Join(homeDir, ".govard")
+	sslDir := filepath.Join(govardDir, "ssl")
+
+	if err := os.MkdirAll(sslDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create ssl directory %s: %w", sslDir, err)
+	}
+
+	// Fix ownership of govardDir if created as root
+	// This ensures that ~/.govard is not root-owned, preventing future permission issues
+	if err := fixOwnership(govardDir); err != nil {
+		return "", err
+	}
+
+	// Fix ownership of sslDir if created as root
+	if err := fixOwnership(sslDir); err != nil {
+		return "", err
+	}
+
+	localCertPath := filepath.Join(sslDir, "root.crt")
+
+	// Extract cert from Caddy container to global govard storage
+	pterm.Debug.Printf("Extracting CA from %s to %s...\n", proxyContainer, localCertPath)
+	cmd := exec.Command("docker", "cp", proxyContainer+":/data/caddy/pki/authorities/local/root.crt", localCertPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to extract CA from container: %v, output: %s", err, string(output))
+	}
+
+	// Ensure readable by user for browser import (especially if created as root)
+	if err := os.Chmod(localCertPath, 0644); err != nil {
+		return "", fmt.Errorf("failed to set permissions on %s: %w", localCertPath, err)
+	}
+
+	// Fix ownership of the cert file
+	if err := fixOwnership(localCertPath); err != nil {
+		return "", err
+	}
+
+	return localCertPath, nil
+}
+
+func getRealHomeDir() (string, error) {
+	// Get the actual user's home directory even if running under sudo
+	homeDir := os.Getenv("HOME")
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		if u, err := user.Lookup(sudoUser); err == nil {
+			homeDir = u.HomeDir
+		} else {
+			return "", fmt.Errorf("failed to lookup sudo user %s: %w", sudoUser, err)
+		}
+	}
+	return homeDir, nil
+}
+
+func fixOwnership(path string) error {
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		return nil
+	}
+
+	u, err := user.Lookup(sudoUser)
+	if err != nil {
+		return fmt.Errorf("failed to lookup sudo user %s: %w", sudoUser, err)
+	}
+
+	uid, convErr := strconv.Atoi(u.Uid)
+	if convErr != nil {
+		return fmt.Errorf("failed to parse uid for %s: %w", sudoUser, convErr)
+	}
+	gid, convErr := strconv.Atoi(u.Gid)
+	if convErr != nil {
+		return fmt.Errorf("failed to parse gid for %s: %w", sudoUser, convErr)
+	}
+
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("failed to set ownership on %s: %w", path, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `govard doctor trust` command on macOS previously relied on the user manually copying the root certificate to `/tmp/govard-ca.crt`, a world-writable directory. This exposed the process to potential race conditions or symlink attacks.
🎯 Impact: An attacker could potentially trick the user into trusting a malicious root certificate.
🔧 Fix: Refactored `internal/engine/trust.go` to securely extract the certificate from the Docker container directly to a user-owned directory (`~/.govard/ssl/root.crt`) on both Linux and macOS.
✅ Verification: Verified with `make test-fast`.


---
*PR created automatically by Jules for task [8729402635995405793](https://jules.google.com/task/8729402635995405793) started by @ddtcorex*