### PR TITLE
chore: Upgrade Go to 1.25.0 across CI and docs

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.24.x"
+  GO_VERSION: "1.25.x"
 
 jobs:
   quality_checks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Primary goals for contributions:
 
 ## 2. Runtime and Toolchain Requirements
 
-- Go: `1.24+` (module uses `go 1.24.0`)
+- Go: `1.25+` (module uses `go 1.25.0`)
 - Node.js: `20` (for frontend UI and frontend tests)
 - Wails: `v2.11+` (for desktop app development)
 - Docker: required for integration tests and runtime orchestration

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Common options:
 # Install to ~/.local/bin (no sudo)
 curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --local
 
-# Install building from source (auto-installs Go 1.24 if needed)
+# Install building from source (auto-installs Go 1.25 if needed)
 curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --source
 ```
 
@@ -111,7 +111,7 @@ sudo installer -pkg govard_<version>_Darwin_arm64.pkg -target /
 
 Ensure you have the following prerequisites installed:
 
-- **Go 1.24+**
+- **Go 1.25+**
 - **Node.js 20+**
 - **Yarn (v1.x)**
 - **golangci-lint (v1.64+)**
@@ -132,7 +132,7 @@ cd govard
 
 If you are contributing to Govard, follow these steps to set up your environment:
 
-1. **Go 1.24+**: Install from [go.dev](https://go.dev/dl/).
+1. **Go 1.25+**: Install from [go.dev](https://go.dev/dl/).
 2. **Yarn**: Enable with `corepack enable` or `npm install -g yarn`.
 3. **golangci-lint**: Install the latest version:
    ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module govard
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/creack/pty v1.1.24


### PR DESCRIPTION
This PR upgrades the project's Go version requirement to 1.25.0 and updates the CI pipeline to use Go 1.25.x. This is necessary to support newer dependencies (like golang.org/x/term v0.41.0) which require Go 1.25+.