### PR TITLE
chore: Upgrade golangci-lint to v2.11.3

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
           $(go env GOPATH)/bin/golangci-lint run
 
       - name: Check gofmt formatting

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Ensure you have the following prerequisites installed:
 - **Go 1.25+**
 - **Node.js 20+**
 - **Yarn (v1.x)**
-- **golangci-lint (v1.64+)**
+- **golangci-lint (v2.11+)**
 - **Docker & Docker Compose**
 - **Wails v2.11+** (required for desktop app development)
 


### PR DESCRIPTION
This PR upgrades golangci-lint to v2.11.3 to support Go 1.25.0. This is necessary because v1.64.5 does not support Go 1.25.0 projects.