### PR TITLE
fix(runtime): run php-fpm as remapped user

### DIFF
--- a/docker/php/etc/entrypoint.sh
+++ b/docker/php/etc/entrypoint.sh
@@ -23,12 +23,15 @@ if [ -n "${PUID:-}" ] && [ "${PUID}" != "1000" ]; then
   fi
 fi
 
+UID_REMAP_CHANGED=0
 if [ -n "${PUID:-}" ]; then
   CURRENT_UID=$(id -u www-data)
   if [ "${CURRENT_UID}" != "${PUID}" ]; then
     echo "Updating www-data UID to ${PUID}..."
     if ! sudo usermod -u "${PUID}" www-data; then
       echo "Warning: could not update www-data UID to ${PUID}; continuing with UID ${CURRENT_UID}." >&2
+    else
+      UID_REMAP_CHANGED=1
     fi
   fi
 fi
@@ -134,6 +137,10 @@ if [ -n "${NODE_VERSION:-}" ]; then
       fi
     fi
   fi
+fi
+
+if [ "${UID_REMAP_CHANGED}" = "1" ] && [ "$(id -u)" != "$(id -u www-data)" ]; then
+  exec sudo -E -H -u www-data "$@"
 fi
 
 exec "$@"

--- a/tests/php_runtime_cron_support_test.go
+++ b/tests/php_runtime_cron_support_test.go
@@ -62,6 +62,16 @@ func TestPHPEntrypointUpdatesGIDBeforeUID(t *testing.T) {
 	}
 }
 
+func TestPHPEntrypointRelaunchesProcessAfterUIDRemap(t *testing.T) {
+	content := readProjectFileForTest(t, filepath.Join("docker", "php", "etc", "entrypoint.sh"))
+	if !strings.Contains(content, "UID_REMAP_CHANGED=1") {
+		t.Fatalf("expected php entrypoint to track successful UID remaps, got:\n%s", content)
+	}
+	if !strings.Contains(content, "exec sudo -E -H -u www-data \"$@\"") {
+		t.Fatalf("expected php entrypoint to launch php-fpm as remapped www-data, got:\n%s", content)
+	}
+}
+
 func TestPHPEntrypointStartsCrondBestEffort(t *testing.T) {
 	content := readProjectFileForTest(t, filepath.Join("docker", "php", "etc", "entrypoint.sh"))
 	if !strings.Contains(content, "sudo crond 2>/dev/null || true") {


### PR DESCRIPTION
Relaunch PHP-FPM as the remapped www-data user after the container entrypoint updates UID/GID from PUID/PGID.

Without this, docker exec resolves www-data to the host UID after startup, but the long-running php-fpm master and worker processes can remain on the original image UID 1000. That breaks reads for files owned by the remapped host UID, such as restrictive Symfony .env.local files.

Adds a regression check for the entrypoint behavior.