### PR TITLE
[codex] Fix macOS desktop source builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,14 @@ desktop_build_tags() {
     echo "$tags"
 }
 
+desktop_build_env() {
+    if [[ "$OS" == "darwin" ]]; then
+        # Wails' macOS desktop frontend references UTType; make the framework
+        # explicit so source installs link reliably across Xcode/macOS SDKs.
+        echo "CGO_LDFLAGS=${CGO_LDFLAGS:-} -framework UniformTypeIdentifiers"
+    fi
+}
+
 # Banner
 show_banner() {
     echo -e "${BLUE}"
@@ -563,7 +571,11 @@ install_source() {
     TMP_BUILD_DIR=$(mktemp -d)
     go build -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${CLI_BINARY_NAME}" cmd/govard/main.go
     DESKTOP_BUILD_TAGS="$(desktop_build_tags)"
-    go build -tags "$DESKTOP_BUILD_TAGS" -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" cmd/govard-desktop/main.go
+    if desktop_env="$(desktop_build_env)" && [[ -n "$desktop_env" ]]; then
+        env "$desktop_env" go build -tags "$DESKTOP_BUILD_TAGS" -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" cmd/govard-desktop/main.go
+    else
+        go build -tags "$DESKTOP_BUILD_TAGS" -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" cmd/govard-desktop/main.go
+    fi
 
     install_binary_file "${TMP_BUILD_DIR}/${CLI_BINARY_NAME}" "$CLI_BINARY_NAME"
     install_binary_file "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" "$DESKTOP_BINARY_NAME"

--- a/internal/desktop/darwin_uniformtypeidentifiers.go
+++ b/internal/desktop/darwin_uniformtypeidentifiers.go
@@ -1,0 +1,8 @@
+//go:build darwin && desktop
+
+package desktop
+
+/*
+#cgo LDFLAGS: -framework UniformTypeIdentifiers
+*/
+import "C"


### PR DESCRIPTION
## Summary
- add a darwin desktop cgo linker shim for UniformTypeIdentifiers
- make source installs inject the same framework when building govard-desktop on macOS

## Root cause
Wails references Apple's UTType API on macOS, but the source desktop build did not link the UniformTypeIdentifiers framework, causing undefined symbol errors during the final arm64 link step.

## Validation
- bash -n install.sh
- go build -tags "desktop production" -o /tmp/govard-desktop-test ./cmd/govard-desktop/main.go