### PR TITLE
Support arm64 Govard images on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKER_ORG ?= ddtcorex/govard-
 HOST_OS := $(shell uname -s)
 DOCKER_MULTIARCH_PLATFORMS ?= linux/amd64,linux/arm64
+DOCKER_BAKE ?= ./scripts/docker-buildx-bake.sh
 ifeq ($(HOST_OS),Darwin)
 DOCKER_PLATFORMS ?= $(DOCKER_MULTIARCH_PLATFORMS)
 else
@@ -103,8 +104,8 @@ clean: ## Remove build artifacts and clean test cache
 
 images: ## Build Govard Docker images
 	@echo "Building Govard Docker Images..."
-	DOCKER_ORG=$(DOCKER_ORG) docker buildx bake -f docker/docker-bake.hcl $(DOCKER_PLATFORM_FLAGS)
+	DOCKER_ORG=$(DOCKER_ORG) DOCKER_PLATFORMS="$(DOCKER_PLATFORMS)" $(DOCKER_BAKE) -f docker/docker-bake.hcl $(DOCKER_PLATFORM_FLAGS)
 
 push: ## Push Govard Docker images as multi-arch manifests
 	@echo "Pushing Govard Docker Images for $(DOCKER_PLATFORMS)..."
-	DOCKER_ORG=$(DOCKER_ORG) docker buildx bake -f docker/docker-bake.hcl $(DOCKER_PLATFORM_FLAGS) --push
+	DOCKER_ORG=$(DOCKER_ORG) DOCKER_PLATFORMS="$(DOCKER_PLATFORMS)" $(DOCKER_BAKE) -f docker/docker-bake.hcl $(DOCKER_PLATFORM_FLAGS) --push

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
 DOCKER_ORG ?= ddtcorex/govard-
+HOST_OS := $(shell uname -s)
+DOCKER_MULTIARCH_PLATFORMS ?= linux/amd64,linux/arm64
+ifeq ($(HOST_OS),Darwin)
+DOCKER_PLATFORMS ?= $(DOCKER_MULTIARCH_PLATFORMS)
+else
+DOCKER_PLATFORMS ?=
+endif
+comma := ,
+DOCKER_PLATFORM_FLAGS := $(foreach platform,$(subst $(comma), ,$(DOCKER_PLATFORMS)),--set "*.platform=$(platform)")
 BINARY_NAME=govard
 BUILD_DIR=bin
 TEST_BINARY=$(BUILD_DIR)/govard-test
@@ -10,7 +19,7 @@ GOLANGCI_LINT_VERSION ?= v2.11.3
 GOLANGCI_LINT_BIN ?= $(shell go env GOPATH)/bin/golangci-lint
 LDFLAGS ?= -s -w -X govard/internal/cmd.Version=$(VERSION) -X govard/internal/desktop.Version=$(VERSION)
 
-.PHONY: help install install-release build-test-binary build clean test test-unit test-coverage test-integration test-integration-ci test-frontend lint lint-install fmt fmt-check vet push
+.PHONY: help install install-release build-test-binary build clean test test-unit test-coverage test-integration test-integration-ci test-frontend lint lint-install fmt fmt-check vet images push
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -92,10 +101,10 @@ clean: ## Remove build artifacts and clean test cache
 	rm -rf $(BUILD_DIR)
 	go clean -testcache
 
-images:
+images: ## Build Govard Docker images
 	@echo "Building Govard Docker Images..."
-	DOCKER_ORG=$(DOCKER_ORG) docker buildx bake -f docker/docker-bake.hcl
+	DOCKER_ORG=$(DOCKER_ORG) docker buildx bake -f docker/docker-bake.hcl $(DOCKER_PLATFORM_FLAGS)
 
-push:
-	@echo "Pushing Govard Docker Images..."
-	DOCKER_ORG=$(DOCKER_ORG) docker buildx bake -f docker/docker-bake.hcl --push
+push: ## Push Govard Docker images as multi-arch manifests
+	@echo "Pushing Govard Docker Images for $(DOCKER_PLATFORMS)..."
+	DOCKER_ORG=$(DOCKER_ORG) docker buildx bake -f docker/docker-bake.hcl $(DOCKER_PLATFORM_FLAGS) --push

--- a/docker/php/etc/entrypoint.sh
+++ b/docker/php/etc/entrypoint.sh
@@ -36,6 +36,12 @@ if [ -n "${PUID:-}" ]; then
   fi
 fi
 
+# After rewriting www-data's UID, the current process may still run with the
+# old numeric UID. Re-enter as www-data before any later sudo calls.
+if [ "${UID_REMAP_CHANGED}" = "1" ] && [ "$(id -u)" != "$(id -u www-data)" ]; then
+  exec sudo -E -H -u www-data /usr/local/bin/entrypoint.sh "$@"
+fi
+
 # Apply recursive chown if requested
 if [ -n "${CHOWN_DIR_LIST:-}" ]; then
   for dir in ${CHOWN_DIR_LIST}; do
@@ -137,10 +143,6 @@ if [ -n "${NODE_VERSION:-}" ]; then
       fi
     fi
   fi
-fi
-
-if [ "${UID_REMAP_CHANGED}" = "1" ] && [ "$(id -u)" != "$(id -u www-data)" ]; then
-  exec sudo -E -H -u www-data "$@"
 fi
 
 exec "$@"

--- a/docker/php/etc/entrypoint.sh
+++ b/docker/php/etc/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 set -e
 
+# UID/GID remaps change the passwd entry for www-data. Do the remap from a
+# root re-entry while the original www-data UID still resolves for sudo.
+if [ "${GOVARD_ENTRYPOINT_ROOT:-}" != "1" ] && [ "$(id -u)" != "0" ] && { [ -n "${PUID:-}" ] || [ -n "${PGID:-}" ]; }; then
+  exec sudo -E -H env GOVARD_ENTRYPOINT_ROOT=1 /usr/local/bin/entrypoint.sh "$@"
+fi
+
 # ─── Synchronization ───────────────────────────────────────────────────────
 
 # Ensure www-data group changes happen before UID changes. Once the current
@@ -34,12 +40,6 @@ if [ -n "${PUID:-}" ]; then
       UID_REMAP_CHANGED=1
     fi
   fi
-fi
-
-# After rewriting www-data's UID, the current process may still run with the
-# old numeric UID. Re-enter as www-data before any later sudo calls.
-if [ "${UID_REMAP_CHANGED}" = "1" ] && [ "$(id -u)" != "$(id -u www-data)" ]; then
-  exec sudo -E -H -u www-data /usr/local/bin/entrypoint.sh "$@"
 fi
 
 # Apply recursive chown if requested
@@ -145,4 +145,10 @@ if [ -n "${NODE_VERSION:-}" ]; then
   fi
 fi
 
+if [ "$(id -u)" = "0" ]; then
+  unset GOVARD_ENTRYPOINT_ROOT
+  exec sudo -E -H -u www-data "$@"
+fi
+
+unset GOVARD_ENTRYPOINT_ROOT
 exec "$@"

--- a/internal/cmd/doctor_fix.go
+++ b/internal/cmd/doctor_fix.go
@@ -475,8 +475,32 @@ func pullRuntimeImages(check engine.DoctorCheck) DoctorFixResult {
 		}
 	}
 
+	composePath := engine.ComposeFilePathWithProfile(wd, config.ProjectName, config.Profile)
+	rebuildIncompatible := func() bool {
+		if _, statErr := os.Stat(composePath); statErr != nil {
+			return false
+		}
+		built, rebuildErr := engine.RebuildIncompatibleGovardImagesFromCompose(composePath, os.Stdout, os.Stderr)
+		if rebuildErr != nil {
+			result.Status = DoctorFixStatusFailed
+			result.Message = fmt.Sprintf("failed to rebuild incompatible local images: %v", rebuildErr)
+			return true
+		}
+		if len(built) > 0 {
+			result.Actions = append(result.Actions, fmt.Sprintf("Rebuilt incompatible local images: %s", strings.Join(built, ", ")))
+		}
+		return false
+	}
+
 	if len(missing) == 0 {
-		result.Message = "All required images are already present."
+		if failed := rebuildIncompatible(); failed {
+			return result
+		}
+		if len(result.Actions) > 1 {
+			result.Message = "Required images are present; incompatible local images were rebuilt."
+		} else {
+			result.Message = "All required images are already present."
+		}
 		return result
 	}
 
@@ -487,7 +511,6 @@ func pullRuntimeImages(check engine.DoctorCheck) DoctorFixResult {
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			pterm.Warning.Printf("Failed to pull %s. Attempting local build fallback...\n", image)
-			composePath := engine.ComposeFilePathWithProfile(wd, config.ProjectName, config.Profile)
 			built, fallbackErr := engine.FallbackBuildMissingGovardImagesFromCompose(composePath, os.Stdout, os.Stderr)
 			if fallbackErr != nil {
 				result.Status = DoctorFixStatusFailed
@@ -506,6 +529,9 @@ func pullRuntimeImages(check engine.DoctorCheck) DoctorFixResult {
 		} else {
 			result.Actions = append(result.Actions, fmt.Sprintf("Pulled %s", image))
 		}
+	}
+	if failed := rebuildIncompatible(); failed {
+		return result
 	}
 
 	return result

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -239,6 +239,13 @@ func proxyEnvToCompose(cmd *cobra.Command, args []string) error {
 				pterm.Info.Println("No missing Govard-managed images required local build.")
 			}
 		}
+		built, rebuildErr := engine.RebuildIncompatibleGovardImagesFromCompose(composePath, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		if rebuildErr != nil {
+			return fmt.Errorf("rebuild incompatible local Govard images: %w", rebuildErr)
+		}
+		if len(built) > 0 {
+			pterm.Success.Printf("Rebuilt %d incompatible local image(s): %v\n", len(built), built)
+		}
 		pterm.Success.Println("✅ Images pulled.")
 		return nil
 	case "cleanup":

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -313,6 +313,23 @@ func buildUpPipelineStages(cmd *cobra.Command, context *upRuntimeContext) []upPi
 			},
 		},
 		{
+			Name:         "LocalImages",
+			OnFailureTip: "govard doctor --fix",
+			Run: func() error {
+				if !context.FallbackLocal {
+					return nil
+				}
+				built, err := engine.RebuildIncompatibleGovardImagesFromCompose(context.Compose, context.Out, context.Err)
+				if err != nil {
+					return fmt.Errorf("rebuild incompatible local Govard images: %w", err)
+				}
+				if len(built) > 0 {
+					pterm.Success.Printf("Rebuilt %d incompatible local image(s): %s\n", len(built), strings.Join(built, ", "))
+				}
+				return nil
+			},
+		},
+		{
 			Name:         "Start",
 			OnFailureTip: "govard doctor",
 			Run: func() error {

--- a/internal/engine/compose_path.go
+++ b/internal/engine/compose_path.go
@@ -34,6 +34,9 @@ func ComposeFilePathWithProfile(projectRoot string, projectName string, profile 
 	if abs, err := filepath.Abs(root); err == nil {
 		root = abs
 	}
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = filepath.Clean(resolved)
+	}
 
 	name := sanitizeComposeProjectName(projectName)
 	if name == "" {

--- a/internal/engine/local_image_fallback.go
+++ b/internal/engine/local_image_fallback.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -38,6 +39,15 @@ type localImageBuildSpec struct {
 	Dependencies  []string
 }
 
+type localImageInspection struct {
+	Architecture string
+}
+
+type localImageBuildOptions struct {
+	BuildMissing      bool
+	BuildIncompatible bool
+}
+
 // LocalBuildSpecForTest exposes resolved local build spec details for tests.
 type LocalBuildSpecForTest struct {
 	ContextRel    string
@@ -46,12 +56,27 @@ type LocalBuildSpecForTest struct {
 	Dependencies  []string
 }
 
-// FallbackBuildMissingGovardImagesFromCompose builds Govard-managed images locally if pulling fails.
+// FallbackBuildMissingGovardImagesFromCompose builds Govard-managed images locally if
+// pulling fails or if an existing local Govard image should be rebuilt for the host.
 func FallbackBuildMissingGovardImagesFromCompose(composePath string, out io.Writer, errOut io.Writer) ([]string, error) {
-	return fallbackBuildMissingGovardImagesFromCompose(composePath, out, errOut)
+	return buildGovardImagesFromCompose(composePath, out, errOut, localImageBuildOptions{
+		BuildMissing:      true,
+		BuildIncompatible: true,
+	})
 }
 
-func fallbackBuildMissingGovardImagesFromCompose(composePath string, out io.Writer, errOut io.Writer) ([]string, error) {
+// RebuildIncompatibleGovardImagesFromCompose rebuilds existing Govard-managed
+// images that are incompatible with the current host architecture.
+func RebuildIncompatibleGovardImagesFromCompose(composePath string, out io.Writer, errOut io.Writer) ([]string, error) {
+	return buildGovardImagesFromCompose(composePath, out, errOut, localImageBuildOptions{
+		BuildIncompatible: true,
+	})
+}
+
+func buildGovardImagesFromCompose(composePath string, out io.Writer, errOut io.Writer, options localImageBuildOptions) ([]string, error) {
+	out = normalizeWriter(out)
+	errOut = normalizeWriter(errOut)
+
 	serviceImages, err := ReadServiceImagesFromCompose(composePath)
 	if err != nil {
 		return nil, fmt.Errorf("read compose service images: %w", err)
@@ -75,6 +100,7 @@ func fallbackBuildMissingGovardImagesFromCompose(composePath string, out io.Writ
 	buildSpecs := make(map[string]localImageBuildSpec)
 	nonBuildableMissing := make([]string, 0)
 	resolved := make(map[string]struct{})
+	dependencyImages := make(map[string]struct{})
 
 	for len(queue) > 0 {
 		image := queue[0]
@@ -83,14 +109,35 @@ func fallbackBuildMissingGovardImagesFromCompose(composePath string, out io.Writ
 		if _, exists := resolved[image]; exists {
 			continue
 		}
-		if imageExistsLocally(image) {
+
+		inspection, inspectErr := inspectLocalImage(image)
+		imageExists := inspectErr == nil
+
+		repoPrefix, service, tag, ok := parseGovardImageReference(image)
+		if !ok {
+			_, isDependency := dependencyImages[image]
+			if (options.BuildMissing || isDependency) && !imageExists {
+				nonBuildableMissing = append(nonBuildableMissing, image)
+			}
 			resolved[image] = struct{}{}
 			continue
 		}
 
-		repoPrefix, service, tag, ok := parseGovardImageReference(image)
-		if !ok {
-			nonBuildableMissing = append(nonBuildableMissing, image)
+		_, isDependency := dependencyImages[image]
+		if imageExists {
+			if !options.BuildIncompatible || !shouldRebuildGovardImageForHost(inspection.Architecture) {
+				resolved[image] = struct{}{}
+				continue
+			}
+			fmt.Fprintf(
+				errOut,
+				"WARNING: rebuilding %s locally because the existing image architecture is %s on %s/%s\n",
+				image,
+				inspection.Architecture,
+				runtime.GOOS,
+				runtime.GOARCH,
+			)
+		} else if !options.BuildMissing && !isDependency {
 			resolved[image] = struct{}{}
 			continue
 		}
@@ -103,7 +150,10 @@ func fallbackBuildMissingGovardImagesFromCompose(composePath string, out io.Writ
 		}
 
 		buildSpecs[image] = spec
-		queue = append(queue, spec.Dependencies...)
+		for _, dependency := range spec.Dependencies {
+			dependencyImages[dependency] = struct{}{}
+			queue = append(queue, dependency)
+		}
 		resolved[image] = struct{}{}
 	}
 
@@ -473,8 +523,29 @@ func resolveOpensearchBuildVersion(tag string) string {
 }
 
 func imageExistsLocally(image string) bool {
-	command := exec.Command("docker", "image", "inspect", image)
-	return command.Run() == nil
+	_, err := inspectLocalImage(image)
+	return err == nil
+}
+
+func inspectLocalImage(image string) (localImageInspection, error) {
+	command := exec.Command("docker", "image", "inspect", image, "--format", "{{.Architecture}}")
+	output, err := command.Output()
+	if err != nil {
+		return localImageInspection{}, err
+	}
+	return localImageInspection{
+		Architecture: strings.TrimSpace(string(output)),
+	}, nil
+}
+
+func shouldRebuildGovardImageForHost(imageArchitecture string) bool {
+	return shouldRebuildGovardImageForHostWithRuntime(imageArchitecture, runtime.GOOS, runtime.GOARCH)
+}
+
+func shouldRebuildGovardImageForHostWithRuntime(imageArchitecture string, goos string, goarch string) bool {
+	return strings.TrimSpace(goos) == "darwin" &&
+		strings.TrimSpace(goarch) == "arm64" &&
+		strings.TrimSpace(imageArchitecture) == "amd64"
 }
 
 func ensureDockerAssetsRoot(startDir string) (string, error) {
@@ -624,4 +695,9 @@ func ResolveLocalBuildSpecForTest(service string, tag string, repositoryPrefix s
 		BuildArgs:     buildArgs,
 		Dependencies:  spec.Dependencies,
 	}, nil
+}
+
+// ShouldRebuildGovardImageForHostForTest exposes host/image architecture policy for tests.
+func ShouldRebuildGovardImageForHostForTest(imageArchitecture string, goos string, goarch string) bool {
+	return shouldRebuildGovardImageForHostWithRuntime(imageArchitecture, goos, goarch)
 }

--- a/internal/engine/local_image_fallback.go
+++ b/internal/engine/local_image_fallback.go
@@ -522,11 +522,6 @@ func resolveOpensearchBuildVersion(tag string) string {
 	}
 }
 
-func imageExistsLocally(image string) bool {
-	_, err := inspectLocalImage(image)
-	return err == nil
-}
-
 func inspectLocalImage(image string) (localImageInspection, error) {
 	command := exec.Command("docker", "image", "inspect", image, "--format", "{{.Architecture}}")
 	output, err := command.Output()

--- a/internal/engine/project_registry.go
+++ b/internal/engine/project_registry.go
@@ -107,7 +107,7 @@ func UpsertProjectRegistryEntry(entry ProjectRegistryEntry) error {
 }
 
 func GetProjectRegistryEntry(path string) (ProjectRegistryEntry, bool) {
-	path = filepath.Clean(strings.TrimSpace(path))
+	path = normalizeProjectRegistryPath(path)
 	if path == "" {
 		return ProjectRegistryEntry{}, false
 	}
@@ -128,7 +128,7 @@ func GetProjectRegistryEntry(path string) (ProjectRegistryEntry, bool) {
 
 // ClearPreviousProfile clears the previous_profile field for a project in the registry.
 func ClearPreviousProfile(path string) error {
-	path = filepath.Clean(strings.TrimSpace(path))
+	path = normalizeProjectRegistryPath(path)
 	if path == "" {
 		return fmt.Errorf("project path is required")
 	}
@@ -143,7 +143,7 @@ func ClearPreviousProfile(path string) error {
 }
 
 func DeleteProjectRegistryEntry(path string) error {
-	path = filepath.Clean(strings.TrimSpace(path))
+	path = normalizeProjectRegistryPath(path)
 	if path == "" {
 		return fmt.Errorf("project path is required")
 	}
@@ -176,7 +176,7 @@ func ValidateProjectIdentityUniqueness(projectPath string, config Config) error 
 		return fmt.Errorf("read project registry: %w", err)
 	}
 
-	cleanPath := filepath.Clean(strings.TrimSpace(projectPath))
+	cleanPath := normalizeProjectRegistryPath(projectPath)
 	projectName := strings.TrimSpace(strings.ToLower(config.ProjectName))
 	if projectName == "" && cleanPath != "." && cleanPath != "" {
 		projectName = NormalizeProjectName(filepath.Base(cleanPath))
@@ -222,14 +222,14 @@ func ValidateProjectIdentityUniqueness(projectPath string, config Config) error 
 }
 
 func normalizeProjectRegistryEntry(entry ProjectRegistryEntry) (ProjectRegistryEntry, bool) {
-	entry.Path = strings.TrimSpace(entry.Path)
+	entry.Path = normalizeProjectRegistryPath(entry.Path)
 	if entry.Path == "" {
 		return ProjectRegistryEntry{}, false
 	}
-	entry.Path = filepath.Clean(entry.Path)
 
 	if os.Getenv(ProjectRegistryPathEnvVar) == "" {
-		if strings.HasPrefix(entry.Path, "/tmp/") || strings.HasPrefix(entry.Path, filepath.Clean(os.TempDir())) || strings.Contains(entry.Path, "govard/tests") {
+		tempDir := normalizeProjectRegistryPath(os.TempDir())
+		if strings.HasPrefix(entry.Path, "/tmp/") || strings.HasPrefix(entry.Path, tempDir) || strings.Contains(entry.Path, "govard/tests") {
 			return ProjectRegistryEntry{}, false
 		}
 	}
@@ -253,6 +253,21 @@ func normalizeProjectRegistryEntry(entry ProjectRegistryEntry) (ProjectRegistryE
 		entry.ProjectName = filepath.Base(entry.Path)
 	}
 	return entry, true
+}
+
+func normalizeProjectRegistryPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = filepath.Clean(path)
+	if path == "." {
+		return path
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return path
 }
 
 func sortProjectRegistryEntries(entries []ProjectRegistryEntry) {

--- a/scripts/docker-buildx-bake.sh
+++ b/scripts/docker-buildx-bake.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env sh
+set -eu
+
+BUILDER_NAME="${GOVARD_BUILDX_BUILDER:-govard-multiarch}"
+PLATFORMS="${DOCKER_PLATFORMS:-}"
+
+has_multiple_platforms() {
+  count=0
+  for platform in $(printf '%s' "${PLATFORMS}" | tr ',' ' '); do
+    if [ -n "${platform}" ]; then
+      count=$((count + 1))
+    fi
+    if [ "${count}" -gt 1 ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_multiarch_builder() {
+  if docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "Creating Docker Buildx builder '${BUILDER_NAME}' for Govard multi-platform images..." >&2
+  docker buildx create --name "${BUILDER_NAME}" --driver docker-container --bootstrap >/dev/null
+}
+
+builder_platforms() {
+  docker buildx inspect "${BUILDER_NAME}" --bootstrap |
+    awk '/^Platforms:/ { sub(/^Platforms:[[:space:]]*/, ""); print; exit }'
+}
+
+platform_is_supported() {
+  platform="$1"
+  platforms_without_spaces=$(printf '%s' "$2" | tr -d ' ')
+  case ",${platforms_without_spaces}," in
+    *",${platform},"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ensure_requested_platforms_supported() {
+  supported_platforms=$(builder_platforms)
+  for platform in $(printf '%s' "${PLATFORMS}" | tr ',' ' '); do
+    if [ -z "${platform}" ]; then
+      continue
+    fi
+    if ! platform_is_supported "${platform}" "${supported_platforms}"; then
+      echo "Docker Buildx builder '${BUILDER_NAME}' does not support requested platform '${platform}'." >&2
+      echo "Supported platforms: ${supported_platforms:-unknown}" >&2
+      echo "Enable Docker Desktop/Rosetta emulation or install binfmt/QEMU support, then retry." >&2
+      exit 1
+    fi
+  done
+}
+
+if has_multiple_platforms; then
+  ensure_multiarch_builder
+  ensure_requested_platforms_supported
+  exec docker buildx bake --builder "${BUILDER_NAME}" "$@"
+fi
+
+exec docker buildx bake "$@"

--- a/tests/cmd_desktop_binary_resolution_test.go
+++ b/tests/cmd_desktop_binary_resolution_test.go
@@ -43,7 +43,7 @@ func TestFindDesktopBinaryForTestPrefersSiblingOfCurrentGovardBinary(t *testing.
 	if err != nil {
 		t.Fatalf("FindDesktopBinaryForTest() error = %v", err)
 	}
-	if got != siblingDesktop {
+	if !sameTestFile(t, got, siblingDesktop) {
 		t.Fatalf("FindDesktopBinaryForTest() = %q, want sibling %q", got, siblingDesktop)
 	}
 }
@@ -82,7 +82,7 @@ func TestFindDesktopBinaryForTestFallsBackToLookPathWhenSiblingMissing(t *testin
 	if err != nil {
 		t.Fatalf("FindDesktopBinaryForTest() error = %v", err)
 	}
-	if got != pathDesktop {
+	if !sameTestFile(t, got, pathDesktop) {
 		t.Fatalf("FindDesktopBinaryForTest() = %q, want PATH binary %q", got, pathDesktop)
 	}
 }
@@ -122,4 +122,18 @@ func TestFindDesktopBinaryForTestReturnsErrorWhenNoSiblingAndNoLookPathMatch(t *
 	if _, err := cmdpkg.FindDesktopBinaryForTest(); err == nil {
 		t.Fatal("FindDesktopBinaryForTest() expected error, got nil")
 	}
+}
+
+func sameTestFile(t *testing.T, left string, right string) bool {
+	t.Helper()
+
+	leftInfo, err := os.Stat(left)
+	if err != nil {
+		t.Fatalf("stat %s: %v", left, err)
+	}
+	rightInfo, err := os.Stat(right)
+	if err != nil {
+		t.Fatalf("stat %s: %v", right, err)
+	}
+	return os.SameFile(leftInfo, rightInfo)
 }

--- a/tests/desktop_environment_cli_test.go
+++ b/tests/desktop_environment_cli_test.go
@@ -61,7 +61,7 @@ func TestDesktopStartEnvironmentUsesGovardUpForProjectForTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartEnvironment failed: %v", err)
 	}
-	if gotDir != root {
+	if !sameTestFile(t, gotDir, root) {
 		t.Fatalf("expected govard dir %q, got %q", root, gotDir)
 	}
 	if !reflect.DeepEqual(gotArgs, []string{"up", "--force-recreate", "--remove-orphans"}) {
@@ -93,7 +93,7 @@ func TestDesktopStopEnvironmentUsesGovardEnvStopForProjectForTest(t *testing.T) 
 	if err != nil {
 		t.Fatalf("StopEnvironment failed: %v", err)
 	}
-	if gotDir != root {
+	if !sameTestFile(t, gotDir, root) {
 		t.Fatalf("expected govard dir %q, got %q", root, gotDir)
 	}
 	if !reflect.DeepEqual(gotArgs, []string{"env", "stop"}) {
@@ -125,7 +125,7 @@ func TestDesktopPullEnvironmentUsesGovardEnvPullForProjectForTest(t *testing.T) 
 	if err != nil {
 		t.Fatalf("PullEnvironment failed: %v", err)
 	}
-	if gotDir != root {
+	if !sameTestFile(t, gotDir, root) {
 		t.Fatalf("expected govard dir %q, got %q", root, gotDir)
 	}
 	if !reflect.DeepEqual(gotArgs, []string{"env", "pull"}) {

--- a/tests/desktop_onboarding_test.go
+++ b/tests/desktop_onboarding_test.go
@@ -62,7 +62,7 @@ domain: demo.test
 	if len(entries) != 1 {
 		t.Fatalf("expected one registry entry, got %d", len(entries))
 	}
-	if entries[0].Path != root {
+	if !sameTestFile(t, entries[0].Path, root) {
 		t.Fatalf("expected registry path %s, got %s", root, entries[0].Path)
 	}
 	if entries[0].ProjectName != "demo" {

--- a/tests/desktop_project_resolution_test.go
+++ b/tests/desktop_project_resolution_test.go
@@ -63,7 +63,7 @@ func TestDesktopProjectResolution(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to resolve %q: %v", tt.query, err)
 			}
-			if filepath.Clean(got) != filepath.Clean(tt.want) {
+			if !sameTestFile(t, got, tt.want) {
 				t.Errorf("ResolveProjectRootForRemotes(%q) = %q, want %q", tt.query, got, tt.want)
 			}
 		})

--- a/tests/desktop_update_test.go
+++ b/tests/desktop_update_test.go
@@ -212,7 +212,7 @@ func TestDesktopResolveGovardBinaryForUpdatePrefersSibling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve govard binary for desktop update failed: %v", err)
 	}
-	if resolved != siblingGovard {
+	if !sameTestFile(t, resolved, siblingGovard) {
 		t.Fatalf("expected sibling govard binary %q, got %q", siblingGovard, resolved)
 	}
 }
@@ -240,7 +240,7 @@ func TestDesktopResolveGovardBinaryForUpdateFallsBackToPATH(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve govard binary for desktop update failed: %v", err)
 	}
-	if resolved != pathGovard {
+	if !sameTestFile(t, resolved, pathGovard) {
 		t.Fatalf("expected PATH govard binary %q, got %q", pathGovard, resolved)
 	}
 }
@@ -261,7 +261,7 @@ func TestDesktopResolveDesktopBinaryForSelfUpdateTarget(t *testing.T) {
 	defer restoreExec()
 
 	target := desktop.ResolveDesktopBinaryForSelfUpdateTargetForTest()
-	if target != runningDesktop {
+	if !sameTestFile(t, target, runningDesktop) {
 		t.Fatalf("expected desktop target %q, got %q", runningDesktop, target)
 	}
 }
@@ -301,7 +301,7 @@ func TestDesktopRestartDesktopAppStartsBinary(t *testing.T) {
 	if !strings.Contains(message, "Restarting Govard Desktop") {
 		t.Fatalf("unexpected restart message: %q", message)
 	}
-	if called != binaryPath {
+	if !sameTestFile(t, called, binaryPath) {
 		t.Fatalf("expected restart command to target %q, got %q", binaryPath, called)
 	}
 }

--- a/tests/docker_buildx_makefile_test.go
+++ b/tests/docker_buildx_makefile_test.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMakefileUsesBuildxWrapperForImageTargets(t *testing.T) {
+	content := readProjectFileForTest(t, "Makefile")
+	if !strings.Contains(content, "./scripts/docker-buildx-bake.sh") {
+		t.Fatalf("expected Makefile image targets to use buildx wrapper, got:\n%s", content)
+	}
+}
+
+func TestDockerBuildxBakeWrapperPreparesMultiPlatformBuilder(t *testing.T) {
+	content := readProjectFileForTest(t, filepath.Join("scripts", "docker-buildx-bake.sh"))
+	for _, expected := range []string{
+		"DOCKER_PLATFORMS",
+		"govard-multiarch",
+		"docker buildx create",
+		"--driver docker-container",
+		"docker buildx inspect \"${BUILDER_NAME}\" --bootstrap",
+		"does not support requested platform",
+		"--builder",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("expected buildx wrapper to contain %q, got:\n%s", expected, content)
+		}
+	}
+}
+
+func TestDockerBuildxBakeWrapperIsExecutable(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file location")
+	}
+	projectRoot := filepath.Join(filepath.Dir(filename), "..")
+	scriptPath := filepath.Join(projectRoot, "scripts", "docker-buildx-bake.sh")
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("stat %s: %v", scriptPath, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("expected %s to be executable, mode is %s", scriptPath, info.Mode())
+	}
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -590,3 +590,29 @@ func LoadComposeServices(t *testing.T, composePath string) map[string]interface{
 
 	return services
 }
+
+func canonicalPathForTest(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve test path %s: %v", path, err)
+	}
+	return resolved
+}
+
+func browserOpenCommandNameForTest(t *testing.T) string {
+	t.Helper()
+
+	switch runtime.GOOS {
+	case "darwin":
+		return "open"
+	case "linux":
+		return "xdg-open"
+	case "windows":
+		return "rundll32"
+	default:
+		t.Fatalf("unsupported platform %q", runtime.GOOS)
+		return ""
+	}
+}

--- a/tests/integration/magento_additional_commands_test.go
+++ b/tests/integration/magento_additional_commands_test.go
@@ -272,7 +272,8 @@ func TestOpenAndShortcutBrowserCommands(t *testing.T) {
 	env := NewTestEnvironment(t)
 	projectDir := env.CreateProjectFromFixture(t, "magento2/options-local", "open-shortcuts-m2")
 	shim := env.SetupRuntimeShims(t, map[string]int{"docker": 0, "ssh": 0, "rsync": 0})
-	installRuntimeCommandShim(t, shim, "xdg-open", 0)
+	browserCommand := browserOpenCommandNameForTest(t)
+	installRuntimeCommandShim(t, shim, browserCommand, 0)
 
 	commands := [][]string{
 		{"open", "admin"},
@@ -290,20 +291,20 @@ func TestOpenAndShortcutBrowserCommands(t *testing.T) {
 
 	ok := WaitForCondition(t, 2*time.Second, 20*time.Millisecond, func() bool {
 		logs := shim.ReadLog(t)
-		return strings.Count(logs, "xdg-open|") >= len(commands)
+		return strings.Count(logs, browserCommand+"|") >= len(commands)
 	})
 	if !ok {
-		t.Fatalf("expected %d xdg-open invocations, got logs:\n%s", len(commands), shim.ReadLog(t))
+		t.Fatalf("expected %d %s invocations, got logs:\n%s", len(commands), browserCommand, shim.ReadLog(t))
 	}
 
 	logs := shim.ReadLog(t)
-	assertContains(t, logs, "xdg-open|https://m2-clone-basic.test/admin")
+	assertContains(t, logs, browserCommand+"|https://m2-clone-basic.test/admin")
 	assertContains(t, logs, "project=m2-clone-basic")
 	assertContains(t, logs, "db=magento")
-	assertContains(t, logs, "xdg-open|mysql://magento:magento@127.0.0.1:3306/magento")
-	assertContains(t, logs, "xdg-open|https://elasticsearch.govard.test")
-	assertContains(t, logs, "xdg-open|https://opensearch.govard.test")
-	assertContains(t, logs, "xdg-open|https://mail.govard.test")
+	assertContains(t, logs, browserCommand+"|mysql://magento:magento@127.0.0.1:3306/magento")
+	assertContains(t, logs, browserCommand+"|https://elasticsearch.govard.test")
+	assertContains(t, logs, browserCommand+"|https://opensearch.govard.test")
+	assertContains(t, logs, browserCommand+"|https://mail.govard.test")
 	if strings.Contains(logs, "ssh|") {
 		t.Fatalf("did not expect ssh tunnel for default open targets, got logs:\n%s", logs)
 	}
@@ -313,7 +314,8 @@ func TestOpenDBEnvironmentSelection(t *testing.T) {
 	env := NewTestEnvironment(t)
 	projectDir := env.CreateProjectFromFixture(t, "magento2/options-local", "open-db-env-selection-m2")
 	shim := env.SetupRuntimeShims(t, map[string]int{"docker": 0, "ssh": 0, "rsync": 0})
-	installRuntimeCommandShim(t, shim, "xdg-open", 0)
+	browserCommand := browserOpenCommandNameForTest(t)
+	installRuntimeCommandShim(t, shim, browserCommand, 0)
 
 	localResult := env.RunGovardWithEnv(t, projectDir, shim.Env(), "open", "db", "-e", "local")
 	localResult.AssertSuccess(t)
@@ -328,7 +330,7 @@ func TestOpenDBEnvironmentSelection(t *testing.T) {
 	clientResult := env.RunGovardWithEnv(t, projectDir, shim.Env(), "open", "db", "-e", "local", "--client")
 	clientResult.AssertSuccess(t)
 	updatedLogs := shim.ReadLog(t)
-	assertContains(t, updatedLogs, "xdg-open|mysql://magento:magento@127.0.0.1:3306/magento")
+	assertContains(t, updatedLogs, browserCommand+"|mysql://magento:magento@127.0.0.1:3306/magento")
 	if strings.Contains(updatedLogs, "ssh|") {
 		t.Fatalf("did not expect ssh tunnel for local db client open, got logs:\n%s", updatedLogs)
 	}
@@ -351,7 +353,8 @@ func TestOpenTargetsRemoteEnvironment(t *testing.T) {
 	env := NewTestEnvironment(t)
 	projectDir := env.CreateProjectFromFixture(t, "magento2/options-local", "open-remote-targets-m2")
 	shim := env.SetupRuntimeShims(t, map[string]int{"docker": 0, "ssh": 0, "rsync": 0})
-	installRuntimeCommandShim(t, shim, "xdg-open", 0)
+	browserCommand := browserOpenCommandNameForTest(t)
+	installRuntimeCommandShim(t, shim, browserCommand, 0)
 
 	adminResult := env.RunGovardWithEnv(t, projectDir, shim.Env(), "open", "admin", "-e", "dev")
 	adminResult.AssertSuccess(t)
@@ -367,8 +370,8 @@ func TestOpenTargetsRemoteEnvironment(t *testing.T) {
 	assertContains(t, strings.ToLower(searchResult.Stdout+searchResult.Stderr), "not supported yet")
 
 	logs := shim.ReadLog(t)
-	assertContains(t, logs, "xdg-open|https://dev.example.com/")
-	assertContains(t, logs, "xdg-open|sftp://deploy@dev.example.com:22/var/www/html")
+	assertContains(t, logs, browserCommand+"|https://dev.example.com/")
+	assertContains(t, logs, browserCommand+"|sftp://deploy@dev.example.com:22/var/www/html")
 	assertContains(t, logs, "ssh|")
 }
 

--- a/tests/integration/magento_remaining_commands_test.go
+++ b/tests/integration/magento_remaining_commands_test.go
@@ -49,8 +49,15 @@ func TestTrustCommandWithShims(t *testing.T) {
 
 	logs := shim.ReadLog(t)
 	assertContains(t, logs, "docker|cp govard-proxy-caddy:/data/caddy/pki/authorities/local/root.crt "+certPath)
-	assertContains(t, logs, "sudo|cp "+certPath+" /usr/local/share/ca-certificates/govard.crt")
-	assertContains(t, logs, "sudo|update-ca-certificates")
+	switch runtime.GOOS {
+	case "darwin":
+		assertContains(t, logs, "sudo|security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "+certPath)
+	case "linux":
+		assertContains(t, logs, "sudo|cp "+certPath+" /usr/local/share/ca-certificates/govard.crt")
+		assertContains(t, logs, "sudo|update-ca-certificates")
+	default:
+		t.Fatalf("unsupported trust command integration platform %q", runtime.GOOS)
+	}
 }
 
 func TestDesktopCommandRuntimePaths(t *testing.T) {
@@ -248,7 +255,7 @@ func TestSelfUpdateAutoConfirmSuccessWithMockRelease(t *testing.T) {
 	assertContains(t, output, "Auto-confirmed via GOVARD_SELF_UPDATE_CONFIRM.")
 	assertContains(t, output, "Checksum verified for "+archiveName+".")
 	assertContains(t, output, "Checksum verified for "+desktopArchiveName+".")
-	assertContains(t, output, "Updated govard-desktop at "+isolatedDesktopBinary)
+	assertContains(t, output, "Updated govard-desktop at "+canonicalPathForTest(t, isolatedDesktopBinary))
 	assertContains(t, output, "Successfully updated Govard to "+releaseTag)
 }
 

--- a/tests/local_image_fallback_test.go
+++ b/tests/local_image_fallback_test.go
@@ -94,3 +94,21 @@ func TestLocalBuildSpecPHPMagento2Debug(t *testing.T) {
 		t.Fatalf("expected dependency on base image, got %v", spec.Dependencies)
 	}
 }
+
+func TestShouldRebuildGovardImageForHostOnDarwinArm64(t *testing.T) {
+	if !engine.ShouldRebuildGovardImageForHostForTest("amd64", "darwin", "arm64") {
+		t.Fatal("expected darwin/arm64 host to rebuild amd64 Govard image")
+	}
+}
+
+func TestShouldNotRebuildGovardImageForHostWhenAlreadyArm64(t *testing.T) {
+	if engine.ShouldRebuildGovardImageForHostForTest("arm64", "darwin", "arm64") {
+		t.Fatal("did not expect darwin/arm64 host to rebuild arm64 Govard image")
+	}
+}
+
+func TestShouldNotRebuildGovardImageForHostOnLinux(t *testing.T) {
+	if engine.ShouldRebuildGovardImageForHostForTest("amd64", "linux", "arm64") {
+		t.Fatal("did not expect linux host to rebuild existing amd64 Govard image")
+	}
+}

--- a/tests/php_runtime_cron_support_test.go
+++ b/tests/php_runtime_cron_support_test.go
@@ -67,8 +67,16 @@ func TestPHPEntrypointRelaunchesProcessAfterUIDRemap(t *testing.T) {
 	if !strings.Contains(content, "UID_REMAP_CHANGED=1") {
 		t.Fatalf("expected php entrypoint to track successful UID remaps, got:\n%s", content)
 	}
-	if !strings.Contains(content, "exec sudo -E -H -u www-data \"$@\"") {
-		t.Fatalf("expected php entrypoint to launch php-fpm as remapped www-data, got:\n%s", content)
+	reenterIndex := strings.Index(content, "exec sudo -E -H -u www-data /usr/local/bin/entrypoint.sh \"$@\"")
+	chownIndex := strings.Index(content, "if [ -n \"${CHOWN_DIR_LIST:-}\" ]; then")
+	if reenterIndex == -1 {
+		t.Fatalf("expected php entrypoint to re-enter as remapped www-data, got:\n%s", content)
+	}
+	if chownIndex == -1 {
+		t.Fatalf("expected php entrypoint to contain CHOWN_DIR_LIST handling, got:\n%s", content)
+	}
+	if reenterIndex > chownIndex {
+		t.Fatalf("expected php entrypoint to re-enter before recursive chown, got:\n%s", content)
 	}
 }
 

--- a/tests/php_runtime_cron_support_test.go
+++ b/tests/php_runtime_cron_support_test.go
@@ -62,21 +62,36 @@ func TestPHPEntrypointUpdatesGIDBeforeUID(t *testing.T) {
 	}
 }
 
-func TestPHPEntrypointRelaunchesProcessAfterUIDRemap(t *testing.T) {
+func TestPHPEntrypointReentersAsRootBeforeUIDRemap(t *testing.T) {
 	content := readProjectFileForTest(t, filepath.Join("docker", "php", "etc", "entrypoint.sh"))
 	if !strings.Contains(content, "UID_REMAP_CHANGED=1") {
 		t.Fatalf("expected php entrypoint to track successful UID remaps, got:\n%s", content)
 	}
-	reenterIndex := strings.Index(content, "exec sudo -E -H -u www-data /usr/local/bin/entrypoint.sh \"$@\"")
+	rootReenterIndex := strings.Index(content, "exec sudo -E -H env GOVARD_ENTRYPOINT_ROOT=1 /usr/local/bin/entrypoint.sh \"$@\"")
+	gidIndex := strings.Index(content, "CURRENT_GID=$(id -g www-data)")
+	uidIndex := strings.Index(content, "CURRENT_UID=$(id -u www-data)")
 	chownIndex := strings.Index(content, "if [ -n \"${CHOWN_DIR_LIST:-}\" ]; then")
-	if reenterIndex == -1 {
-		t.Fatalf("expected php entrypoint to re-enter as remapped www-data, got:\n%s", content)
+	dropIndex := strings.LastIndex(content, "exec sudo -E -H -u www-data \"$@\"")
+	if rootReenterIndex == -1 {
+		t.Fatalf("expected php entrypoint to re-enter as root before UID/GID remap, got:\n%s", content)
+	}
+	if gidIndex == -1 || uidIndex == -1 {
+		t.Fatalf("expected php entrypoint to contain UID/GID remap blocks, got:\n%s", content)
+	}
+	if rootReenterIndex > gidIndex || rootReenterIndex > uidIndex {
+		t.Fatalf("expected php entrypoint to re-enter as root before modifying www-data, got:\n%s", content)
 	}
 	if chownIndex == -1 {
 		t.Fatalf("expected php entrypoint to contain CHOWN_DIR_LIST handling, got:\n%s", content)
 	}
-	if reenterIndex > chownIndex {
+	if rootReenterIndex > chownIndex {
 		t.Fatalf("expected php entrypoint to re-enter before recursive chown, got:\n%s", content)
+	}
+	if dropIndex == -1 {
+		t.Fatalf("expected php entrypoint to drop back to www-data before the final command, got:\n%s", content)
+	}
+	if dropIndex < uidIndex {
+		t.Fatalf("expected php entrypoint to drop to www-data after UID remap, got:\n%s", content)
 	}
 }
 

--- a/tests/self_update_test.go
+++ b/tests/self_update_test.go
@@ -221,8 +221,9 @@ func TestResolveDesktopUpdateTargetsForTestPrefersSiblingTargetWhenCLIBinaryPath
 	if len(got) != 1 {
 		t.Fatalf("expected 1 desktop target, got %d: %v", len(got), got)
 	}
-	if got[0] != siblingDesktop {
-		t.Fatalf("expected sibling desktop target %q, got %v", siblingDesktop, got)
+	expectedSiblingDesktop := canonicalTestPath(t, siblingDesktop)
+	if got[0] != expectedSiblingDesktop {
+		t.Fatalf("expected sibling desktop target %q, got %v", expectedSiblingDesktop, got)
 	}
 }
 
@@ -250,8 +251,9 @@ func TestResolveDesktopUpdateTargetsForTestDeduplicatesTargets(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected deduplicated desktop target, got %d: %v", len(got), got)
 	}
-	if got[0] != desktopBinary {
-		t.Fatalf("unexpected desktop target %q, want %q", got[0], desktopBinary)
+	expectedDesktopBinary := canonicalTestPath(t, desktopBinary)
+	if got[0] != expectedDesktopBinary {
+		t.Fatalf("unexpected desktop target %q, want %q", got[0], expectedDesktopBinary)
 	}
 }
 
@@ -283,8 +285,9 @@ func TestResolveDesktopUpdateTargetsForTestFallsBackToPATHWhenSiblingIsMissing(t
 	if len(got) != 1 {
 		t.Fatalf("expected path fallback target, got %d: %v", len(got), got)
 	}
-	if got[0] != pathDesktop {
-		t.Fatalf("expected PATH target %q, got %v", pathDesktop, got)
+	expectedPathDesktop := canonicalTestPath(t, pathDesktop)
+	if got[0] != expectedPathDesktop {
+		t.Fatalf("expected PATH target %q, got %v", expectedPathDesktop, got)
 	}
 }
 
@@ -309,9 +312,20 @@ func TestResolveDesktopUpdateTargetsForTestUsesExplicitDesktopTargetEnv(t *testi
 	if len(got) != 1 {
 		t.Fatalf("expected explicit desktop target, got %d: %v", len(got), got)
 	}
-	if !slices.Contains(got, customDesktop) {
-		t.Fatalf("expected explicit target %q in %v", customDesktop, got)
+	expectedCustomDesktop := canonicalTestPath(t, customDesktop)
+	if !slices.Contains(got, expectedCustomDesktop) {
+		t.Fatalf("expected explicit target %q in %v", expectedCustomDesktop, got)
 	}
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve test path %s: %v", path, err)
+	}
+	return resolved
 }
 
 func TestDetectMixedInstallChannelPairsForTestIncludesConflictingCopies(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR makes Govard handle Apple Silicon/macOS image workflows more reliably.

- Rebuild locally cached Govard-managed `amd64` images on `darwin/arm64` when the image already exists but is incompatible with the host.
- Run the rebuild check through `govard up`, `govard env pull`, and `govard doctor --fix`, so the fix applies even when images are present and `docker compose pull` does not report them as missing.
- Add `DOCKER_PLATFORMS` support for `make images` and `make push`, with macOS defaulting to `linux/amd64,linux/arm64` and single-platform overrides still supported.
- Route image builds through a Buildx wrapper that creates/uses a `docker-container` builder for multi-platform builds and fails early with a clear message if the requested platform is not supported.
- Fix the PHP image entrypoint UID/GID remap flow by re-entering as root before changing `www-data`, then dropping back to `www-data` before running the final command.
- Canonicalize symlinked project paths in compose-file and project-registry paths, and stabilize macOS-specific tests around browser/trust commands and binary path resolution.

## Root Cause

On Apple Silicon, Docker can have a Govard-managed image in the local cache with `amd64` architecture. Because the image exists, the previous fallback path did not rebuild it, but the runtime could still be using an image that is incompatible with the host.

The PHP entrypoint also attempted to call `sudo` after changing the UID for `www-data`. At that point, the current process could be running under a numeric UID that no longer resolves in `/etc/passwd`, which causes `sudo` to fail with `you do not exist in the passwd database`.

For image publishing, `docker buildx bake` with multiple platforms fails on Docker's default `docker` builder. Multi-platform builds need a compatible builder such as `docker-container`, or a clear preflight failure when the requested platform is not available.

## Implementation Notes

- `FallbackBuildMissingGovardImagesFromCompose` now delegates to a shared build path that can build missing images and rebuild incompatible local images.
- `RebuildIncompatibleGovardImagesFromCompose` inspects existing local image architecture and rebuilds Govard-managed `amd64` images only on `darwin/arm64`.
- `govard up`, `env pull`, and `doctor --fix` call the incompatible-image rebuild path after compose rendering/pull handling.
- `scripts/docker-buildx-bake.sh` preserves the existing bake interface while selecting a multi-platform builder only when `DOCKER_PLATFORMS` contains more than one platform.
- The PHP entrypoint now performs UID/GID mutation from a root re-entry and only drops to `www-data` at the end.

## Tests

- `go test -count=1 ./tests`
- `go test -count=1 ./internal/engine ./internal/cmd`
- `git diff --check`
- `sh -n scripts/docker-buildx-bake.sh`
- `make -n images DOCKER_PLATFORMS=linux/amd64,linux/arm64`
- `make -n push DOCKER_PLATFORMS=linux/amd64,linux/arm64`
- `DOCKER_PLATFORMS=linux/arm64 ./scripts/docker-buildx-bake.sh -f docker/docker-bake.hcl --set "*.platform=linux/arm64" --print dnsmasq`
- Verified the multi-platform Buildx wrapper fails early with a clear message on a Linux host whose builder does not advertise `linux/arm64`.
- Verified the PHP entrypoint in Docker with `PUID=2000` and `PGID=2000`; the final command ran as UID `2000`, and `www-data` resolved to UID `2000`.
