### PR TITLE
feat: custom nginx/apache config extension point

### DIFF
--- a/docker/apache/etc/httpd.conf
+++ b/docker/apache/etc/httpd.conf
@@ -71,4 +71,5 @@ CustomLog /proc/self/fd/1 combined
             SetHandler "proxy:fcgi://php:9000"
         </Else>
     </FilesMatch>
+    @CUSTOM_INCLUDE@
 </VirtualHost>

--- a/docker/nginx/etc/templates/cakephp.conf
+++ b/docker/nginx/etc/templates/cakephp.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/default.conf
+++ b/docker/nginx/etc/templates/default.conf
@@ -34,4 +34,5 @@ server {
     location ~* (\.htaccess$|\.git) {
         deny all;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/drupal.conf
+++ b/docker/nginx/etc/templates/drupal.conf
@@ -31,4 +31,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/hybrid.conf
+++ b/docker/nginx/etc/templates/hybrid.conf
@@ -29,4 +29,5 @@ server {
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/laravel.conf
+++ b/docker/nginx/etc/templates/laravel.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/magento1.conf
+++ b/docker/nginx/etc/templates/magento1.conf
@@ -42,4 +42,5 @@ server {
     location ~* (\.htaccess$|\.git) {
         deny all;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/magento2.conf
+++ b/docker/nginx/etc/templates/magento2.conf
@@ -136,4 +136,5 @@ server {
     location ~* (\.php$|\.phtml$|\.htaccess$|\.git) {
         deny all;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/shopware.conf
+++ b/docker/nginx/etc/templates/shopware.conf
@@ -37,4 +37,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/symfony.conf
+++ b/docker/nginx/etc/templates/symfony.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docker/nginx/etc/templates/wordpress.conf
+++ b/docker/nginx/etc/templates/wordpress.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -291,6 +291,8 @@ Remote fields support `op://...` references resolved through the 1Password CLI.
 | `.govard/docker-compose.override.yml` | Compose overrides merged after framework includes |
 | `.govard/commands/*` | Custom commands exposed via `govard custom` |
 | `.govard/hooks/*` | Scripts referenced by `hooks.*.run` |
+| `.govard/nginx/custom/*.conf` | Extra nginx directives included inside the rendered `server {}` block (nginx web server only) |
+| `.govard/apache/custom/*.conf` | Extra Apache directives included inside the rendered `<VirtualHost>` block (Apache web server only) |
 
 **Lifecycle hook events:**
 
@@ -300,9 +302,9 @@ Remote fields support `op://...` references resolved through the 1Password CLI.
 - `pre-delete` / `post-delete`
 
 ::: tip TIP
-Govard fingerprints `.govard/docker-compose.override.yml`. If it changes, the next `env up` auto-re-renders the compose output.
+Govard fingerprints `.govard/docker-compose.override.yml`, `.govard/nginx/custom/`, and `.govard/apache/custom/`. If any of them change, the next `env up` auto-re-renders the compose output.
 
-When overriding services, prefer additive merges (extra environment variables, labels, ports). Replacing full lists like `services.web.volumes` can discard required Govard-managed mounts.
+When overriding services, prefer additive merges (extra environment variables, labels, ports). Replacing full lists like `services.web.volumes` can discard required Govard-managed mounts. `.govard/nginx/custom/` and `.govard/apache/custom/` exist precisely so you don't have to replace the whole web server config just to add a directive.
 :::
 
 ---

--- a/docs/vi/reference/configuration.md
+++ b/docs/vi/reference/configuration.md
@@ -275,6 +275,8 @@ Các trường thông tin remote hỗ trợ các tham chiếu `op://...` đượ
 | `.govard/docker-compose.override.yml` | Ghi đè Compose được merge sau khi include framework |
 | `.govard/commands/*` | Các lệnh tùy chỉnh được hiển thị qua `govard custom` |
 | `.govard/hooks/*` | Các script được tham chiếu bởi `hooks.*.run` |
+| `.govard/nginx/custom/*.conf` | Directive nginx bổ sung, được include vào bên trong `server {}` đã render (chỉ áp dụng cho nginx) |
+| `.govard/apache/custom/*.conf` | Directive Apache bổ sung, được include vào bên trong `<VirtualHost>` đã render (chỉ áp dụng cho Apache) |
 
 **Các sự kiện lifecycle hook:**
 
@@ -284,9 +286,9 @@ Các trường thông tin remote hỗ trợ các tham chiếu `op://...` đượ
 - `pre-delete` / `post-delete`
 
 ::: tip GỢI Ý
-Govard tạo mã hash vân tay cho `.govard/docker-compose.override.yml`. Nếu file này thay đổi, lệnh `env up` tiếp theo sẽ tự động re-render cấu trúc compose.
+Govard tạo mã hash vân tay cho `.govard/docker-compose.override.yml`, `.govard/nginx/custom/`, và `.govard/apache/custom/`. Nếu bất kỳ thứ nào trong số này thay đổi, lệnh `env up` tiếp theo sẽ tự động re-render cấu trúc compose.
 
-Khi ghi đè dịch vụ, nên ưu tiên các bổ sung nhỏ (thêm biến môi trường, label, port). Việc thay thế hoàn toàn danh sách như `services.web.volumes` có thể làm mất các mount quan trọng do Govard quản lý.
+Khi ghi đè dịch vụ, nên ưu tiên các bổ sung nhỏ (thêm biến môi trường, label, port). Việc thay thế hoàn toàn danh sách như `services.web.volumes` có thể làm mất các mount quan trọng do Govard quản lý. `.govard/nginx/custom/` và `.govard/apache/custom/` tồn tại chính xác để bạn không cần thay thế toàn bộ cấu hình web server chỉ để thêm một directive.
 :::
 
 ---

--- a/internal/blueprints/files/includes/base.yml
+++ b/internal/blueprints/files/includes/base.yml
@@ -15,11 +15,17 @@ services:
       {{ if and (not $isApache) .NginxConfigPath }}
       - "{{ .NginxConfigPath }}:/etc/nginx/templates/{{ if $isHybrid }}hybrid.conf{{ else }}{{ .NGINXTemplate }}{{ end }}:ro"
       {{ end }}
+      {{ if and (not $isApache) .NginxCustomConfigDir }}
+      - "{{ .NginxCustomConfigDir }}:/etc/nginx/custom:ro"
+      {{ end }}
       {{ if and $isMagento (not $isApache) (not $isHybrid) .NginxMageRunMapPath }}
       - "{{ .NginxMageRunMapPath }}:/etc/nginx/conf.d/mage-run-map.conf:ro"
       {{ end }}
       {{ if and $isApache .ApacheConfigDir }}
       - "{{ .ApacheConfigDir }}:/usr/local/apache2/conf"
+      {{ end }}
+      {{ if and $isApache .ApacheCustomConfigDir }}
+      - "{{ .ApacheCustomConfigDir }}:/usr/local/apache2/conf/custom:ro"
       {{ end }}
     networks:
       - govard-net
@@ -57,6 +63,9 @@ services:
       - .:{{ .WorkDir }}
       {{ if .ApacheConfigDir }}
       - "{{ .ApacheConfigDir }}:/usr/local/apache2/conf"
+      {{ end }}
+      {{ if .ApacheCustomConfigDir }}
+      - "{{ .ApacheCustomConfigDir }}:/usr/local/apache2/conf/custom:ro"
       {{ end }}
     networks:
       - govard-net

--- a/internal/blueprints/files/support/apache/httpd.conf
+++ b/internal/blueprints/files/support/apache/httpd.conf
@@ -71,4 +71,5 @@ CustomLog /proc/self/fd/1 combined
             SetHandler "proxy:fcgi://php:9000"
         </Else>
     </FilesMatch>
+    @CUSTOM_INCLUDE@
 </VirtualHost>

--- a/internal/blueprints/files/support/nginx/templates/cakephp.conf
+++ b/internal/blueprints/files/support/nginx/templates/cakephp.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/default.conf
+++ b/internal/blueprints/files/support/nginx/templates/default.conf
@@ -34,4 +34,5 @@ server {
     location ~* (\.htaccess$|\.git) {
         deny all;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/drupal.conf
+++ b/internal/blueprints/files/support/nginx/templates/drupal.conf
@@ -31,4 +31,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/hybrid.conf
+++ b/internal/blueprints/files/support/nginx/templates/hybrid.conf
@@ -29,4 +29,5 @@ server {
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/laravel.conf
+++ b/internal/blueprints/files/support/nginx/templates/laravel.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/magento1.conf
+++ b/internal/blueprints/files/support/nginx/templates/magento1.conf
@@ -42,4 +42,5 @@ server {
     location ~* (\.htaccess$|\.git) {
         deny all;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/magento2.conf
+++ b/internal/blueprints/files/support/nginx/templates/magento2.conf
@@ -136,4 +136,5 @@ server {
     location ~* (\.php$|\.phtml$|\.htaccess$|\.git) {
         deny all;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/shopware.conf
+++ b/internal/blueprints/files/support/nginx/templates/shopware.conf
@@ -37,4 +37,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/symfony.conf
+++ b/internal/blueprints/files/support/nginx/templates/symfony.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/blueprints/files/support/nginx/templates/wordpress.conf
+++ b/internal/blueprints/files/support/nginx/templates/wordpress.conf
@@ -30,4 +30,5 @@ server {
         expires 30d;
         access_log off;
     }
+    ${NGINX_CUSTOM_INCLUDE}
 }

--- a/internal/conventions/paths.go
+++ b/internal/conventions/paths.go
@@ -14,9 +14,11 @@ const (
 	ProjectComposeOverridePath = ".govard/docker-compose.override.yml"
 
 	// Directories
-	ProjectExtensionsDir = ".govard"
-	ProjectCommandsDir   = ".govard/commands"
-	ProjectHooksDir      = ".govard/hooks"
+	ProjectExtensionsDir   = ".govard"
+	ProjectCommandsDir     = ".govard/commands"
+	ProjectHooksDir        = ".govard/hooks"
+	ProjectNginxCustomDir  = ".govard/nginx/custom"
+	ProjectApacheCustomDir = ".govard/apache/custom"
 
 	// Complex Paths
 	ProjectLocalConfigPath = ".govard/.govard.local.yml"

--- a/internal/engine/extensions.go
+++ b/internal/engine/extensions.go
@@ -16,6 +16,8 @@ const (
 	ProjectHooksDir            = conventions.ProjectHooksDir
 	ProjectLocalConfigPath     = conventions.ProjectLocalConfigPath
 	ProjectComposeOverridePath = conventions.ProjectComposeOverridePath
+	ProjectNginxCustomDir      = conventions.ProjectNginxCustomDir
+	ProjectApacheCustomDir     = conventions.ProjectApacheCustomDir
 	GlobalCommandsDirEnvVar    = "GOVARD_GLOBAL_COMMANDS_DIR"
 )
 

--- a/internal/engine/render.go
+++ b/internal/engine/render.go
@@ -35,10 +35,12 @@ type RenderData struct {
 	NGINXTemplate          string
 	NginxConfigPath        string
 	NginxMageRunMapPath    string
+	NginxCustomConfigDir   string
 	ApacheDocumentRoot     string
 	ApacheConfigDir        string
 	ApacheHTTPDConfigPath  string
 	ApacheMageRunMapPath   string
+	ApacheCustomConfigDir  string
 	DatabaseName           string
 	ImageRepository        string
 	XdebugSessionPattern   string
@@ -180,6 +182,37 @@ func projectComposeOverrideFingerprint(root string) (string, error) {
 
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+func projectCustomConfigDirFingerprint(dirPath string) (string, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	hasher := sha256.New()
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(dirPath, name))
+		if err != nil {
+			return "", err
+		}
+		hasher.Write([]byte(name))
+		hasher.Write([]byte{0})
+		hasher.Write(data)
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 func renderEnvironmentFingerprint() string {
@@ -325,6 +358,14 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 	if err != nil {
 		return fmt.Errorf("fingerprint compose override: %w", err)
 	}
+	nginxCustomFingerprint, err := projectCustomConfigDirFingerprint(filepath.Join(root, ProjectNginxCustomDir))
+	if err != nil {
+		return fmt.Errorf("fingerprint nginx custom config dir: %w", err)
+	}
+	apacheCustomFingerprint, err := projectCustomConfigDirFingerprint(filepath.Join(root, ProjectApacheCustomDir))
+	if err != nil {
+		return fmt.Errorf("fingerprint apache custom config dir: %w", err)
+	}
 	envFingerprint := renderEnvironmentFingerprint()
 	packageManager := ResolveNodePackageManager(root)
 	runtimeDomainHosts := knownProjectRuntimeHostDomains(root, config)
@@ -335,7 +376,7 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 	hashPath := outputPath + ".hash"
 
 	hashData, _ := json.Marshal(config)
-	hashSum := sha256.Sum256(append(hashData, []byte(profile+BlueprintVersion+blueprintFingerprint+overrideFingerprint+envFingerprint+packageManager+runtimeDomainHostsFingerprint+govardRootCAPath)...))
+	hashSum := sha256.Sum256(append(hashData, []byte(profile+BlueprintVersion+blueprintFingerprint+overrideFingerprint+nginxCustomFingerprint+apacheCustomFingerprint+envFingerprint+packageManager+runtimeDomainHostsFingerprint+govardRootCAPath)...))
 	currentHash := hex.EncodeToString(hashSum[:])
 
 	if existingHash, err := os.ReadFile(hashPath); err == nil && string(existingHash) == currentHash {
@@ -381,6 +422,16 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 		renderData.NGINXPublic = config.Stack.WebRoot
 	}
 	renderData.ApacheDocumentRoot = buildContainerDocumentRoot(renderData.NGINXPublic)
+
+	// Any real os.Stat error here (as opposed to "not exist") would already have
+	// surfaced from projectCustomConfigDirFingerprint above, so treating every
+	// non-nil error as "directory absent" is safe only in that context.
+	if info, err := os.Stat(filepath.Join(root, ProjectNginxCustomDir)); err == nil && info.IsDir() {
+		renderData.NginxCustomConfigDir = filepath.Join(root, ProjectNginxCustomDir)
+	}
+	if info, err := os.Stat(filepath.Join(root, ProjectApacheCustomDir)); err == nil && info.IsDir() {
+		renderData.ApacheCustomConfigDir = filepath.Join(root, ProjectApacheCustomDir)
+	}
 
 	if nginxMapPath, apacheMapPath, err := prepareMagentoRunMappingAssets(config); err != nil {
 		return fmt.Errorf("failed to prepare Magento run mapping assets: %w", err)

--- a/internal/engine/web_server_assets.go
+++ b/internal/engine/web_server_assets.go
@@ -63,10 +63,16 @@ func prepareNginxConfigAsset(blueprintsFS fs.FS, data RenderData, hybrid bool) (
 		return "", fmt.Errorf("read nginx support template %s: %w", templatePath, err)
 	}
 
+	nginxCustomInclude := ""
+	if strings.TrimSpace(data.NginxCustomConfigDir) != "" {
+		nginxCustomInclude = "include /etc/nginx/custom/*.conf;"
+	}
+
 	rendered := strings.NewReplacer(
 		"${NGINX_PUBLIC}", data.NGINXPublic,
 		"${XDEBUG_SESSION_PATTERN}", data.XdebugSessionPattern,
 		"${CONVENTIONS_WORK_DIR}", conventions.DefaultWorkDir,
+		"${NGINX_CUSTOM_INCLUDE}", nginxCustomInclude,
 	).Replace(string(content))
 
 	destPath := filepath.Join(GovardHomeDir(), "nginx", data.Config.ProjectName, "default.conf")
@@ -90,10 +96,16 @@ func prepareApacheHTTPDConfigAsset(blueprintsFS fs.FS, data RenderData) (string,
 		return "", fmt.Errorf("read apache support template %s: %w", templatePath, err)
 	}
 
+	apacheCustomInclude := ""
+	if strings.TrimSpace(data.ApacheCustomConfigDir) != "" {
+		apacheCustomInclude = "IncludeOptional conf/custom/*.conf"
+	}
+
 	rendered := strings.NewReplacer(
 		"@DOCROOT@", data.ApacheDocumentRoot,
 		"@XDEBUG_SESSION@", data.XdebugSessionPattern,
 		"@CONVENTIONS_WORK_DIR@", conventions.DefaultWorkDir,
+		"@CUSTOM_INCLUDE@", apacheCustomInclude,
 	).Replace(string(content))
 
 	destPath := filepath.Join(GovardHomeDir(), "apache", data.Config.ProjectName, "httpd.conf")

--- a/tests/blueprint_workflow_test.go
+++ b/tests/blueprint_workflow_test.go
@@ -233,6 +233,124 @@ func TestRenderBlueprintReRendersWhenProjectComposeOverrideChanges(t *testing.T)
 	}
 }
 
+func TestRenderBlueprintReRendersWhenNginxCustomConfigDirChanges(t *testing.T) {
+	tempDir := t.TempDir()
+	setTestGovardHome(t, tempDir)
+
+	_, filename, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(filename), "..")
+	blueprintsDir := filepath.Join(projectRoot, "internal", "blueprints", "files")
+
+	destBlueprintsDir := filepath.Join(tempDir, "blueprints")
+	if err := copyDir(blueprintsDir, destBlueprintsDir); err != nil {
+		t.Fatalf("Failed to copy blueprints: %v", err)
+	}
+
+	config := engine.Config{
+		ProjectName: "sample-project",
+		Framework:   "custom",
+		Domain:      "sample-project.test",
+		Stack: engine.Stack{
+			PHPVersion: "8.4",
+			Services: engine.Services{
+				WebServer: "nginx",
+				Search:    "none",
+				Cache:     "none",
+				Queue:     "none",
+			},
+		},
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("first render failed: %v", err)
+	}
+
+	hashPath := engine.ComposeFilePath(tempDir, config.ProjectName) + ".hash"
+	beforeHash, err := os.ReadFile(hashPath)
+	if err != nil {
+		t.Fatalf("read first hash: %v", err)
+	}
+
+	customDir := filepath.Join(tempDir, engine.ProjectNginxCustomDir)
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
+		t.Fatalf("create nginx custom dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(customDir, "extra.conf"), []byte("location /extra { return 200; }\n"), 0o644); err != nil {
+		t.Fatalf("write nginx custom snippet: %v", err)
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("second render failed: %v", err)
+	}
+
+	afterHash, err := os.ReadFile(hashPath)
+	if err != nil {
+		t.Fatalf("read second hash: %v", err)
+	}
+	if string(beforeHash) == string(afterHash) {
+		t.Fatalf("expected render hash to change after adding .govard/nginx/custom snippet, got same hash: %s", string(afterHash))
+	}
+}
+
+func TestRenderBlueprintReRendersWhenApacheCustomConfigDirChanges(t *testing.T) {
+	tempDir := t.TempDir()
+	setTestGovardHome(t, tempDir)
+
+	_, filename, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(filename), "..")
+	blueprintsDir := filepath.Join(projectRoot, "internal", "blueprints", "files")
+
+	destBlueprintsDir := filepath.Join(tempDir, "blueprints")
+	if err := copyDir(blueprintsDir, destBlueprintsDir); err != nil {
+		t.Fatalf("Failed to copy blueprints: %v", err)
+	}
+
+	config := engine.Config{
+		ProjectName: "sample-project",
+		Framework:   "custom",
+		Domain:      "sample-project.test",
+		Stack: engine.Stack{
+			PHPVersion: "8.4",
+			Services: engine.Services{
+				WebServer: "apache",
+				Search:    "none",
+				Cache:     "none",
+				Queue:     "none",
+			},
+		},
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("first render failed: %v", err)
+	}
+
+	hashPath := engine.ComposeFilePath(tempDir, config.ProjectName) + ".hash"
+	beforeHash, err := os.ReadFile(hashPath)
+	if err != nil {
+		t.Fatalf("read first hash: %v", err)
+	}
+
+	customDir := filepath.Join(tempDir, engine.ProjectApacheCustomDir)
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
+		t.Fatalf("create apache custom dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(customDir, "extra.conf"), []byte("Alias /extra /var/www/html/extra\n"), 0o644); err != nil {
+		t.Fatalf("write apache custom snippet: %v", err)
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("second render failed: %v", err)
+	}
+
+	afterHash, err := os.ReadFile(hashPath)
+	if err != nil {
+		t.Fatalf("read second hash: %v", err)
+	}
+	if string(beforeHash) == string(afterHash) {
+		t.Fatalf("expected render hash to change after adding .govard/apache/custom snippet, got same hash: %s", string(afterHash))
+	}
+}
+
 func TestRenderBlueprintReRendersWhenPackageManagerSignalChanges(t *testing.T) {
 	tempDir := t.TempDir()
 	setTestGovardHome(t, tempDir)
@@ -344,5 +462,214 @@ func TestRenderBlueprintReRendersWhenSSHAuthSockChanges(t *testing.T) {
 	}
 	if strings.Contains(string(after), "/tmp/ssh-old.sock:/ssh-agent") {
 		t.Fatalf("expected old SSH_AUTH_SOCK mount to be replaced, got:\n%s", string(after))
+	}
+}
+
+func TestRenderBlueprintIncludesNginxCustomConfigDir(t *testing.T) {
+	tempDir := t.TempDir()
+	setTestGovardHome(t, tempDir)
+
+	_, filename, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(filename), "..")
+	blueprintsDir := filepath.Join(projectRoot, "internal", "blueprints", "files")
+
+	destBlueprintsDir := filepath.Join(tempDir, "blueprints")
+	if err := copyDir(blueprintsDir, destBlueprintsDir); err != nil {
+		t.Fatalf("Failed to copy blueprints: %v", err)
+	}
+
+	config := engine.Config{
+		ProjectName: "sample-project",
+		Framework:   "custom",
+		Domain:      "sample-project.test",
+		Stack: engine.Stack{
+			PHPVersion: "8.4",
+			Services: engine.Services{
+				WebServer: "nginx",
+				Search:    "none",
+				Cache:     "none",
+				Queue:     "none",
+			},
+		},
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("first render failed: %v", err)
+	}
+
+	nginxConfPath := filepath.Join(engine.GovardHomeDir(), "nginx", config.ProjectName, "default.conf")
+	before, err := os.ReadFile(nginxConfPath)
+	if err != nil {
+		t.Fatalf("read first nginx conf: %v", err)
+	}
+	if strings.Contains(string(before), "/etc/nginx/custom") {
+		t.Fatalf("expected no custom include before .govard/nginx/custom exists, got:\n%s", string(before))
+	}
+
+	composePath := engine.ComposeFilePath(tempDir, config.ProjectName)
+	beforeCompose, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("read first compose file: %v", err)
+	}
+	if strings.Contains(string(beforeCompose), "/etc/nginx/custom") {
+		t.Fatalf("expected no custom volume before .govard/nginx/custom exists, got:\n%s", string(beforeCompose))
+	}
+
+	customDir := filepath.Join(tempDir, engine.ProjectNginxCustomDir)
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
+		t.Fatalf("create nginx custom dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(customDir, "extra.conf"), []byte("location /extra { return 200; }\n"), 0o644); err != nil {
+		t.Fatalf("write nginx custom snippet: %v", err)
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("second render failed: %v", err)
+	}
+
+	after, err := os.ReadFile(nginxConfPath)
+	if err != nil {
+		t.Fatalf("read second nginx conf: %v", err)
+	}
+	if !strings.Contains(string(after), "include /etc/nginx/custom/*.conf;") {
+		t.Fatalf("expected nginx conf to include custom directory, got:\n%s", string(after))
+	}
+
+	afterCompose, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("read second compose file: %v", err)
+	}
+	if !strings.Contains(string(afterCompose), customDir+":/etc/nginx/custom:ro") {
+		t.Fatalf("expected compose output to mount nginx custom config dir, got:\n%s", string(afterCompose))
+	}
+}
+
+func TestRenderBlueprintIncludesApacheCustomConfigDir(t *testing.T) {
+	tempDir := t.TempDir()
+	setTestGovardHome(t, tempDir)
+
+	_, filename, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(filename), "..")
+	blueprintsDir := filepath.Join(projectRoot, "internal", "blueprints", "files")
+
+	destBlueprintsDir := filepath.Join(tempDir, "blueprints")
+	if err := copyDir(blueprintsDir, destBlueprintsDir); err != nil {
+		t.Fatalf("Failed to copy blueprints: %v", err)
+	}
+
+	config := engine.Config{
+		ProjectName: "sample-project",
+		Framework:   "custom",
+		Domain:      "sample-project.test",
+		Stack: engine.Stack{
+			PHPVersion: "8.4",
+			Services: engine.Services{
+				WebServer: "apache",
+				Search:    "none",
+				Cache:     "none",
+				Queue:     "none",
+			},
+		},
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("first render failed: %v", err)
+	}
+
+	httpdConfPath := filepath.Join(engine.GovardHomeDir(), "apache", config.ProjectName, "httpd.conf")
+	before, err := os.ReadFile(httpdConfPath)
+	if err != nil {
+		t.Fatalf("read first httpd.conf: %v", err)
+	}
+	if strings.Contains(string(before), "conf/custom") {
+		t.Fatalf("expected no custom include before .govard/apache/custom exists, got:\n%s", string(before))
+	}
+
+	customDir := filepath.Join(tempDir, engine.ProjectApacheCustomDir)
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
+		t.Fatalf("create apache custom dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(customDir, "extra.conf"), []byte("Alias /extra /var/www/html/extra\n"), 0o644); err != nil {
+		t.Fatalf("write apache custom snippet: %v", err)
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("second render failed: %v", err)
+	}
+
+	after, err := os.ReadFile(httpdConfPath)
+	if err != nil {
+		t.Fatalf("read second httpd.conf: %v", err)
+	}
+	if !strings.Contains(string(after), "IncludeOptional conf/custom/*.conf") {
+		t.Fatalf("expected httpd.conf to include custom directory, got:\n%s", string(after))
+	}
+
+	composePath := engine.ComposeFilePath(tempDir, config.ProjectName)
+	afterCompose, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("read compose file: %v", err)
+	}
+	if !strings.Contains(string(afterCompose), customDir+":/usr/local/apache2/conf/custom:ro") {
+		t.Fatalf("expected compose output to mount apache custom config dir, got:\n%s", string(afterCompose))
+	}
+}
+
+func TestRenderBlueprintIncludesApacheCustomConfigDirInHybridMode(t *testing.T) {
+	tempDir := t.TempDir()
+	setTestGovardHome(t, tempDir)
+
+	_, filename, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(filename), "..")
+	blueprintsDir := filepath.Join(projectRoot, "internal", "blueprints", "files")
+
+	destBlueprintsDir := filepath.Join(tempDir, "blueprints")
+	if err := copyDir(blueprintsDir, destBlueprintsDir); err != nil {
+		t.Fatalf("Failed to copy blueprints: %v", err)
+	}
+
+	config := engine.Config{
+		ProjectName: "sample-project",
+		Framework:   "custom",
+		Domain:      "sample-project.test",
+		Stack: engine.Stack{
+			PHPVersion: "8.4",
+			Services: engine.Services{
+				WebServer: "hybrid",
+				Search:    "none",
+				Cache:     "none",
+				Queue:     "none",
+			},
+		},
+	}
+
+	customDir := filepath.Join(tempDir, engine.ProjectApacheCustomDir)
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
+		t.Fatalf("create apache custom dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(customDir, "extra.conf"), []byte("Alias /extra /var/www/html/extra\n"), 0o644); err != nil {
+		t.Fatalf("write apache custom snippet: %v", err)
+	}
+
+	if err := engine.RenderBlueprint(tempDir, config); err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	httpdConfPath := filepath.Join(engine.GovardHomeDir(), "apache", config.ProjectName, "httpd.conf")
+	rendered, err := os.ReadFile(httpdConfPath)
+	if err != nil {
+		t.Fatalf("read httpd.conf: %v", err)
+	}
+	if !strings.Contains(string(rendered), "IncludeOptional conf/custom/*.conf") {
+		t.Fatalf("expected httpd.conf to include custom directory in hybrid mode, got:\n%s", string(rendered))
+	}
+
+	composePath := engine.ComposeFilePath(tempDir, config.ProjectName)
+	renderedCompose, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("read compose file: %v", err)
+	}
+	if !strings.Contains(string(renderedCompose), customDir+":/usr/local/apache2/conf/custom:ro") {
+		t.Fatalf("expected hybrid apache service to mount apache custom config dir, got:\n%s", string(renderedCompose))
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a project-scoped way to extend the rendered nginx/Apache web server config without replacing the whole file: drop `.conf` snippets into `.govard/nginx/custom/` (nginx syntax) or `.govard/apache/custom/` (Apache syntax).
- Govard auto-mounts each directory read-only into the relevant container and includes it (`include`/`IncludeOptional`) only when present — zero behavior change for existing projects.
- Works across all 10 nginx framework templates plus Apache (pure-Apache and hybrid mode).
- Adding/editing/removing snippet files is fingerprinted into Govard's render hash, so `govard env up` auto-re-renders on the next run.
- Fixes a docs/build-parity gap discovered along the way: `docker/nginx/etc/templates/*.conf` and `docker/apache/etc/httpd.conf` must stay byte-identical to the blueprint templates (enforced by pre-existing tests) — both mirrors are kept in sync.

Design doc: `docs/superpowers/specs/2026-07-16-nginx-apache-custom-config-extension-design.md` (local, gitignored)
Implementation plan: `docs/superpowers/plans/2026-07-16-nginx-apache-custom-config-extension.md` (local, gitignored)

## Test plan

- [x] `make test` (lint + fmt-check + vet + unit tests) passes
- [x] `gofmt -s -l .` shows no drift
- [x] Each of the 5 implementation tasks passed an individual spec-compliance + code-quality review
- [x] Final whole-branch review: Ready to merge (no Critical/Important findings)
- [x] Manually validated end-to-end against a real Magento 1 project for all three `web_server` modes:
  - `nginx`: custom `location ^~ /api/rest` rewrite via `.govard/nginx/custom/`, verified request reaches Magento's REST layer
  - `apache`: equivalent `RewriteRule` via `.govard/apache/custom/`, same verification
  - `hybrid`: both `web` (nginx) and `apache` containers independently mount and include their respective custom dirs; verified an nginx-only intercept route and the Apache-side rewrite (proxied through nginx) both work
  - Verified editing a snippet's content triggers re-render (hash changes) and takes effect after a reload, without requiring any container recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)