### PR TITLE
fix: make db sync/import progress bar accurate and complete

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -435,22 +435,176 @@ func resolveDBImportReader(options dbCommandOptions) (io.Reader, io.Closer, int6
 	return os.Stdin, nil, 0, nil
 }
 
+// reportStreamShortfall prints a one-line note when the stream finished with
+// fewer bytes than the pre-transfer estimate (see GetDatabaseSize) predicted.
+// Without this, a bar that legitimately finishes below 100% (because the
+// estimate overshot reality, not because anything failed) reads as "stuck" or
+// "incomplete" - this makes clear the transfer did complete.
+//
+// This intentionally does NOT take the caller's stdout io.Writer: that writer
+// is also wired to importCmd.Stdout, and when it isn't a plain *os.File,
+// exec.Cmd spawns its own background goroutine to pump the child process's
+// output into it - writing here too would race against that goroutine on the
+// same io.Writer. Routing through pterm's own default output avoids that
+// shared-writer hazard entirely and matches how every other status message
+// in this file is printed (pterm.Success/Warning without a custom writer).
+func reportStreamShortfall(bytesRead int64, totalSize int64) {
+	if totalSize <= 0 || bytesRead >= totalSize {
+		return
+	}
+	pterm.Info.Printf(
+		"Stream complete: transferred %s (pre-sync estimate was %s - estimates are approximate).\n",
+		units.HumanSize(float64(bytesRead)), units.HumanSize(float64(totalSize)),
+	)
+}
+
+// progressThroughputSampleInterval throttles how often the transfer rate is
+// recomputed, so the displayed speed is a stable rolling figure rather than a
+// noisy per-chunk instantaneous value.
+const progressThroughputSampleInterval = 500 * time.Millisecond
+
+// progressLabel builds the static part of the progress title: the estimated
+// total is shown once as context, not as a continuously-updating "current/
+// total" pair - GetDatabaseSize's estimate can be quite a bit off from the
+// real stream size, so refreshing "current" against it on every read tends
+// to look more precise (and more suspicious when it's wrong) than it is.
+func progressLabel(base string, totalSize int64) string {
+	return fmt.Sprintf("%s (~%s estimated)", base, units.HumanSize(float64(totalSize)))
+}
+
 type dbProgressReader struct {
 	reader io.Reader
 	bar    *pterm.ProgressbarPrinter
 	total  int64
 	label  string
+
+	// bytesRead is this reader's own authoritative running count. It is
+	// deliberately NOT the same as bar.Current: pterm's ProgressbarPrinter.Add
+	// snaps Total=Current and permanently deactivates the bar (IsActive=false,
+	// all further UpdateTitle calls become no-ops) the instant Current reaches
+	// Total (pterm v0.12.83). Since total is only an estimate, real bytes can
+	// exceed it - feeding bar.Add(n) directly would then freeze the whole
+	// display (byte count, throughput, ETA) while data keeps flowing silently
+	// in the background. Tracking bytesRead separately keeps the display
+	// alive and growing no matter how far past the estimate the real transfer
+	// goes; see advanceBar for how bar.Current is kept just shy of bar.Total.
+	bytesRead int64
+
+	// startedAt drives our own elapsed-time display. pterm's built-in
+	// ShowElapsedTime is deliberately disabled on bars used here (see
+	// renderFinalizeOnBar's doc): it runs its own background rerender
+	// goroutine that would race against updates made from a different
+	// goroutine once the SAME bar stays alive into the (separately
+	// goroutine-driven) finalize phase.
+	startedAt time.Time
+
+	lastSampleAt time.Time
+	lastSampleN  int64
+	lastSuffix   string
 }
 
 func (r *dbProgressReader) Read(p []byte) (n int, err error) {
 	n, err = r.reader.Read(p)
 	if n > 0 && r.bar != nil {
-		r.bar.Add(n)
-		current := float64(r.bar.Current)
-		total := float64(r.total)
-		r.bar.UpdateTitle(fmt.Sprintf("%s [%s/%s]", r.label, units.HumanSize(current), units.HumanSize(total)))
+		if r.startedAt.IsZero() {
+			r.startedAt = time.Now()
+		}
+		r.bytesRead += int64(n)
+		r.advanceBar(n)
+		r.updateThroughput()
+		pct := displayPercent(r.bytesRead, r.total)
+		elapsed := time.Since(r.startedAt).Round(time.Second)
+		r.bar.UpdateTitle(fmt.Sprintf("%s %d%%%s | %s", r.label, pct, r.lastSuffix, elapsed))
 	}
 	return n, err
+}
+
+// advanceBar feeds pterm's own bar (used only for the visual fill length; its
+// own percentage/count display are disabled via WithShowPercentage(false)/
+// WithShowCount(false)), capping the amount added so bar.Current never
+// reaches bar.Total - see the bytesRead field doc for why that matters.
+func (r *dbProgressReader) advanceBar(n int) {
+	if r.bar.Current+n >= r.bar.Total {
+		n = r.bar.Total - r.bar.Current - 1
+	}
+	if n > 0 {
+		r.bar.Add(n)
+	}
+}
+
+// displayPercent computes the percentage shown in the title, capped at 99 so
+// the bar never claims completion before the stream has actually ended (the
+// real "done" signal comes afterwards: the stream-complete note, then the
+// finalize spinner - not this number reaching 100).
+func displayPercent(current, total int64) int {
+	if total <= 0 {
+		return 0
+	}
+	pct := int(current * 100 / total)
+	if pct > 99 {
+		pct = 99
+	}
+	if pct < 0 {
+		pct = 0
+	}
+	return pct
+}
+
+// DisplayPercentForTest exposes displayPercent for tests.
+func DisplayPercentForTest(current, total int64) int {
+	return displayPercent(current, total)
+}
+
+// updateThroughput recomputes the transfer rate (and ETA) from the bytes read
+// since the previous sample, at most once per progressThroughputSampleInterval.
+// totalSize is only an estimate (see GetDatabaseSize), so a rate/ETA that's
+// clearly meaningless (no progress yet, or already past the estimate) is
+// hidden rather than shown as a nonsensical number.
+func (r *dbProgressReader) updateThroughput() {
+	now := time.Now()
+	if r.lastSampleAt.IsZero() {
+		r.lastSampleAt = now
+		r.lastSampleN = r.bytesRead
+		return
+	}
+
+	elapsed := now.Sub(r.lastSampleAt)
+	if elapsed < progressThroughputSampleInterval {
+		return
+	}
+
+	deltaBytes := r.bytesRead - r.lastSampleN
+	remaining := r.total - r.bytesRead
+	r.lastSampleAt = now
+	r.lastSampleN = r.bytesRead
+	r.lastSuffix = formatThroughputSuffix(deltaBytes, elapsed, remaining)
+}
+
+// formatThroughputSuffix renders the ", <rate>/s, ETA ~<duration>" suffix
+// appended to the progress title. Returns "" when there isn't enough signal
+// yet for a meaningful rate (no bytes since the last sample, non-positive
+// elapsed time) or the estimate has already been reached (remaining <= 0).
+func formatThroughputSuffix(deltaBytes int64, elapsed time.Duration, remaining int64) string {
+	if deltaBytes <= 0 || elapsed <= 0 {
+		return ""
+	}
+
+	rate := float64(deltaBytes) / elapsed.Seconds()
+	if rate <= 0 {
+		return ""
+	}
+
+	suffix := fmt.Sprintf(", %s/s", units.HumanSize(rate))
+	if remaining > 0 {
+		eta := time.Duration(float64(remaining) / rate * float64(time.Second)).Round(time.Second)
+		suffix += fmt.Sprintf(", ETA ~%s", eta)
+	}
+	return suffix
+}
+
+// FormatThroughputSuffixForTest exposes formatThroughputSuffix for tests.
+func FormatThroughputSuffixForTest(deltaBytes int64, elapsed time.Duration, remaining int64) string {
+	return formatThroughputSuffix(deltaBytes, elapsed, remaining)
 }
 
 func stdinIsTerminal() bool {
@@ -499,24 +653,30 @@ func buildDBDumpCommand(config engine.Config, options dbCommandOptions) (*exec.C
 	return remote.BuildSSHExecCommand(options.Environment, remoteCfg, true, dumpStr), "", nil
 }
 
-func buildDBImportCommand(config engine.Config, options dbCommandOptions) (*exec.Cmd, error) {
+// buildDBImportCommand also returns a finalizePoller for the resolved import
+// target, so callers can report the target database's growing size while
+// waiting for the import to finish committing.
+func buildDBImportCommand(config engine.Config, options dbCommandOptions) (*exec.Cmd, *finalizePoller, error) {
 	if options.Environment == "local" {
 		containerName := dbContainerName(config)
 		if err := ensureLocalDBRunning(containerName); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return buildLocalDBImportCommand(containerName, resolveLocalDBCredentials(config, containerName)), nil
+		credentials := resolveLocalDBCredentials(config, containerName)
+		poller := &finalizePoller{config: config, remoteName: "local", credentials: credentials, noNoise: options.NoNoise, noPII: options.NoPII}
+		return buildLocalDBImportCommand(containerName, credentials), poller, nil
 	}
 
 	remoteCfg, err := resolveDBRemote(config, options.Environment, true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	credentials, probeErr := resolveRemoteDBCredentials(config, options.Environment, remoteCfg)
 	if probeErr != nil {
 		pterm.Warning.Println(formatRemoteDBProbeWarning(options.Environment, probeErr))
 	}
-	return remote.BuildSSHExecCommand(options.Environment, remoteCfg, true, buildRemoteMySQLImportCommandString(credentials)), nil
+	poller := &finalizePoller{config: config, remoteName: options.Environment, remoteCfg: remoteCfg, credentials: credentials, noNoise: options.NoNoise, noPII: options.NoPII}
+	return remote.BuildSSHExecCommand(options.Environment, remoteCfg, true, buildRemoteMySQLImportCommandString(credentials)), poller, nil
 }
 
 func dbContainerName(config engine.Config) string {
@@ -589,11 +749,146 @@ func runDumpToWriter(dumpCmd *exec.Cmd, writer io.Writer, sanitize bool, stderr 
 	return waitErr
 }
 
-func RunImportFromReader(importCmd *exec.Cmd, reader io.Reader, sanitize bool, stdout io.Writer, stderr io.Writer) error {
-	return RunImportFromReaderWithProgress(importCmd, reader, 0, sanitize, stdout, stderr)
+// finalizePoller knows how to check the current size of the import's target
+// database, so waitForImportCompletion can show real signs of life while the
+// import process keeps running after all bytes have been streamed to it.
+type finalizePoller struct {
+	config      engine.Config
+	remoteName  string
+	remoteCfg   engine.RemoteConfig
+	credentials dbCredentials
+	noNoise     bool
+	noPII       bool
 }
 
-func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, totalSize int64, sanitize bool, stdout io.Writer, stderr io.Writer) error {
+func (p *finalizePoller) size() (int64, error) {
+	return GetDatabaseSize(p.config, p.remoteName, p.remoteCfg, p.credentials, p.noNoise, p.noPII)
+}
+
+var finalizePollInterval = 5 * time.Second
+
+// SetFinalizePollIntervalForTest overrides the finalize-phase poll interval for tests.
+func SetFinalizePollIntervalForTest(d time.Duration) func() {
+	previous := finalizePollInterval
+	finalizePollInterval = d
+	return func() {
+		finalizePollInterval = previous
+	}
+}
+
+// waitForImportCompletion blocks until importCmd has actually exited, keeping
+// bar's own visual fill/animation going in the meantime instead of replacing
+// it with a separate indicator. Streaming all bytes into the import process's
+// stdin (what bar tracked up to this point) only means the data has been
+// handed off - the process can keep running for a long time afterwards (e.g.
+// mysql committing a large transaction), so callers must not treat "bytes
+// copied" as "import done". bar only reaches (and visually fills to) 100%
+// once importCmd has actually exited successfully.
+// poll, when non-nil, is called periodically to report the target database's
+// growing size while the wait is in progress; pass nil to disable that.
+func waitForImportCompletion(bar *pterm.ProgressbarPrinter, label string, startedAt time.Time, importCmd *exec.Cmd, poll func() (int64, error)) error {
+	rendered := make(chan struct{})
+	done := make(chan error, 1)
+	go renderFinalizeOnBar(bar, label, startedAt, poll, done, rendered)
+
+	err := importCmd.Wait()
+	done <- err
+	<-rendered
+	return err
+}
+
+// WaitForImportCompletionForTest exposes waitForImportCompletion for tests.
+func WaitForImportCompletionForTest(bar *pterm.ProgressbarPrinter, label string, startedAt time.Time, importCmd *exec.Cmd, poll func() (int64, error)) error {
+	return waitForImportCompletion(bar, label, startedAt, importCmd, poll)
+}
+
+// renderFinalizeOnBar keeps updating bar - the SAME progress bar used during
+// the copy phase - while waiting for the import process to actually finish,
+// instead of stopping it and showing a disconnected spinner/message. Only at
+// genuine completion does bar's fill advance to 100%; on failure it's
+// stopped without reaching 100%. label is the STATIC part of the title (bar's
+// copy-phase dbProgressReader has already overwritten bar.Title with the
+// last dynamic render, so it can't be recovered from bar itself).
+//
+// All mutation of bar happens in this one goroutine; the caller only sends a
+// single done signal and waits for rendered to close. This matters for the
+// same reason described for pterm.SpinnerPrinter elsewhere in this file:
+// pterm.ProgressbarPrinter also runs its own background rerender goroutine
+// when ShowElapsedTime is enabled, which would race against updates made
+// here from a second goroutine - callers must construct bar with
+// WithShowElapsedTime(false) (elapsed time is tracked and rendered manually
+// instead, via dbProgressReader/this function, both single-goroutine-owned).
+func renderFinalizeOnBar(bar *pterm.ProgressbarPrinter, label string, startedAt time.Time, poll func() (int64, error), done <-chan error, rendered chan<- struct{}) {
+	defer close(rendered)
+
+	if startedAt.IsZero() {
+		startedAt = time.Now()
+	}
+
+	statusText := "finalizing (waiting for database to commit)"
+	if poll != nil {
+		if size, err := poll(); err == nil {
+			statusText = fmt.Sprintf("finalizing, written so far: %s", units.HumanSize(float64(size)))
+		}
+	}
+	render := func() {
+		elapsed := time.Since(startedAt).Round(time.Second)
+		bar.UpdateTitle(fmt.Sprintf("%s - %s | %s", label, statusText, elapsed))
+	}
+	render()
+
+	frameTicker := time.NewTicker(pterm.DefaultSpinner.Delay)
+	defer frameTicker.Stop()
+
+	var pollC <-chan time.Time
+	if poll != nil {
+		pollTicker := time.NewTicker(finalizePollInterval)
+		defer pollTicker.Stop()
+		pollC = pollTicker.C
+	}
+
+	for {
+		select {
+		case err := <-done:
+			elapsed := time.Since(startedAt).Round(time.Second)
+			if err != nil {
+				bar.UpdateTitle(fmt.Sprintf("%s - failed while finalizing | %s", label, elapsed))
+				_, _ = bar.Stop()
+				return
+			}
+			// Set the "100%" text ourselves - bar.Add below only advances
+			// pterm's own fill/stop bookkeeping, it doesn't touch the title
+			// text (ShowPercentage is disabled; our percentage is always
+			// manually embedded in the title, so it must be updated here too).
+			bar.UpdateTitle(fmt.Sprintf("%s - 100%% - Import finalized | %s", label, elapsed))
+			if remaining := bar.Total - bar.Current; remaining > 0 {
+				// Add()ing the exact remainder brings Current to Total,
+				// which pterm renders as a fully-filled bar and stops on its
+				// own - the real completion signal this bar has been
+				// deliberately capped short of until now (see advanceBar).
+				bar.Add(remaining)
+			} else {
+				_, _ = bar.Stop()
+			}
+			return
+		case <-frameTicker.C:
+			render()
+		case <-pollC:
+			if size, err := poll(); err == nil {
+				statusText = fmt.Sprintf("finalizing, written so far: %s", units.HumanSize(float64(size)))
+			}
+			render()
+		}
+	}
+}
+
+func RunImportFromReader(importCmd *exec.Cmd, reader io.Reader, sanitize bool, stdout io.Writer, stderr io.Writer) error {
+	return RunImportFromReaderWithProgress(importCmd, reader, 0, sanitize, stdout, stderr, nil)
+}
+
+// poll, when non-nil, is called periodically while waiting for importCmd to
+// finish, to report the target database's growing size.
+func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, totalSize int64, sanitize bool, stdout io.Writer, stderr io.Writer, poll func() (int64, error)) error {
 	stdin, err := importCmd.StdinPipe()
 	if err != nil {
 		return err
@@ -613,6 +908,8 @@ func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, tota
 
 	// Progress tracking and Gzip detection logic
 	var bar *pterm.ProgressbarPrinter
+	var progressReader *dbProgressReader
+	var progressLabelText string
 	var finalReader io.Reader
 
 	// Heuristic: If we are reading a compressed source and totalSize equals the source size,
@@ -628,14 +925,18 @@ func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, tota
 	}
 
 	if totalSize > 0 {
+		progressLabelText = progressLabel("Importing DB", totalSize)
 		bar, _ = pterm.DefaultProgressbar.WithTotal(int(totalSize)).
-			WithTitle(fmt.Sprintf("Importing DB [0/%s]", units.HumanSize(float64(totalSize)))).
+			WithTitle(progressLabelText).
 			WithShowCount(false).
+			WithShowPercentage(false).
+			WithShowElapsedTime(false).
 			Start()
 
 		if trackCompressed {
 			// track progress on the COMPRESSED source (local .sql.gz file)
-			readerWithPeek = &dbProgressReader{reader: readerWithPeek, bar: bar, total: totalSize, label: "Importing DB"}
+			progressReader = &dbProgressReader{reader: readerWithPeek, bar: bar, total: totalSize, label: progressLabelText}
+			readerWithPeek = progressReader
 		}
 	}
 
@@ -652,7 +953,8 @@ func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, tota
 
 	if totalSize > 0 && !trackCompressed {
 		// Track against uncompressed stream (remote sync case)
-		finalReader = &dbProgressReader{reader: finalReader, bar: bar, total: totalSize, label: "Importing DB"}
+		progressReader = &dbProgressReader{reader: finalReader, bar: bar, total: totalSize, label: progressLabelText}
+		finalReader = progressReader
 	}
 
 	if err := importCmd.Start(); err != nil {
@@ -677,12 +979,24 @@ func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, tota
 	}
 
 	if bar != nil {
-		bar.Add(int(totalSize) - bar.Current)
-		_, _ = bar.Stop()
+		// Do not stop bar here: totalSize is only an estimate (see
+		// GetDatabaseSize), so the real byte count read from the stream may
+		// land short of it, and the import process (e.g. mysql committing a
+		// large transaction) can keep running long after the stream ends.
+		// bar stays alive and visually fills to 100% only once
+		// waitForImportCompletion confirms the process actually finished.
+		reportStreamShortfall(progressReader.bytesRead, totalSize)
 	}
 
 	closeErr := stdin.Close()
-	waitErr := importCmd.Wait()
+
+	var waitErr error
+	if bar != nil {
+		waitErr = waitForImportCompletion(bar, progressLabelText, progressReader.startedAt, importCmd, poll)
+	} else {
+		waitErr = importCmd.Wait()
+	}
+
 	if copyErr != nil {
 		return copyErr
 	}
@@ -693,10 +1007,12 @@ func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, tota
 }
 
 func RunDumpToImport(dumpCmd *exec.Cmd, importCmd *exec.Cmd, sanitize bool, stdout io.Writer, stderr io.Writer) error {
-	return RunDumpToImportWithProgress(dumpCmd, importCmd, 0, sanitize, stdout, stderr)
+	return RunDumpToImportWithProgress(dumpCmd, importCmd, 0, sanitize, stdout, stderr, nil)
 }
 
-func RunDumpToImportWithProgress(dumpCmd *exec.Cmd, importCmd *exec.Cmd, totalSize int64, sanitize bool, stdout io.Writer, stderr io.Writer) error {
+// poll, when non-nil, is called periodically while waiting for importCmd to
+// finish, to report the target database's growing size.
+func RunDumpToImportWithProgress(dumpCmd *exec.Cmd, importCmd *exec.Cmd, totalSize int64, sanitize bool, stdout io.Writer, stderr io.Writer, poll func() (int64, error)) error {
 	dumpStdout, err := dumpCmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -728,6 +1044,8 @@ func RunDumpToImportWithProgress(dumpCmd *exec.Cmd, importCmd *exec.Cmd, totalSi
 	importSuffix := "\nCOMMIT; SET FOREIGN_KEY_CHECKS=1; SET UNIQUE_CHECKS=1; SET AUTOCOMMIT=1;\n"
 
 	var bar *pterm.ProgressbarPrinter
+	var progressReader *dbProgressReader
+	var progressLabelText string
 	var reader io.Reader = dumpStdout
 	isGzip := false
 
@@ -748,15 +1066,19 @@ func RunDumpToImportWithProgress(dumpCmd *exec.Cmd, importCmd *exec.Cmd, totalSi
 
 	// Progress tracking logic
 	if totalSize > 0 {
+		progressLabelText = progressLabel("Syncing DB", totalSize)
 		bar, _ = pterm.DefaultProgressbar.WithTotal(int(totalSize)).
-			WithTitle(fmt.Sprintf("Syncing DB [0/%s]", units.HumanSize(float64(totalSize)))).
+			WithTitle(progressLabelText).
 			WithShowCount(false).
+			WithShowPercentage(false).
+			WithShowElapsedTime(false).
 			Start()
 
 		// In RunDumpToImport, the source is always a pipe from the remote dump command.
 		// If totalSize is provided here, it's always the logical/uncompressed size
 		// from GetDatabaseSize(), so we ALWAYS track uncompressed progress.
-		reader = &dbProgressReader{reader: reader, bar: bar, total: totalSize, label: "Syncing DB"}
+		progressReader = &dbProgressReader{reader: reader, bar: bar, total: totalSize, label: progressLabelText}
+		reader = progressReader
 	}
 
 	// Wrap the reader with performance-optimized session variables
@@ -774,13 +1096,24 @@ func RunDumpToImportWithProgress(dumpCmd *exec.Cmd, importCmd *exec.Cmd, totalSi
 	}
 
 	if bar != nil {
-		bar.Add(int(totalSize) - bar.Current)
-		_, _ = bar.Stop()
+		// Do not stop bar here: totalSize is only an estimate (see
+		// GetDatabaseSize), so the real byte count read from the stream may
+		// land short of it, and the import process (e.g. mysql committing a
+		// large transaction) can keep running long after the stream ends.
+		// bar stays alive and visually fills to 100% only once
+		// waitForImportCompletion confirms the process actually finished.
+		reportStreamShortfall(progressReader.bytesRead, totalSize)
 	}
 
 	closeErr := importStdin.Close()
 	dumpErr := dumpCmd.Wait()
-	importErr := importCmd.Wait()
+
+	var importErr error
+	if bar != nil {
+		importErr = waitForImportCompletion(bar, progressLabelText, progressReader.startedAt, importCmd, poll)
+	} else {
+		importErr = importCmd.Wait()
+	}
 
 	if copyErr != nil {
 		// If copy failed, check if it was due to a process termination
@@ -844,7 +1177,7 @@ func BuildDBDumpCommandForTest(config engine.Config, options DBCommandOptions) (
 
 // BuildDBImportCommandForTest exposes buildDBImportCommand args for tests in /tests.
 func BuildDBImportCommandForTest(config engine.Config, options DBCommandOptions) ([]string, error) {
-	command, err := buildDBImportCommand(config, options)
+	command, _, err := buildDBImportCommand(config, options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/db_import.go
+++ b/internal/cmd/db_import.go
@@ -42,6 +42,7 @@ func runStreamDBImport(cmd *cobra.Command, config engine.Config, options dbComma
 		pterm.Warning.Println(formatRemoteDBProbeWarning(options.Environment, probeErr))
 	}
 	localCredentials := resolveLocalDBCredentials(config, containerName)
+	localPoller := &finalizePoller{config: config, remoteName: "local", credentials: localCredentials, noNoise: options.NoNoise, noPII: options.NoPII}
 	if options.Drop {
 		if !options.AssumeYes {
 			if !stdinIsTerminal() {
@@ -91,7 +92,7 @@ func runStreamDBImport(cmd *cobra.Command, config engine.Config, options dbComma
 		}
 		defer fileReader.Close()
 
-		if err := RunImportFromReaderWithProgress(destinationImportCmd, fileReader, totalSize, false, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+		if err := RunImportFromReaderWithProgress(destinationImportCmd, fileReader, totalSize, false, cmd.OutOrStdout(), cmd.ErrOrStderr(), localPoller.size); err != nil {
 			return fmt.Errorf("stream-db local import step failed: %w", err)
 		}
 
@@ -99,7 +100,7 @@ func runStreamDBImport(cmd *cobra.Command, config engine.Config, options dbComma
 		return nil
 	}
 
-	if err := RunDumpToImportWithProgress(sourceDumpCmd, destinationImportCmd, totalSize, sanitizeStreamDump, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+	if err := RunDumpToImportWithProgress(sourceDumpCmd, destinationImportCmd, totalSize, sanitizeStreamDump, cmd.OutOrStdout(), cmd.ErrOrStderr(), localPoller.size); err != nil {
 		return fmt.Errorf("stream-db import failed: %w", err)
 	}
 	pterm.Success.Printf("stream import completed from remote '%s' into local database.\n", options.Environment)
@@ -201,7 +202,7 @@ func runDirectDBImport(cmd *cobra.Command, config engine.Config, options dbComma
 		pterm.Success.Println("Database reset successful.")
 	}
 
-	importCommand, err := buildDBImportCommand(config, options)
+	importCommand, poller, err := buildDBImportCommand(config, options)
 	if err != nil {
 		return err
 	}
@@ -218,7 +219,7 @@ func runDirectDBImport(cmd *cobra.Command, config engine.Config, options dbComma
 		pterm.Description.Println("Tip: cat backup.sql | govard db import")
 	}
 
-	if err := RunImportFromReaderWithProgress(importCommand, reader, totalSize, false, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+	if err := RunImportFromReaderWithProgress(importCommand, reader, totalSize, false, cmd.OutOrStdout(), cmd.ErrOrStderr(), poller.size); err != nil {
 		return fmt.Errorf("db import failed: %w", err)
 	}
 	pterm.Success.Println("Database import completed.")

--- a/internal/cmd/sync_rsync.go
+++ b/internal/cmd/sync_rsync.go
@@ -92,7 +92,8 @@ func buildDatabaseSyncAction(config engine.Config, source SyncEndpoint, destinat
 
 			dumpCmd := remote.BuildSSHExecCommand(source.Name, source.RemoteCfg, true, dumpCmdStr)
 			importCmd := buildLocalDBImportCommand(localDBContainer, localCredentials)
-			return RunDumpToImportWithProgress(dumpCmd, importCmd, totalSize, true, os.Stdout, os.Stderr)
+			poller := &finalizePoller{config: config, remoteName: "local", credentials: localCredentials, noNoise: noNoise, noPII: noPII}
+			return RunDumpToImportWithProgress(dumpCmd, importCmd, totalSize, true, os.Stdout, os.Stderr, poller.size)
 		}, nil
 	case source.IsLocal && !destination.IsLocal:
 		remoteCredentials, probeErr := resolveRemoteDBCredentials(config, destination.Name, destination.RemoteCfg)
@@ -111,7 +112,8 @@ func buildDatabaseSyncAction(config engine.Config, source SyncEndpoint, destinat
 
 			dumpCmd := buildLocalDBDumpCommand(localDBContainer, localCredentials, noNoise, noPII, config.Framework)
 			importCmd := remote.BuildSSHExecCommand(destination.Name, destination.RemoteCfg, true, importCmdStr)
-			return RunDumpToImportWithProgress(dumpCmd, importCmd, totalSize, true, os.Stdout, os.Stderr)
+			poller := &finalizePoller{config: config, remoteName: destination.Name, remoteCfg: destination.RemoteCfg, credentials: remoteCredentials, noNoise: noNoise, noPII: noPII}
+			return RunDumpToImportWithProgress(dumpCmd, importCmd, totalSize, true, os.Stdout, os.Stderr, poller.size)
 		}, nil
 	default:
 		return "", nil, fmt.Errorf("database synchronization only supports transfers between local and remote environments")

--- a/tests/db_finalize_import_test.go
+++ b/tests/db_finalize_import_test.go
@@ -1,0 +1,146 @@
+package tests
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"govard/internal/cmd"
+
+	"github.com/pterm/pterm"
+)
+
+// newTestProgressBar builds a bar the same way production code does
+// (pterm.DefaultProgressbar...Start()), redirecting output to a captured
+// buffer, and returns a restore func to undo the writer override.
+func newTestProgressBar(t *testing.T, total int, title string) (*pterm.ProgressbarPrinter, *bytes.Buffer) {
+	t.Helper()
+	originalWriter := pterm.DefaultProgressbar.Writer
+	t.Cleanup(func() { pterm.DefaultProgressbar.Writer = originalWriter })
+
+	var captured bytes.Buffer
+	pterm.DefaultProgressbar.Writer = &captured
+
+	bar, _ := pterm.DefaultProgressbar.WithTotal(total).
+		WithTitle(title).
+		WithShowCount(false).
+		WithShowPercentage(false).
+		WithShowElapsedTime(false).
+		Start()
+	return bar, &captured
+}
+
+// TestWaitForImportCompletionShowsFinalizingIndicator reproduces the reported
+// bug: the progress bar reports 100% and disappears as soon as bytes have
+// been streamed into the import command's stdin, even though the import
+// process (e.g. mysql committing a large transaction) can keep running for
+// a long time afterwards with zero UI feedback. The fix must keep animating
+// the SAME bar with a "finalizing" indicator, and only mark 100% once the
+// import process has actually exited.
+func TestWaitForImportCompletionShowsFinalizingIndicator(t *testing.T) {
+	bar, out := newTestProgressBar(t, 100, "Importing DB (~1kB estimated)")
+
+	// Simulates an import command that has already consumed all its input
+	// (stdin already closed by the caller) but keeps doing work afterwards,
+	// analogous to mysql running its final COMMIT after all statements have
+	// been read from the pipe.
+	importCmd := exec.Command("sh", "-c", "sleep 0.2")
+	if err := importCmd.Start(); err != nil {
+		t.Fatalf("failed to start fake import command: %v", err)
+	}
+
+	start := time.Now()
+	err := cmd.WaitForImportCompletionForTest(bar, "Importing DB (~1kB estimated)", time.Time{}, importCmd, nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("expected to block until the import process actually exited, only waited %v", elapsed)
+	}
+	if !strings.Contains(out.String(), "finalizing") {
+		t.Fatalf("expected a finalizing indicator to be shown while waiting for import completion, got: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "100%") {
+		t.Fatalf("expected the true completion signal (100%%) once the import process has actually exited, got: %q", out.String())
+	}
+}
+
+func TestWaitForImportCompletionPropagatesFailure(t *testing.T) {
+	bar, out := newTestProgressBar(t, 100, "Importing DB (~1kB estimated)")
+
+	importCmd := exec.Command("sh", "-c", "exit 1")
+	if err := importCmd.Start(); err != nil {
+		t.Fatalf("failed to start fake import command: %v", err)
+	}
+
+	err := cmd.WaitForImportCompletionForTest(bar, "Importing DB (~1kB estimated)", time.Time{}, importCmd, nil)
+	if err == nil {
+		t.Fatal("expected an error when the import command exits non-zero")
+	}
+	if strings.Contains(out.String(), "100%") {
+		t.Fatalf("did not expect a 100%% completion signal when the import command failed, got: %q", out.String())
+	}
+}
+
+// TestWaitForImportCompletionPollsTargetSize reproduces the real-world
+// complaint that a multi-GB import can sit at "finalizing..." for tens of
+// minutes with zero indication it's still alive. When a poll func is
+// supplied, the bar's title must be updated with the polled size at least
+// once while waiting - a stub stands in for GetDatabaseSize so the test
+// stays hermetic (no Docker/mysql dependency).
+func TestWaitForImportCompletionPollsTargetSize(t *testing.T) {
+	restore := cmd.SetFinalizePollIntervalForTest(10 * time.Millisecond)
+	defer restore()
+
+	bar, out := newTestProgressBar(t, 100, "Importing DB (~1kB estimated)")
+
+	importCmd := exec.Command("sh", "-c", "sleep 0.2")
+	if err := importCmd.Start(); err != nil {
+		t.Fatalf("failed to start fake import command: %v", err)
+	}
+
+	polls := 0
+	poll := func() (int64, error) {
+		polls++
+		return int64(polls) * 1024 * 1024 * 1024, nil
+	}
+
+	if err := cmd.WaitForImportCompletionForTest(bar, "Importing DB (~1kB estimated)", time.Time{}, importCmd, poll); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if polls == 0 {
+		t.Fatal("expected the poll function to be called at least once while waiting")
+	}
+	if !strings.Contains(out.String(), "written so far") {
+		t.Fatalf("expected the bar to report the polled size, got: %q", out.String())
+	}
+}
+
+// TestWaitForImportCompletionPollErrorsAreIgnored ensures a transient poll
+// failure (e.g. the target briefly unreachable during a heavy commit) never
+// aborts the wait or surfaces as the operation's error.
+func TestWaitForImportCompletionPollErrorsAreIgnored(t *testing.T) {
+	restore := cmd.SetFinalizePollIntervalForTest(10 * time.Millisecond)
+	defer restore()
+
+	bar, _ := newTestProgressBar(t, 100, "Importing DB (~1kB estimated)")
+
+	importCmd := exec.Command("sh", "-c", "sleep 0.1")
+	if err := importCmd.Start(); err != nil {
+		t.Fatalf("failed to start fake import command: %v", err)
+	}
+
+	poll := func() (int64, error) {
+		return 0, errors.New("target briefly unreachable")
+	}
+
+	if err := cmd.WaitForImportCompletionForTest(bar, "Importing DB (~1kB estimated)", time.Time{}, importCmd, poll); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/tests/db_progress_overestimate_test.go
+++ b/tests/db_progress_overestimate_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"govard/internal/cmd"
+
+	"github.com/pterm/pterm"
+)
+
+// TestImportProgressDoesNotLieAboutCompletion reproduces a real-world case:
+// GetDatabaseSize() only estimates the dump size (SUM(data_length) from
+// information_schema), so the real, uncompressed dump stream can end up
+// noticeably smaller than that estimate. When the stream reaches EOF short
+// of the estimated total, the copy-phase percentage must not claim "100%" -
+// that would produce a frozen line like "Syncing DB [2.892GB/5.826GB] 100%"
+// where the visible byte count and the percentage contradict each other. The
+// bar is only allowed to reach 100% afterwards, once the import process has
+// actually finished (the "- 100% - Import finalized" text appended by
+// waitForImportCompletion) - so this only checks the copy-phase portion of
+// the output, i.e. everything before "finalizing".
+func TestImportProgressDoesNotLieAboutCompletion(t *testing.T) {
+	originalWriter := pterm.DefaultProgressbar.Writer
+	defer func() { pterm.DefaultProgressbar.Writer = originalWriter }()
+
+	var captured bytes.Buffer
+	pterm.DefaultProgressbar.Writer = &captured
+
+	actualData := strings.Repeat("x", 500)
+	estimatedTotal := int64(len(actualData) * 2) // estimate is double the real size
+
+	importCmd := exec.Command("sh", "-c", "cat > /dev/null")
+
+	if err := cmd.RunImportFromReaderWithProgress(importCmd, strings.NewReader(actualData), estimatedTotal, false, os.Stdout, os.Stderr, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := captured.String()
+	copyPhase, _, found := strings.Cut(output, "finalizing")
+	if !found {
+		t.Fatalf("expected the output to reach the finalizing phase, got: %q", output)
+	}
+	if strings.Contains(copyPhase, "100%") {
+		t.Fatalf("progress bar falsely reported 100%% during the copy phase after transferring only half of the estimated total; copy-phase output: %q", copyPhase)
+	}
+}
+
+// TestImportProgressReportsShortfallNote covers the follow-up UX issue: a bar
+// that legitimately stops below 100% (because the pre-sync estimate
+// overshot the real dump size) looks identical to a stalled/failed transfer
+// unless something explicitly says the stream did complete. A one-line note
+// should make that clear whenever the real byte count landed short of the
+// estimate.
+//
+// This note is deliberately NOT written through the importCmd.Stdout writer
+// (passed here as os.Stdout, a real *os.File): exec.Cmd can share a *os.File
+// with the child process directly, but a non-file io.Writer (e.g. a
+// bytes.Buffer) makes exec.Cmd spawn its own background copy goroutine,
+// which would race against a direct write from this test/production code on
+// the same writer. Capturing via pterm.SetDefaultOutput avoids that hazard.
+func TestImportProgressReportsShortfallNote(t *testing.T) {
+	originalWriter := pterm.DefaultProgressbar.Writer
+	defer func() { pterm.DefaultProgressbar.Writer = originalWriter }()
+	pterm.DefaultProgressbar.Writer = &bytes.Buffer{}
+
+	var captured bytes.Buffer
+	pterm.SetDefaultOutput(&captured)
+	defer pterm.SetDefaultOutput(os.Stdout)
+
+	actualData := strings.Repeat("x", 500)
+	estimatedTotal := int64(len(actualData) * 2)
+
+	importCmd := exec.Command("sh", "-c", "cat > /dev/null")
+
+	if err := cmd.RunImportFromReaderWithProgress(importCmd, strings.NewReader(actualData), estimatedTotal, false, os.Stdout, os.Stderr, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(captured.String(), "Stream complete") {
+		t.Fatalf("expected a note confirming the stream completed despite landing short of the estimate, got: %q", captured.String())
+	}
+}
+
+// TestImportProgressNoShortfallNoteWhenEstimateMatched ensures the note is
+// only shown when there actually was a shortfall - it shouldn't add noise to
+// the common case where the transfer reaches (or exceeds) the estimate.
+func TestImportProgressNoShortfallNoteWhenEstimateMatched(t *testing.T) {
+	originalWriter := pterm.DefaultProgressbar.Writer
+	defer func() { pterm.DefaultProgressbar.Writer = originalWriter }()
+	pterm.DefaultProgressbar.Writer = &bytes.Buffer{}
+
+	var captured bytes.Buffer
+	pterm.SetDefaultOutput(&captured)
+	defer pterm.SetDefaultOutput(os.Stdout)
+
+	actualData := strings.Repeat("x", 500)
+	estimatedTotal := int64(len(actualData)) // estimate matches reality exactly
+
+	importCmd := exec.Command("sh", "-c", "cat > /dev/null")
+
+	if err := cmd.RunImportFromReaderWithProgress(importCmd, strings.NewReader(actualData), estimatedTotal, false, os.Stdout, os.Stderr, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(captured.String(), "Stream complete") {
+		t.Fatalf("did not expect a shortfall note when the transfer matched the estimate, got: %q", captured.String())
+	}
+}

--- a/tests/db_progress_percent_test.go
+++ b/tests/db_progress_percent_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"govard/internal/cmd"
+
+	"github.com/pterm/pterm"
+)
+
+// TestDisplayPercentCapsBelow100UntilDone covers the core contract: the
+// percentage shown during the copy phase must never claim 100% - the real
+// "done" signal is the stream-complete note plus the finalize spinner
+// afterwards, not this number.
+func TestDisplayPercentCapsBelow100UntilDone(t *testing.T) {
+	cases := []struct {
+		name    string
+		current int64
+		total   int64
+		want    int
+	}{
+		{"under estimate", 50, 100, 50},
+		{"exactly at estimate", 100, 100, 99},
+		{"past estimate", 500, 100, 99},
+		{"zero total", 50, 0, 0},
+		{"zero current", 0, 100, 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := cmd.DisplayPercentForTest(c.current, c.total)
+			if got != c.want {
+				t.Fatalf("DisplayPercentForTest(%d, %d) = %d, want %d", c.current, c.total, got, c.want)
+			}
+			if got >= 100 {
+				t.Fatalf("DisplayPercentForTest(%d, %d) = %d, must never reach 100", c.current, c.total, got)
+			}
+		})
+	}
+}
+
+// TestImportProgressSurvivesUnderestimate reproduces the more serious bug
+// found while investigating this: pterm's ProgressbarPrinter.Add snaps
+// Total=Current and permanently deactivates the bar (all further UpdateTitle
+// calls become no-ops) the instant Current reaches Total. If the pre-sync
+// estimate undershoots the real stream size, that would freeze the entire
+// display - byte count, throughput, ETA - while a possibly large remainder
+// keeps copying silently in the background. The fix must keep the bar alive
+// and its title updating for the whole transfer, no matter how far past the
+// estimate it goes.
+func TestImportProgressSurvivesUnderestimate(t *testing.T) {
+	originalWriter := pterm.DefaultProgressbar.Writer
+	defer func() { pterm.DefaultProgressbar.Writer = originalWriter }()
+	var captured bytes.Buffer
+	pterm.DefaultProgressbar.Writer = &captured
+
+	// Real data is 5x the estimate.
+	actualData := strings.Repeat("x", 1000)
+	estimatedTotal := int64(200)
+
+	importCmd := exec.Command("sh", "-c", "cat > /dev/null")
+	if err := cmd.RunImportFromReaderWithProgress(importCmd, strings.NewReader(actualData), estimatedTotal, false, os.Stdout, os.Stderr, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := captured.String()
+	if strings.Contains(output, "500%") {
+		t.Fatalf("expected the percentage to never overshoot past the cap, got: %q", output)
+	}
+	copyPhase, _, found := strings.Cut(output, "finalizing")
+	if !found {
+		t.Fatalf("expected the output to reach the finalizing phase, got: %q", output)
+	}
+	if strings.Contains(copyPhase, "100%") {
+		t.Fatalf("expected the bar to never claim 100%% mid-copy when the estimate undershoots, copy-phase output: %q", copyPhase)
+	}
+	if output == "" {
+		t.Fatal("expected the bar to keep rendering for the entire transfer, got no output at all")
+	}
+}
+
+// TestImportProgressTitleOmitsByteCount ensures the title only shows the
+// estimate once (as static context) plus percentage/rate/ETA - not a
+// continuously-updating "current/total" byte pair, which read as more
+// precise than the underlying estimate actually is.
+func TestImportProgressTitleOmitsByteCount(t *testing.T) {
+	originalWriter := pterm.DefaultProgressbar.Writer
+	defer func() { pterm.DefaultProgressbar.Writer = originalWriter }()
+	var captured bytes.Buffer
+	pterm.DefaultProgressbar.Writer = &captured
+
+	actualData := strings.Repeat("x", 500)
+	estimatedTotal := int64(len(actualData))
+
+	importCmd := exec.Command("sh", "-c", "cat > /dev/null")
+	if err := cmd.RunImportFromReaderWithProgress(importCmd, strings.NewReader(actualData), estimatedTotal, false, os.Stdout, os.Stderr, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := captured.String()
+	if !strings.Contains(output, "estimated") {
+		t.Fatalf("expected the estimated total to be shown as static context, got: %q", output)
+	}
+	if strings.Contains(output, "/500B") || strings.Contains(output, "[0B") {
+		t.Fatalf("did not expect a current/total byte pair in the title, got: %q", output)
+	}
+}

--- a/tests/db_progress_throughput_test.go
+++ b/tests/db_progress_throughput_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"govard/internal/cmd"
+)
+
+// TestFormatThroughputSuffixShowsRateAndETA covers the common case: some
+// bytes moved over a non-trivial window, with an estimated total still ahead.
+func TestFormatThroughputSuffixShowsRateAndETA(t *testing.T) {
+	// 10 MiB in 1s => 10 MiB/s; 100 MiB remaining => ETA ~10s.
+	deltaBytes := int64(10 * 1024 * 1024)
+	elapsed := time.Second
+	remaining := int64(100 * 1024 * 1024)
+
+	suffix := cmd.FormatThroughputSuffixForTest(deltaBytes, elapsed, remaining)
+
+	if !strings.Contains(suffix, "/s") {
+		t.Fatalf("expected a rate figure in the suffix, got: %q", suffix)
+	}
+	if !strings.Contains(suffix, "ETA") {
+		t.Fatalf("expected an ETA in the suffix, got: %q", suffix)
+	}
+}
+
+// TestFormatThroughputSuffixHidesETAWhenTotalAlreadyReached covers the case
+// where the actual transfer has caught up to (or passed) the estimated
+// total - showing a negative or zero ETA would be nonsensical.
+func TestFormatThroughputSuffixHidesETAWhenTotalAlreadyReached(t *testing.T) {
+	suffix := cmd.FormatThroughputSuffixForTest(1024, time.Second, 0)
+
+	if !strings.Contains(suffix, "/s") {
+		t.Fatalf("expected the rate to still be shown, got: %q", suffix)
+	}
+	if strings.Contains(suffix, "ETA") {
+		t.Fatalf("expected no ETA once the estimated total has been reached, got: %q", suffix)
+	}
+}
+
+// TestFormatThroughputSuffixEmptyWithoutSignal covers the "not enough data
+// yet" cases: no bytes moved since the last sample, or no elapsed time.
+func TestFormatThroughputSuffixEmptyWithoutSignal(t *testing.T) {
+	cases := []struct {
+		name       string
+		deltaBytes int64
+		elapsed    time.Duration
+		remaining  int64
+	}{
+		{"no bytes since last sample", 0, time.Second, 1024},
+		{"no elapsed time", 1024, 0, 1024},
+		{"negative delta", -5, time.Second, 1024},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			suffix := cmd.FormatThroughputSuffixForTest(c.deltaBytes, c.elapsed, c.remaining)
+			if suffix != "" {
+				t.Fatalf("expected an empty suffix, got: %q", suffix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Progress bar previously claimed 100% as soon as bytes were streamed into mysql's stdin, even though mysql could keep committing for tens of minutes afterwards with zero feedback - now the same bar stays alive through the finalize/commit phase (polling the target DB's growing size) and only fills to 100% once the import process has actually exited successfully.
- Fixed the bar force-padding its counter to the pre-sync size estimate (a false 100% next to a smaller real byte count when the estimate overshot reality) and, conversely, silently freezing mid-transfer when the estimate undershot reality (pterm auto-stops the bar the instant Current reaches Total).
- Percentage is now capped at 99% during the copy phase, byte counters are tracked independently of pterm's internal state, throughput/ETA are shown, and the pre-sync estimate is shown once as static context instead of a continuously-updating current/total pair.
- Fixed a data race from writing status text through the same writer wired to the child process's stdout.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` (including `-tags integration`)
- [x] `gofmt -s -l` on changed files (no drift)
- [x] `go test ./...`
- [x] `go test ./tests/ -race` (repeated runs, including a synthetic long-running finalize case) - no races/flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)