### PR TITLE
fix: resolve open CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -88,7 +88,7 @@ jobs:
           cache: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean

--- a/internal/engine/blueprint_registry.go
+++ b/internal/engine/blueprint_registry.go
@@ -258,6 +258,9 @@ func extractTarGzArchive(payload []byte, dest string) error {
 			return err
 		}
 
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("unsafe archive path %q", header.Name)
+		}
 		targetPath, err := safeArchivePath(dest, header.Name)
 		if err != nil {
 			return err
@@ -296,6 +299,9 @@ func extractZipArchive(payload []byte, dest string) error {
 	}
 
 	for _, zipped := range reader.File {
+		if strings.Contains(zipped.Name, "..") {
+			return fmt.Errorf("unsafe archive path %q", zipped.Name)
+		}
 		targetPath, err := safeArchivePath(dest, zipped.Name)
 		if err != nil {
 			return err

--- a/internal/engine/bootstrap/emdash.go
+++ b/internal/engine/bootstrap/emdash.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"govard/internal/conventions"
 	"io"
@@ -141,8 +142,8 @@ func downloadAndExtractStarterTemplate(projectDir string) error {
 				return fmt.Errorf("create template file %s: %w", targetPath, err)
 			}
 			if _, err := io.Copy(file, tarReader); err != nil {
-				file.Close()
-				return fmt.Errorf("write template file %s: %w", targetPath, err)
+				closeErr := file.Close()
+				return fmt.Errorf("write template file %s: %w", targetPath, errors.Join(err, closeErr))
 			}
 			if err := file.Close(); err != nil {
 				return fmt.Errorf("close template file %s: %w", targetPath, err)

--- a/internal/engine/bootstrap/magento1.go
+++ b/internal/engine/bootstrap/magento1.go
@@ -245,6 +245,12 @@ func RunSQLViaDockerExec(containerName string, dbUser string, dbPassword string,
 
 // Md5SaltedHash returns the MD5 hash of (salt + password) as a hex string.
 // This matches Magento 1's salted password hashing: md5(salt . password).
+//
+// MD5 is required here, not a choice: Magento 1's own auth code only ever
+// verifies this exact format, so using a stronger algorithm would produce a
+// hash Magento 1 itself cannot log in with. This only ever hashes the local
+// dev bootstrap's default admin credentials (see conventions.DefaultAdminUser
+// / DefaultAdminPassword), never a real user secret.
 func Md5SaltedHash(salt, password string) string {
 	h := md5.New() //nolint:gosec
 	fmt.Fprint(h, salt+password)

--- a/internal/engine/bootstrap/staged_project.go
+++ b/internal/engine/bootstrap/staged_project.go
@@ -158,7 +158,7 @@ func copyProjectPath(srcPath, dstPath string) error {
 	}
 }
 
-func copyProjectFile(srcPath, dstPath string, mode os.FileMode) error {
+func copyProjectFile(srcPath, dstPath string, mode os.FileMode) (err error) {
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
 		return fmt.Errorf("open staged file %s: %w", srcPath, err)
@@ -173,7 +173,11 @@ func copyProjectFile(srcPath, dstPath string, mode os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("create project file %s: %w", dstPath, err)
 	}
-	defer dstFile.Close()
+	defer func() {
+		if cerr := dstFile.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	if _, err := io.Copy(dstFile, srcFile); err != nil {
 		return fmt.Errorf("copy staged file %s: %w", srcPath, err)

--- a/internal/engine/bootstrap/wordpress.go
+++ b/internal/engine/bootstrap/wordpress.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"govard/internal/conventions"
 	"io"
@@ -317,8 +318,8 @@ func downloadAndExtractWordPressCore(projectDir string) error {
 				return fmt.Errorf("create WordPress file %s: %w", targetPath, err)
 			}
 			if _, err := io.Copy(file, tarReader); err != nil {
-				file.Close()
-				return fmt.Errorf("write WordPress file %s: %w", targetPath, err)
+				closeErr := file.Close()
+				return fmt.Errorf("write WordPress file %s: %w", targetPath, errors.Join(err, closeErr))
 			}
 			if err := file.Close(); err != nil {
 				return fmt.Errorf("close WordPress file %s: %w", targetPath, err)

--- a/internal/engine/operations_log.go
+++ b/internal/engine/operations_log.go
@@ -47,7 +47,7 @@ func OperationsLogPath() string {
 	return filepath.Join(".govard", "operations.log")
 }
 
-func WriteOperationEvent(event OperationEvent) error {
+func WriteOperationEvent(event OperationEvent) (err error) {
 	event.Operation = strings.TrimSpace(event.Operation)
 	if event.Operation == "" {
 		return fmt.Errorf("operation name is required")
@@ -80,7 +80,11 @@ func WriteOperationEvent(event OperationEvent) error {
 	if err != nil {
 		return fmt.Errorf("open operations log: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	if _, err := file.Write(append(payload, '\n')); err != nil {
 		return fmt.Errorf("write operation event: %w", err)

--- a/internal/engine/remote/audit.go
+++ b/internal/engine/remote/audit.go
@@ -42,7 +42,7 @@ func AuditLogPath() string {
 	return filepath.Join(home, ".govard", "remote.log")
 }
 
-func WriteAuditEvent(event AuditEvent) error {
+func WriteAuditEvent(event AuditEvent) (err error) {
 	if event.Operation == "" {
 		return fmt.Errorf("remote audit operation is required")
 	}
@@ -67,7 +67,11 @@ func WriteAuditEvent(event AuditEvent) error {
 	if err != nil {
 		return fmt.Errorf("open remote audit log: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	if _, err := file.Write(append(payload, '\n')); err != nil {
 		return fmt.Errorf("write remote audit event: %w", err)

--- a/internal/engine/render.go
+++ b/internal/engine/render.go
@@ -569,11 +569,25 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 	if err := EnsureComposePathReady(outputPath); err != nil {
 		return fmt.Errorf("failed to prepare compose output path: %w", err)
 	}
+	if err := writeRenderedCompose(outputPath, merged); err != nil {
+		return err
+	}
+
+	_ = os.WriteFile(hashPath, []byte(currentHash), conventions.DefaultFilePerm)
+
+	return nil
+}
+
+func writeRenderedCompose(outputPath string, merged map[string]interface{}) (err error) {
 	f, err := os.OpenFile(outputPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, conventions.DefaultFilePerm)
 	if err != nil {
 		return fmt.Errorf("create compose output %s: %w", outputPath, err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	// Prune empty root-level maps to avoid validation errors (e.g., "volumes must be a mapping")
 	if volumes, ok := merged["volumes"].(map[string]interface{}); ok && len(volumes) == 0 {
@@ -587,13 +601,9 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 		return fmt.Errorf("marshal rendered compose: %w", err)
 	}
 
-	_, err = f.Write(out)
-	if err != nil {
+	if _, err = f.Write(out); err != nil {
 		return fmt.Errorf("write compose output %s: %w", outputPath, err)
 	}
-
-	_ = os.WriteFile(hashPath, []byte(currentHash), conventions.DefaultFilePerm)
-
 	return nil
 }
 

--- a/internal/engine/snapshot.go
+++ b/internal/engine/snapshot.go
@@ -251,7 +251,7 @@ func copyDir(src string, dst string) error {
 	return nil
 }
 
-func copyFileWithMode(src string, dst string, mode os.FileMode) error {
+func copyFileWithMode(src string, dst string, mode os.FileMode) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("open source file %s: %w", src, err)
@@ -266,7 +266,11 @@ func copyFileWithMode(src string, dst string, mode os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("open destination file %s: %w", dst, err)
 	}
-	defer out.Close()
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	_, err = io.Copy(out, in)
 	if err != nil {

--- a/internal/engine/trust.go
+++ b/internal/engine/trust.go
@@ -228,10 +228,17 @@ func extractRootCAFromContainer(destinationPath string) error {
 	return fmt.Errorf("tried containers %s", strings.Join(attemptErrors, " | "))
 }
 
+// warmupCaddyCA makes a single TLS handshake against the local Caddy proxy to
+// force it to mint its root CA / leaf cert on first run, before that CA
+// exists anywhere for us to verify against (extractRootCAFromContainer calls
+// this only after an initial extraction attempt fails). The dial target is
+// hardcoded to loopback, no data is sent or read, and the connection is
+// closed immediately after the handshake, so InsecureSkipVerify carries no
+// meaningful risk here — there is nothing yet to verify against.
 func warmupCaddyCA() {
 	dialer := &net.Dialer{Timeout: 2 * time.Second}
 	conn, err := tls.DialWithDialer(dialer, "tcp", "127.0.0.1:443", &tls.Config{
-		InsecureSkipVerify: true, // local bootstrap probe
+		InsecureSkipVerify: true, // local bootstrap probe, see doc comment above
 		ServerName:         "mail.govard.test",
 	})
 	if err != nil {

--- a/internal/proxy/caddy.go
+++ b/internal/proxy/caddy.go
@@ -261,7 +261,7 @@ func upsertRoute(config map[string]interface{}, serverName string, domain string
 		changed = true
 	}
 
-	newRoutes := make([]interface{}, 0, len(routes)+1)
+	newRoutes := make([]interface{}, 0, len(routes))
 	inserted := false
 	for _, route := range routes {
 		routeMap, ok := route.(map[string]interface{})


### PR DESCRIPTION
## Summary

- Handles previously-ignored writable-file `Close()` errors flagged by `go/unhandled-writable-file-close` in `render.go`, `bootstrap/wordpress.go`, `bootstrap/emdash.go`, `bootstrap/staged_project.go`, `operations_log.go`, `snapshot.go`, and `remote/audit.go` (named returns + deferred close-error capture, or `errors.Join` for the copy-then-close error paths).
- Adds an inline `strings.Contains(name, "..")` guard next to the existing `safeArchivePath` sanitizer in `blueprint_registry.go` so CodeQL's `go/zipslip` sanitizer-recognition pattern picks it up (the archive extraction was already safe in practice via `safeArchivePath`, but CodeQL's local dataflow model doesn't credit a helper function 100+ lines away as a barrier).
- Drops the overflow-prone `len(routes)+1` capacity computation in `internal/proxy/caddy.go` (`go/allocation-size-overflow`) — `append` handles growth safely without a precomputed size.
- Pins `docker/setup-buildx-action@v3` and `goreleaser/goreleaser-action@v6` to commit SHAs in the CI/release workflows (`actions/unpinned-tag`).
- Documents (and dismisses via the GitHub API, with justification) two alerts that are intentional-by-design and would break functionality if "fixed":
  - `go/weak-sensitive-data-hashing` in `bootstrap/magento1.go`: `Md5SaltedHash` replicates Magento 1's own `md5(salt+password)` auth format for a freshly bootstrapped project's *default* admin credentials — Magento 1 itself only verifies this exact format.
  - `go/disabled-certificate-check` in `trust.go`: `warmupCaddyCA()` dials only hardcoded `127.0.0.1:443`, sends/reads no data, and exists solely to force Caddy to mint its local dev root CA before any CA exists locally to verify against.

Closes #71

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -s -l` on all changed files (no drift)
- [x] `make test` (lint + fmt-check + vet + full unit/integration suite) passes