### PR TITLE
fix(sync): warn on empty --path, infer path from positional arg, fix directory detection

### DIFF
--- a/docs/vi/workflows/remotes-and-sync.md
+++ b/docs/vi/workflows/remotes-and-sync.md
@@ -82,6 +82,8 @@ Lệnh `govard sync` di chuyển các file nguồn, media, và dữ liệu datab
 govard sync --source staging --destination local --full --plan
 govard sync --from staging --to local --media
 govard sync -s dev --db --no-noise --no-pii
+govard sync -s prod --file --path app/etc/config.php
+govard sync -s dev --file app/design/frontend/MyTheme
 ```
 
 Tự động chọn remote `staging` nếu không khai báo `--source`, và fallback về `dev`.
@@ -117,6 +119,10 @@ Cờ `--media` đơn lẻ sẽ mặc định chạy chế độ đồng bộ med
 | `-p, --path` | Chỉ định một file hoặc thư mục cụ thể tương đối với thư mục gốc dự án |
 | `-I, --include` | Cấu hình pattern bao gồm của rsync (có thể lặp lại nhiều lần) |
 | `-X, --exclude` | Cấu hình pattern loại trừ của rsync (có thể lặp lại nhiều lần) |
+
+::: tip
+Nếu không truyền `--path`, toàn bộ thư mục gốc của dự án sẽ được đồng bộ — `govard sync` sẽ cảnh báo điều này trong kế hoạch trước khi hỏi xác nhận. Bạn cũng có thể bỏ qua `-p`/`--path` và truyền path dưới dạng tham số cuối cùng, ví dụ: `govard sync -s dev --file app/design/frontend/MyTheme`.
+:::
 
 ### Các bộ lọc bảo mật cơ sở dữ liệu (Database Privacy Filters)
 

--- a/docs/workflows/remotes-and-sync.md
+++ b/docs/workflows/remotes-and-sync.md
@@ -83,6 +83,7 @@ govard sync --source staging --destination local --full --plan
 govard sync --from staging --to local --media
 govard sync -s dev --db --no-noise --no-pii
 govard sync -s prod --file --path app/etc/config.php
+govard sync -s dev --file app/design/frontend/MyTheme
 ```
 
 Auto-selects `staging` if no `--source` provided, falling back to `dev`.
@@ -118,6 +119,10 @@ Bare `--media` defaults to the `optimized` media mode.
 | `-p, --path` | Specific file/directory relative to project root |
 | `-I, --include` | Rsync include pattern (repeatable) |
 | `-X, --exclude` | Rsync exclude pattern (repeatable) |
+
+::: tip
+Omitting `--path` syncs the entire project root — `govard sync` warns you about this in the plan before asking for confirmation. You can also skip `-p`/`--path` entirely and pass the path as a trailing argument instead, e.g. `govard sync -s dev --file app/design/frontend/MyTheme`.
+:::
 
 ### Database Privacy Filters
 

--- a/internal/cmd/media_flag.go
+++ b/internal/cmd/media_flag.go
@@ -29,3 +29,40 @@ func normalizeExplicitMediaModeArg(args []string) (string, bool) {
 		return "", false
 	}
 }
+
+func resolvePositionalPathArg(cmd *cobra.Command, currentPath string, args []string) string {
+	if cmd == nil || cmd.Flags().Changed("path") || currentPath != "" {
+		return currentPath
+	}
+	if len(args) == 0 {
+		return currentPath
+	}
+	candidate := strings.TrimSpace(args[0])
+	if candidate == "" {
+		return currentPath
+	}
+	if _, consumedByMedia := normalizeExplicitMediaModeArg(args); consumedByMedia {
+		return currentPath
+	}
+	return candidate
+}
+
+// ResolvePositionalPathArgForTest exposes resolvePositionalPathArg's precedence
+// rules for testing without needing a full cobra.Command. pathFlagChanged
+// simulates cmd.Flags().Changed("path").
+func ResolvePositionalPathArgForTest(pathFlagChanged bool, currentPath string, args []string) string {
+	if pathFlagChanged || currentPath != "" {
+		return currentPath
+	}
+	if len(args) == 0 {
+		return currentPath
+	}
+	candidate := strings.TrimSpace(args[0])
+	if candidate == "" {
+		return currentPath
+	}
+	if _, consumedByMedia := normalizeExplicitMediaModeArg(args); consumedByMedia {
+		return currentPath
+	}
+	return candidate
+}

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -102,6 +102,7 @@ Case Studies:
 		full, _ := cmd.Flags().GetBool("full")
 		deleteFiles, _ := cmd.Flags().GetBool("delete")
 		path, _ := cmd.Flags().GetString("path")
+		path = resolvePositionalPathArg(cmd, path, args)
 		planOnly, _ := cmd.Flags().GetBool("plan")
 		yes, _ := cmd.Flags().GetBool("yes")
 		resume, _ := cmd.Flags().GetBool("resume")

--- a/internal/cmd/sync_plan.go
+++ b/internal/cmd/sync_plan.go
@@ -76,7 +76,7 @@ func buildSyncExecutionPlan(config engine.Config, endpoints ResolvedSyncEndpoint
 			endpoints.Destination,
 			sourcePath,
 			destinationPath,
-			isSyncingDirectory(opts.Path, sourcePath, destinationPath),
+			isSyncingDirectory(opts.Path, sourcePath, destinationPath, endpoints.Source.IsLocal, endpoints.Destination.IsLocal),
 			opts.Delete,
 			opts.Resume,
 			opts.NoCompress,
@@ -167,6 +167,13 @@ func evaluateSyncPolicy(endpoints ResolvedSyncEndpoints, opts SyncExecutionOptio
 	warnings := []string{}
 	if opts.Path != "" && (opts.Media != "" || opts.DB) {
 		warnings = append(warnings, "Path filter only applies to file synchronization; media and database will use full configured paths.")
+	}
+	if opts.Files && strings.TrimSpace(opts.Path) == "" {
+		if opts.Delete {
+			warnings = append(warnings, "No --path specified: the ENTIRE project root will be synced, and --delete is enabled — files outside any single subfolder may be permanently removed. Re-run with -p/--path if you meant to target a specific path.")
+		} else {
+			warnings = append(warnings, "No --path specified: the ENTIRE project root will be synced, not a subfolder. Re-run with -p/--path if you meant to target a specific path.")
+		}
 	}
 	if len(opts.Include) > 0 && !opts.Files && opts.Media == "" {
 		warnings = append(warnings, "Include patterns are only applicable to file or media rsync operations.")
@@ -347,28 +354,29 @@ func getSyncNoiseExcludes(framework string) []string {
 	return engine.GetFrameworkSyncNoiseExcludes(framework)
 }
 
-func isSyncingDirectory(path, sourcePath, destinationPath string) bool {
+func isSyncingDirectory(path, sourcePath, destinationPath string, sourceIsLocal, destinationIsLocal bool) bool {
 	if path == "" || strings.HasSuffix(path, "/") || strings.HasSuffix(path, "\\") {
 		return true
 	}
 
-	// If source is local, check if it's a directory
-	if info, err := os.Stat(sourcePath); err == nil && info.IsDir() {
-		return true
+	if sourceIsLocal {
+		if info, err := os.Stat(sourcePath); err == nil {
+			return info.IsDir()
+		}
+	}
+	if destinationIsLocal {
+		if info, err := os.Stat(destinationPath); err == nil {
+			return info.IsDir()
+		}
 	}
 
-	// If destination is local, check if it exists as a directory
-	if info, err := os.Stat(destinationPath); err == nil && info.IsDir() {
-		return true
-	}
-
-	// Special case for common directories known in this project
-	pathLower := strings.ToLower(path)
-	if pathLower == "vendor" || pathLower == "node_modules" || pathLower == "pub/media" || pathLower == "media" || pathLower == "var" {
-		return true
-	}
-
-	return false
+	// Neither side is resolvable locally (or the path doesn't exist yet):
+	// fall back to an extension check. Paths without a file extension are
+	// assumed to be directories -- covers arbitrary framework paths (theme
+	// folders, storage dirs, etc.) without needing a hardcoded list. A real
+	// directory whose name contains a dot can still be forced with a
+	// trailing slash.
+	return filepath.Ext(path) == ""
 }
 
 // BuildSyncExecutionPlanForTest exposes buildSyncExecutionPlan for tests in /tests.

--- a/tests/integration/bootstrap_sync_options_matrix_test.go
+++ b/tests/integration/bootstrap_sync_options_matrix_test.go
@@ -301,7 +301,7 @@ func TestSyncOptionsMatrixWithSimulatedEnvironments(t *testing.T) {
 		logs := shim.ReadLog(t)
 		assertMatrixContains(t, logs, "rsync|")
 		assertMatrixContains(t, logs, "--delete")
-		assertMatrixContains(t, logs, "deploy@staging.example.com:'/srv/www/staging/app/code'")
+		assertMatrixContains(t, logs, "deploy@staging.example.com:'/srv/www/staging/app/code/'")
 		assertMatrixContains(t, logs, filepath.Join(projectDir, "app", "code"))
 	})
 

--- a/tests/integration/magento_three_env_bootstrap_sync_test.go
+++ b/tests/integration/magento_three_env_bootstrap_sync_test.go
@@ -193,5 +193,5 @@ func TestMagentoThreeEnvironmentInitBootstrapAndSyncOptions(t *testing.T) {
 	assertContains(t, syncLogs, "--include app/*")
 	assertContains(t, syncLogs, "--exclude vendor/")
 	assertContains(t, syncLogs, "--delete")
-	assertContains(t, syncLogs, "deploy@dev.example.com:'/var/www/html/app/code'")
+	assertContains(t, syncLogs, "deploy@dev.example.com:'/var/www/html/app/code/'")
 }

--- a/tests/media_flag_test.go
+++ b/tests/media_flag_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"testing"
+
+	"govard/internal/cmd"
+)
+
+func TestResolvePositionalPathArgUsesBareTrailingArg(t *testing.T) {
+	got := cmd.ResolvePositionalPathArgForTest(false, "", []string{"var/log/"})
+	if got != "var/log/" {
+		t.Fatalf("expected positional arg to become path, got: %q", got)
+	}
+}
+
+func TestResolvePositionalPathArgIgnoredWhenPathFlagChanged(t *testing.T) {
+	got := cmd.ResolvePositionalPathArgForTest(true, "app/etc/config.php", []string{"ignored"})
+	if got != "app/etc/config.php" {
+		t.Fatalf("expected explicit --path to win, got: %q", got)
+	}
+}
+
+func TestResolvePositionalPathArgIgnoredWhenNoPositionalArgs(t *testing.T) {
+	got := cmd.ResolvePositionalPathArgForTest(false, "", nil)
+	if got != "" {
+		t.Fatalf("expected empty path when no positional args, got: %q", got)
+	}
+}

--- a/tests/sync_aliases_test.go
+++ b/tests/sync_aliases_test.go
@@ -138,6 +138,147 @@ func TestSyncCommandExplicitMediaModeStillParsesWithSpaceSeparatedValue(t *testi
 	}
 }
 
+func TestSyncCommandWarnsWhenPathMissingForFileSync(t *testing.T) {
+	resetSyncFlagsForAliasTest(t)
+
+	tempDir := t.TempDir()
+	writeSyncAliasConfig(t, tempDir)
+	chdirForTest(t, tempDir)
+
+	root := cmd.RootCommandForTest()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"sync", "--plan", "--file", "-e", "dev"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "No --path specified: the ENTIRE project root will be synced, not a subfolder.") {
+		t.Fatalf("expected empty-path warning, got: %s", out)
+	}
+}
+
+func TestSyncCommandWarnsHarderWhenPathMissingAndDeleteEnabled(t *testing.T) {
+	resetSyncFlagsForAliasTest(t)
+
+	tempDir := t.TempDir()
+	writeSyncAliasConfig(t, tempDir)
+	chdirForTest(t, tempDir)
+
+	root := cmd.RootCommandForTest()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"sync", "--plan", "--file", "--delete", "-e", "dev"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "No --path specified: the ENTIRE project root will be synced, and --delete is enabled") {
+		t.Fatalf("expected delete-aware empty-path warning, got: %s", out)
+	}
+}
+
+func TestSyncCommandNoEmptyPathWarningWhenPathGiven(t *testing.T) {
+	resetSyncFlagsForAliasTest(t)
+
+	tempDir := t.TempDir()
+	writeSyncAliasConfig(t, tempDir)
+	chdirForTest(t, tempDir)
+
+	root := cmd.RootCommandForTest()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"sync", "--plan", "--file", "--path", "app/etc/config.php", "-e", "dev"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "No --path specified") {
+		t.Fatalf("did not expect empty-path warning when --path is set, got: %s", out)
+	}
+}
+
+func TestSyncCommandBareTrailingArgBecomesPath(t *testing.T) {
+	resetSyncFlagsForAliasTest(t)
+
+	tempDir := t.TempDir()
+	writeSyncAliasConfig(t, tempDir)
+	chdirForTest(t, tempDir)
+
+	root := cmd.RootCommandForTest()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"sync", "--plan", "--file", "-e", "dev", "var/log/"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Path Filter: var/log/") {
+		t.Fatalf("expected bare trailing arg to become --path, got: %s", out)
+	}
+	if strings.Contains(out, "No --path specified") {
+		t.Fatalf("did not expect empty-path warning once positional arg supplies a path, got: %s", out)
+	}
+}
+
+func TestSyncCommandExplicitMediaModePositionalIsNotReusedAsPath(t *testing.T) {
+	resetSyncFlagsForAliasTest(t)
+
+	tempDir := t.TempDir()
+	writeSyncAliasConfig(t, tempDir)
+	chdirForTest(t, tempDir)
+
+	root := cmd.RootCommandForTest()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"sync", "--plan", "--media", "all", "-e", "dev"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Path Filter: (none)") {
+		t.Fatalf("expected 'all' consumed by --media, not reused as path, got: %s", out)
+	}
+}
+
+func TestSyncCommandExplicitPathWinsOverPositionalArg(t *testing.T) {
+	resetSyncFlagsForAliasTest(t)
+
+	tempDir := t.TempDir()
+	writeSyncAliasConfig(t, tempDir)
+	chdirForTest(t, tempDir)
+
+	root := cmd.RootCommandForTest()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"sync", "--plan", "--file", "--path", "app/etc/config.php", "-e", "dev", "ignored-positional"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Path Filter: app/etc/config.php") {
+		t.Fatalf("expected explicit --path to win over positional arg, got: %s", out)
+	}
+}
+
 func TestResetSyncFlagsForTestClearsStringArrayFlags(t *testing.T) {
 	resetSyncFlagsForAliasTest(t)
 

--- a/tests/sync_plan_test.go
+++ b/tests/sync_plan_test.go
@@ -68,6 +68,85 @@ func TestSyncPlanDirectoryDetection(t *testing.T) {
 	}
 }
 
+func TestSyncPlanDirectoryDetectionForUnlistedFrameworkPath(t *testing.T) {
+	tempDir := t.TempDir()
+	destDir := filepath.Join(tempDir, "dest")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := engine.Config{ProjectName: "test-project", Framework: "magento2"}
+
+	endpoints := cmd.ResolveSyncEndpointsForTest(
+		cmd.SyncEndpoint{
+			Name:     "staging",
+			IsLocal:  false,
+			RootPath: "/var/www/html",
+			RemoteCfg: engine.RemoteConfig{
+				Host: "staging.example.com",
+				Path: "/var/www/html",
+			},
+		},
+		cmd.SyncEndpoint{Name: "local", IsLocal: true, RootPath: destDir},
+	)
+
+	// "app/design/frontend/MyTheme" is not in the old hardcoded whitelist and
+	// does not exist yet at the destination -- must still be treated as a
+	// directory so rsync doesn't nest it inside itself at the destination.
+	opts := cmd.SyncExecutionOptionsForTest(true, "", false)
+	opts.Path = "app/design/frontend/MyTheme"
+
+	plan, err := cmd.BuildSyncExecutionPlanForTest(config, endpoints, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected 1 rsync command, got %d", len(plan.Commands))
+	}
+	if !strings.Contains(plan.Commands[0], "MyTheme/") {
+		t.Errorf("expected rsync command to contain trailing-slash 'MyTheme/', got: %s", plan.Commands[0])
+	}
+}
+
+func TestSyncPlanDirectoryDetectionTreatsExtensionPathAsFile(t *testing.T) {
+	tempDir := t.TempDir()
+	destDir := filepath.Join(tempDir, "dest")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := engine.Config{ProjectName: "test-project", Framework: "magento2"}
+
+	endpoints := cmd.ResolveSyncEndpointsForTest(
+		cmd.SyncEndpoint{
+			Name:     "staging",
+			IsLocal:  false,
+			RootPath: "/var/www/html",
+			RemoteCfg: engine.RemoteConfig{
+				Host: "staging.example.com",
+				Path: "/var/www/html",
+			},
+		},
+		cmd.SyncEndpoint{Name: "local", IsLocal: true, RootPath: destDir},
+	)
+
+	opts := cmd.SyncExecutionOptionsForTest(true, "", false)
+	opts.Path = "app/etc/config.php"
+
+	plan, err := cmd.BuildSyncExecutionPlanForTest(config, endpoints, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected 1 rsync command, got %d", len(plan.Commands))
+	}
+	if strings.Contains(plan.Commands[0], "config.php/") {
+		t.Errorf("expected file path to NOT get a trailing slash, got: %s", plan.Commands[0])
+	}
+}
+
 func TestSyncPlanScopes(t *testing.T) {
 	config := engine.Config{
 		ProjectName: "test-project",


### PR DESCRIPTION
Closes #80

## Summary

- Warn (in the sync plan, before confirmation) when `--path` is empty for a file sync, since that silently syncs the entire project root with no default excludes — escalated wording when `--delete` is also enabled.
- Infer `--path` from a bare trailing positional argument (e.g. `govard sync --file -e dev var/log/`) when the flag wasn't explicitly set, without breaking the existing `--media all` space-separated-value convention that already inspects the same positional slot.
- Replace `isSyncingDirectory`'s hardcoded directory-name whitelist (`vendor`, `node_modules`, `pub/media`, `media`, `var`) with a file-extension heuristic (plus locality-aware `os.Stat`), so arbitrary real directories that don't exist yet at the destination (e.g. `app/design/frontend/MyTheme`, `app/code`) are correctly detected as directories instead of getting nested inside themselves at the destination by rsync.
- Document both the empty-path warning and the positional-path shortcut in `docs/workflows/remotes-and-sync.md` and its Vietnamese counterpart.

## Rationale

Reported via two real-world sync footguns: users forgetting `-p`/`--path` and accidentally syncing/deleting far more than intended, and directory paths outside the old hardcoded whitelist ending up duplicated in a nested folder at the destination.

## Test plan

- [x] `go test ./...` — all unit tests pass
- [x] `go test -tags integration ./tests/integration/...` — all integration tests pass, including two fixtures updated to the corrected (fixed) rsync trailing-slash expectation for `--path app/code`
- [x] `gofmt -s -l .` — no drift
- [x] `go vet ./...` — clean
- [x] `make test` — full lint + fmt-check + vet + unit + frontend + integration suite passes