### PR TITLE
fix(cmd): drop 1-hour cache from self-update latest-release lookup

### DIFF
--- a/internal/cmd/self_update.go
+++ b/internal/cmd/self_update.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
-
-	"govard/internal/engine"
 )
 
 const (
@@ -264,19 +262,6 @@ func selfUpdateReleaseBaseURL(repo, releaseTag string) string {
 }
 
 func fetchLatestReleaseTag(client *http.Client, repo string) (string, error) {
-	cacheFile := filepath.Join(engine.GovardHomeDir(), "cache", "latest-release.json")
-	var cacheData struct {
-		Tag       string    `json:"tag"`
-		FetchedAt time.Time `json:"fetched_at"`
-	}
-	if b, err := os.ReadFile(cacheFile); err == nil {
-		if json.Unmarshal(b, &cacheData) == nil && time.Since(cacheData.FetchedAt) < time.Hour {
-			if isValidReleaseTag(cacheData.Tag) {
-				return cacheData.Tag, nil
-			}
-		}
-	}
-
 	url := selfUpdateLatestReleaseURL(repo)
 	body, err := downloadText(client, url)
 	if err != nil {
@@ -293,13 +278,6 @@ func fetchLatestReleaseTag(client *http.Client, repo string) (string, error) {
 	tag, err := validateReleaseTag(release.TagName)
 	if err != nil {
 		return "", fmt.Errorf("invalid release tag received from upstream: %w", err)
-	}
-
-	cacheData.Tag = tag
-	cacheData.FetchedAt = time.Now()
-	if b, err := json.Marshal(cacheData); err == nil {
-		_ = os.MkdirAll(filepath.Dir(cacheFile), conventions.DefaultDirPerm)
-		_ = os.WriteFile(cacheFile, b, conventions.DefaultFilePerm)
 	}
 
 	return tag, nil


### PR DESCRIPTION
Closes #84

## Summary

- `govard self-update` cached the resolved latest-release tag on disk for
  1 hour before re-checking GitHub. Since self-update is an explicit,
  infrequent manual action, this only risked installing a stale tag right
  after a new release with no meaningful benefit. Removed the cache so
  `self-update` always resolves the true latest release live.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -s -l .` (no drift)
- [x] `go vet ./...`
- [x] `go test ./...` (all pass, including self-update release-tag tests)