### PR TITLE
fix(docs): pin postcss to patched version via npm override

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2066,9 +2066,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2124,9 +2124,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2144,7 +2144,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
   },
   "overrides": {
     "vite": "^6.4.3",
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "postcss": "^8.5.18"
   }
 }


### PR DESCRIPTION
## Summary
- Dependabot alert #33 (high): postcss < 8.5.18 path traversal via sourceMappingURL auto-loading, pulled in transitively through `vitepress` in `docs/`.
- Add `postcss` to `docs/package.json`'s `overrides`, matching the existing `vite`/`esbuild` override pattern, and regenerate `docs/package-lock.json`. Resolves to postcss 8.5.25.
- `desktop/frontend` already pinned postcss to a patched version (8.5.22) via its `resolutions` field — no change needed there.

Closes #86

## Test plan
- [x] `npm install` in `docs/` completes with 0 vulnerabilities reported
- [x] Confirmed `docs/package-lock.json` resolves `postcss` to 8.5.25 (patched, alert required >= 8.5.18)
- [x] Confirmed `desktop/frontend/yarn.lock` already resolves postcss to 8.5.22 (patched, unaffected)