### PR TITLE
fix(sync): stop database sync when remote credential probe fails

### DIFF
--- a/internal/cmd/sync_rsync.go
+++ b/internal/cmd/sync_rsync.go
@@ -78,7 +78,7 @@ func buildDatabaseSyncAction(config engine.Config, source SyncEndpoint, destinat
 	case !source.IsLocal && destination.IsLocal:
 		remoteCredentials, probeErr := resolveRemoteDBCredentials(config, source.Name, source.RemoteCfg)
 		if probeErr != nil {
-			pterm.Warning.Println(formatRemoteDBProbeWarning(source.Name, probeErr))
+			return "", nil, fmt.Errorf("cannot sync database: %s", formatRemoteDBProbeWarning(source.Name, probeErr))
 		}
 		dumpCmdStr := buildRemoteMySQLDumpCommandString(remoteCredentials, noNoise, noPII, config.Framework, true)
 		importCmdStr := buildLocalMySQLClientCommandScript(localCredentials, true)
@@ -98,7 +98,7 @@ func buildDatabaseSyncAction(config engine.Config, source SyncEndpoint, destinat
 	case source.IsLocal && !destination.IsLocal:
 		remoteCredentials, probeErr := resolveRemoteDBCredentials(config, destination.Name, destination.RemoteCfg)
 		if probeErr != nil {
-			pterm.Warning.Println(formatRemoteDBProbeWarning(destination.Name, probeErr))
+			return "", nil, fmt.Errorf("cannot sync database: %s", formatRemoteDBProbeWarning(destination.Name, probeErr))
 		}
 		dumpCmdStr := buildLocalMySQLDumpCommandScript(localCredentials, noNoise, noPII, config.Framework)
 		importCmdStr := buildRemoteMySQLImportCommandString(remoteCredentials)

--- a/tests/integration/bootstrap_sync_options_matrix_test.go
+++ b/tests/integration/bootstrap_sync_options_matrix_test.go
@@ -224,10 +224,18 @@ func TestSyncOptionsMatrixWithSimulatedEnvironments(t *testing.T) {
 
 	t.Run("PlanFullDeletePathIncludeExcludeResume", func(t *testing.T) {
 		projectDir := env.CreateProjectFromFixture(t, "magento2/options-local", "sync-options-full-plan")
+		// DB scope resolves remote credentials by probing the remote over SSH,
+		// so this needs the shim (unlike the file-only plan subtests above).
+		shim := env.SetupRuntimeShims(t, map[string]int{
+			"docker": 0,
+			"ssh":    0,
+			"rsync":  0,
+		})
+
 		result := env.RunGovardWithEnv(
 			t,
 			projectDir,
-			isolatedHomeEnv(t),
+			append(shim.Env(), isolatedHomeEnv(t)...),
 			"sync",
 			"--source", "staging",
 			"--destination", "local",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -261,6 +261,10 @@ case "$*" in
   *govard-rsync-ok*)
     printf '%s\n' "govard-rsync-ok"
     ;;
+  *"db.default missing"*)
+    # Fake Magento 2 app/etc/env.php DB probe payload (see magentoDBProbePHP)
+    printf '%s\n' "eyJob3N0IjoiZGIiLCJ1c2VybmFtZSI6Im1hZ2VudG8iLCJwYXNzd29yZCI6Im1hZ2VudG8iLCJkYm5hbWUiOiJtYWdlbnRvIiwidGFibGVfcHJlZml4IjoiIiwiY3J5cHRfa2V5IjoiIn0="
+    ;;
 esac
 `
 	}

--- a/tests/sync_plan_test.go
+++ b/tests/sync_plan_test.go
@@ -148,9 +148,11 @@ func TestSyncPlanDirectoryDetectionTreatsExtensionPathAsFile(t *testing.T) {
 }
 
 func TestSyncPlanScopes(t *testing.T) {
+	// Framework "custom" resolves DB credentials from RemoteConfig directly,
+	// without probing the remote over SSH -- keeps this test hermetic.
 	config := engine.Config{
 		ProjectName: "test-project",
-		Framework:   "magento2",
+		Framework:   "custom",
 	}
 
 	endpoints := cmd.ResolveSyncEndpointsForTest(
@@ -195,10 +197,30 @@ func TestSyncPlanScopes(t *testing.T) {
 }
 
 func TestSyncPlanDatabaseUsesTablePrefixForIgnoredTables(t *testing.T) {
+	// Exercises the same table-prefix resolution the DB sync action relies on,
+	// without going through the remote metadata probe (see BuildDatabaseSyncAction,
+	// which now aborts the sync when that probe fails instead of falling back).
+	got := cmd.BuildIgnoredTableArgsForTest("magento", "demo_", true, false, "magento2")
+
+	found := false
+	for _, arg := range got {
+		if arg == "--ignore-table=magento.demo_cron_schedule" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected prefixed ignored table, got: %v", got)
+	}
+}
+
+func TestSyncPlanDatabaseStopsWhenRemoteCredentialsCannotBeResolved(t *testing.T) {
+	// Magento2 resolves DB credentials by probing the remote over SSH for .env/env.php.
+	// Against a host that can't be reached, that probe fails -- the sync must stop
+	// with a clear error instead of silently falling back to guessed credentials.
 	config := engine.Config{
 		ProjectName: "test-project",
 		Framework:   "magento2",
-		TablePrefix: "demo_",
 	}
 
 	endpoints := cmd.ResolveSyncEndpointsForTest(
@@ -215,18 +237,13 @@ func TestSyncPlanDatabaseUsesTablePrefixForIgnoredTables(t *testing.T) {
 	)
 
 	opts := cmd.SyncExecutionOptionsForTest(false, "", true)
-	opts.NoNoise = true
 
-	plan, err := cmd.BuildSyncExecutionPlanForTest(config, endpoints, opts)
-	if err != nil {
-		t.Fatal(err)
+	_, err := cmd.BuildSyncExecutionPlanForTest(config, endpoints, opts)
+	if err == nil {
+		t.Fatal("expected sync plan to fail when remote DB credentials cannot be resolved, got nil error")
 	}
-
-	if len(plan.Commands) != 1 {
-		t.Fatalf("expected 1 database command, got %d", len(plan.Commands))
-	}
-	if !strings.Contains(plan.Commands[0], "--ignore-table=magento.demo_cron_schedule") {
-		t.Fatalf("expected sync DB dump to use prefixed ignored table, got: %s", plan.Commands[0])
+	if !strings.Contains(err.Error(), "cannot sync database") {
+		t.Fatalf("expected error to explain the DB sync was stopped, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #88

## Summary
- `govard sync --db` used to warn and silently fall back to generic default DB credentials whenever probing the remote for real credentials (.env/env.php) failed, then still ran the dump/import pipe with them.
- That pipe would fail much later, deep inside an `ssh ... | docker exec ...` chain, with a confusing auth/connection error instead of surfacing the actual "couldn't read remote metadata" cause -- and file/media sync could already be underway or complete by then.
- `buildDatabaseSyncAction` now returns the probe error immediately (for both sync directions), which surfaces as a `sync` command failure before the confirmation prompt or any transfer starts, since it runs during plan-building.
- Other callers of `resolveRemoteDBCredentials` (`db connect`, `db query`, `db info`, `db import --stream-db`) are untouched -- they're single, immediately-visible operations, not multi-step pipelines that fail later.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -s -l .` shows no drift
- [x] `go test ./...` (updated `TestSyncPlanScopes` and `TestSyncPlanDatabaseUsesTablePrefixForIgnoredTables` to stay hermetic without depending on a real SSH probe outcome; added `TestSyncPlanDatabaseStopsWhenRemoteCredentialsCannotBeResolved`)