### PR TITLE
fix(cmd): stop unrelated commands from resetting the active profile

### DIFF
--- a/internal/cmd/observability.go
+++ b/internal/cmd/observability.go
@@ -21,6 +21,14 @@ func trackProjectRegistry(config engine.Config, cwd string, command string) erro
 		return nil
 	}
 
+	// previous_profile is only ever set by `config profile switch`/`clear`; preserve it here
+	// so unrelated commands (sync, lock, db, bootstrap, remote, tunnel) don't erase the
+	// bookkeeping that lets `env up` detect and warn about a profile shift.
+	previousProfile := ""
+	if existing, ok := engine.GetProjectRegistryEntry(projectRoot); ok {
+		previousProfile = existing.PreviousProfile
+	}
+
 	entry := engine.ProjectRegistryEntry{
 		Path:             projectRoot,
 		ProjectName:      normalizeProjectName(config.ProjectName, projectRoot),
@@ -31,6 +39,7 @@ func trackProjectRegistry(config engine.Config, cwd string, command string) erro
 		LastSeenAt:       time.Now().UTC(),
 		PHPVersion:       strings.TrimSpace(config.Stack.PHPVersion),
 		Profile:          strings.TrimSpace(config.Profile),
+		PreviousProfile:  previousProfile,
 		FrameworkVersion: strings.TrimSpace(config.FrameworkVersion),
 	}
 	return engine.UpsertProjectRegistryEntry(entry)

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -19,13 +19,7 @@ import (
 )
 
 func loadConfig() engine.Config {
-	wd, _ := os.Getwd()
-	config, _, err := engine.LoadConfigFromDir(wd, false)
-	if err != nil {
-		pterm.Warning.Printf("Failed to load layered config: %v\n", err)
-		return engine.Config{}
-	}
-	return config
+	return loadConfigWithProfile("")
 }
 
 // loadConfigWithProfile loads config with a specific profile (used by env proxy).
@@ -47,7 +41,9 @@ func loadFullConfig() (engine.Config, error) {
 
 func loadFullConfigWithProfile(profile string) (engine.Config, error) {
 	wd, _ := os.Getwd()
-	config, _, err := engine.LoadConfigFromDirWithProfile(wd, true, profile)
+	// Resolve profile: explicit flag > project registry (last-used) > empty (default)
+	resolvedProfile := engine.ResolveEffectiveProfile(wd, profile)
+	config, _, err := engine.LoadConfigFromDirWithProfile(wd, true, resolvedProfile)
 	if err != nil {
 		return engine.Config{}, fmt.Errorf("could not load config: %w", err)
 	}

--- a/tests/profile_persistence_test.go
+++ b/tests/profile_persistence_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"govard/internal/cmd"
+	"govard/internal/engine"
+)
+
+// Reproduces the reported bug: after `govard config profile switch <name>`, running an
+// unrelated command that doesn't take an explicit --profile flag (e.g. `govard lock
+// generate`, `govard sync`, `govard db dump`) silently resets the active profile back
+// to empty in both the project registry and govard.lock, so the next `govard env up`
+// no longer picks up the previously selected profile.
+func TestLockGenerateDoesNotResetActiveProfile(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, ".govard.yml"), []byte(`project_name: demo
+domain: demo.test
+framework: magento2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, ".govard.upgrade.yml"), []byte(`profile: upgrade
+stack:
+  php_version: "8.2"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	registryPath := filepath.Join(t.TempDir(), "projects.json")
+	t.Setenv(engine.ProjectRegistryPathEnvVar, registryPath)
+
+	// Simulate a prior `govard config profile switch upgrade`.
+	if err := engine.UpsertProjectRegistryEntry(engine.ProjectRegistryEntry{
+		Path:    tempDir,
+		Profile: "upgrade",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := cmd.SetLockDependenciesForTest(engine.LockDependencies{
+		ReadDockerVersion:        func() (string, error) { return "27.2.1", nil },
+		ReadDockerComposeVersion: func() (string, error) { return "2.29.7", nil },
+		ReadServiceImages:        func(composePath string) (map[string]string, error) { return map[string]string{}, nil },
+		Now:                      func() time.Time { return time.Date(2026, 2, 20, 12, 0, 0, 0, time.UTC) },
+	})
+	defer restore()
+
+	cwd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run an unrelated command that never passes --profile.
+	root := cmd.RootCommandForTest()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"lock", "generate"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute lock generate: %v", err)
+	}
+
+	entry, ok := engine.GetProjectRegistryEntry(tempDir)
+	if !ok {
+		t.Fatal("expected project registry entry")
+	}
+	if entry.Profile != "upgrade" {
+		t.Fatalf("lock generate reset the active profile in the registry: expected %q, got %q", "upgrade", entry.Profile)
+	}
+
+	lock, err := engine.ReadLockFile(filepath.Join(tempDir, "govard.lock"))
+	if err != nil {
+		t.Fatalf("read generated lockfile: %v", err)
+	}
+	if lock.Project.Profile != "upgrade" {
+		t.Fatalf("lock generate wrote wrong profile into govard.lock: expected %q, got %q", "upgrade", lock.Project.Profile)
+	}
+}
+
+// Reproduces a related bug: any command that records registry activity (sync, lock,
+// db, bootstrap, remote, tunnel) wipes previous_profile because trackProjectRegistry
+// builds a brand-new registry entry without carrying it forward. previous_profile is
+// what lets `govard env up` detect a profile shift and warn about it (e.g. Redis RDB
+// version incompatibilities); silently losing it right after a profile switch defeats
+// that safety net.
+func TestLockGenerateDoesNotResetPreviousProfile(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, ".govard.yml"), []byte(`project_name: demo
+domain: demo.test
+framework: magento2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	registryPath := filepath.Join(t.TempDir(), "projects.json")
+	t.Setenv(engine.ProjectRegistryPathEnvVar, registryPath)
+
+	// Simulate the state right after `govard config profile switch upgrade`:
+	// profile is now "upgrade", previous_profile records what it shifted from.
+	if err := engine.UpsertProjectRegistryEntry(engine.ProjectRegistryEntry{
+		Path:            tempDir,
+		Profile:         "upgrade",
+		PreviousProfile: "staging",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := cmd.SetLockDependenciesForTest(engine.LockDependencies{
+		ReadDockerVersion:        func() (string, error) { return "27.2.1", nil },
+		ReadDockerComposeVersion: func() (string, error) { return "2.29.7", nil },
+		ReadServiceImages:        func(composePath string) (map[string]string, error) { return map[string]string{}, nil },
+		Now:                      func() time.Time { return time.Date(2026, 2, 20, 12, 0, 0, 0, time.UTC) },
+	})
+	defer restore()
+
+	cwd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+
+	root := cmd.RootCommandForTest()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"lock", "generate"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute lock generate: %v", err)
+	}
+
+	entry, ok := engine.GetProjectRegistryEntry(tempDir)
+	if !ok {
+		t.Fatal("expected project registry entry")
+	}
+	if entry.PreviousProfile != "staging" {
+		t.Fatalf("lock generate reset previous_profile: expected %q, got %q", "staging", entry.PreviousProfile)
+	}
+}


### PR DESCRIPTION
Closes #90

## Summary

- `loadFullConfigWithProfile()`/`loadConfig()` in `internal/cmd/utils.go` now resolve the effective profile through `engine.ResolveEffectiveProfile()` (explicit `--profile` > project registry's last-used profile > default), the same way `loadConfigWithProfile()` already did. Previously they silently defaulted to no profile whenever `--profile` wasn't passed.
- `trackProjectRegistry()` in `internal/cmd/observability.go` now preserves the existing registry entry's `previous_profile` instead of wiping it every time any tracked command runs.

## Why

Commands like `sync`, `lock generate`/`lock check`, `bootstrap`, `remote add/exec/test`, `tunnel start`, and `db <subcommand>` (without `--profile`) loaded config with an unresolved empty profile, then wrote that empty value back into `~/.govard/projects.json` (and, for `lock generate`, into `govard.lock`'s `project.profile`) via `trackProjectRegistry()`. That silently erased whatever profile had been selected via `govard config profile switch`, so a later `govard env up` no longer applied it. This is what looked like "upgrading govard resets my profile" — the update itself doesn't touch profile state, but post-upgrade workflows commonly run exactly these commands.

## Test plan

- [x] Added `tests/profile_persistence_test.go`: reproduces both bugs via `govard lock generate` run without `--profile` after a prior profile switch, confirms both fail before the fix and pass after.
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -s -l .` — no drift