### PR TITLE
fix(release): publish macOS govard-desktop archive for self-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       fail-fast: false
+      max-parallel: 1 # serialize: both legs append to the shared release checksums.txt
       matrix:
         arch: [amd64, arm64]
     steps:
@@ -50,10 +51,18 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: Build macOS pkg
+      - name: Build macOS pkg and desktop archive
         run: ./scripts/build-macos-pkg.sh "${GITHUB_REF_NAME}" "${{ matrix.arch }}" dist
 
-      - name: Upload macOS pkg asset
+      - name: Upload macOS assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF_NAME}" dist/*.pkg --clobber
+        run: gh release upload "${GITHUB_REF_NAME}" dist/*.pkg dist/*.tar.gz --clobber
+
+      - name: Append checksums for macOS assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${GITHUB_REF_NAME}" -p checksums.txt -O dist/checksums.txt --clobber
+          (cd dist && shasum -a 256 *.tar.gz >> checksums.txt)
+          gh release upload "${GITHUB_REF_NAME}" dist/checksums.txt --clobber

--- a/scripts/build-macos-pkg.sh
+++ b/scripts/build-macos-pkg.sh
@@ -61,3 +61,13 @@ pkgbuild \
   "$PKG_PATH"
 
 echo "Created: $PKG_PATH"
+
+# `govard self-update` refreshes govard-desktop by downloading
+# govard-desktop_<version>_Darwin_<arch>.tar.gz (same naming as the Linux
+# archive GoReleaser produces) — ship it here since GoReleaser only
+# cross-builds govard-desktop for linux.
+DESKTOP_ARCHIVE_NAME="govard-desktop_${VERSION}_Darwin_${ARCH}.tar.gz"
+DESKTOP_ARCHIVE_PATH="$OUT_DIR/$DESKTOP_ARCHIVE_NAME"
+tar -czf "$DESKTOP_ARCHIVE_PATH" -C "$BIN_DIR" govard-desktop
+
+echo "Created: $DESKTOP_ARCHIVE_PATH"


### PR DESCRIPTION
Closes #92

## Summary

- `govard self-update` on macOS 404s trying to download
  `govard-desktop_<version>_Darwin_<arch>.tar.gz` — GoReleaser only
  cross-builds `govard-desktop` for Linux, so that archive was never
  published for Darwin, even though `build-macos-pkg.sh` already compiles
  the exact binary for the `.pkg` installer. Confirmed against the live
  `v1.59.0` release assets.
- `scripts/build-macos-pkg.sh` now also produces
  `govard-desktop_<version>_Darwin_<arch>.tar.gz` from the binary it
  already builds.
- `.github/workflows/release.yml`'s `macos-pkg` job uploads that archive
  alongside the `.pkg` and appends its checksum to the release's
  `checksums.txt` (verified by `self-update`). The two arch matrix legs
  now run serialized (`max-parallel: 1`) since both append to the same
  shared `checksums.txt`.

This fixes it going forward, starting with the next tagged release — it
does not backfill already-published releases (e.g. v1.59.0).

## Test plan

- [x] `bash -n scripts/build-macos-pkg.sh` (syntax check; `pkgbuild`/macOS
      toolchain isn't available to fully execute outside CI)
- [x] YAML validated (`yaml.safe_load`)
- [ ] Verify on the next tagged release: `govard-desktop_<version>_Darwin_amd64.tar.gz`
      and `_arm64.tar.gz` appear as release assets, `checksums.txt` has entries
      for them, and `sudo govard self-update` succeeds on macOS with the
      desktop app installed