### PR TITLE
fix(engine): stop docker image pull noise from breaking volume check

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os/exec"
@@ -174,9 +175,16 @@ func IsVolumeEmpty(volumeName string) (bool, error) {
 	// Run a tiny container to check for files
 	// We skip 'lost+found' if it exists
 	cmd := exec.Command("docker", "run", "--rm", "-v", fmt.Sprintf("%s:/data:ro", volumeName), "alpine", "sh", "-c", "ls -A /data | grep -v 'lost+found' | wc -l")
-	output, err := cmd.CombinedOutput()
+	// Use Output() (stdout only): if the alpine image isn't cached yet, `docker run`
+	// writes its pull progress to stderr, which CombinedOutput() would otherwise mix
+	// into the count we're about to parse.
+	output, err := cmd.Output()
 	if err != nil {
-		return false, fmt.Errorf("failed to check volume: %w (%s)", err, strings.TrimSpace(string(output)))
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, fmt.Errorf("failed to check volume: %w (%s)", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return false, fmt.Errorf("failed to check volume: %w", err)
 	}
 
 	countStr := strings.TrimSpace(string(output))


### PR DESCRIPTION
## Summary
- `IsVolumeEmpty` used `cmd.CombinedOutput()`, which mixes the container's stdout with `docker run`'s stderr. When `alpine:latest` isn't cached locally, Docker writes pull progress to stderr, corrupting the numeric output the code expects and breaking `strconv.Atoi` parsing — intermittently, only when the image isn't already cached.
- Switched to `cmd.Output()` so only real stdout is parsed; stderr is still captured via `exec.ExitError` and included in the error message on genuine command failures.

Closes #96

## Test plan
- [x] Reproduced the exact reported error by removing `alpine:latest` locally and running the existing integration test (`tests/volume_check_test.go`) against unfixed code — failed with the same message.
- [x] Re-ran the same test against the fix — passes.
- [x] `go build ./...`, `go vet ./internal/engine/...`, `gofmt -s -l internal/engine/docker.go` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)