### PR TITLE
fix(runtime): don't abort php entrypoint on CHOWN_DIR_LIST failure

### DIFF
--- a/docker/php/etc/entrypoint.sh
+++ b/docker/php/etc/entrypoint.sh
@@ -42,12 +42,18 @@ if [ -n "${PUID:-}" ]; then
   fi
 fi
 
-# Apply recursive chown if requested
+# Apply recursive chown if requested. On some bind-mount backends (e.g.
+# Docker Desktop for Mac), chown can be refused for individual paths owned by
+# a UID that doesn't match the host session, for reasons outside this
+# script's control. That must not abort the whole entrypoint: combined with
+# `set -e` above, an unguarded failure here would prevent php-fpm from ever
+# starting, so any such failure is logged as a warning instead.
 if [ -n "${CHOWN_DIR_LIST:-}" ]; then
   for dir in ${CHOWN_DIR_LIST}; do
     if [ -d "${dir}" ]; then
       echo "Fixing permissions for ${dir}..."
-      sudo chown -R www-data:www-data "${dir}"
+      sudo chown -R www-data:www-data "${dir}" || \
+        echo "Warning: could not fix ownership for some paths under ${dir}; continuing." >&2
     fi
   done
 fi

--- a/tests/php_runtime_cron_support_test.go
+++ b/tests/php_runtime_cron_support_test.go
@@ -95,6 +95,16 @@ func TestPHPEntrypointReentersAsRootBeforeUIDRemap(t *testing.T) {
 	}
 }
 
+func TestPHPEntrypointDoesNotAbortOnChownDirListFailure(t *testing.T) {
+	content := readProjectFileForTest(t, filepath.Join("docker", "php", "etc", "entrypoint.sh"))
+	if !strings.Contains(content, "sudo chown -R www-data:www-data \"${dir}\" || \\") {
+		t.Fatalf("expected php entrypoint to guard the CHOWN_DIR_LIST chown against failure, got:\n%s", content)
+	}
+	if !strings.Contains(content, "Warning: could not fix ownership for some paths under ${dir}; continuing.") {
+		t.Fatalf("expected php entrypoint to warn instead of aborting (set -e) when the CHOWN_DIR_LIST chown fails, got:\n%s", content)
+	}
+}
+
 func TestPHPEntrypointStartsCrondBestEffort(t *testing.T) {
 	content := readProjectFileForTest(t, filepath.Join("docker", "php", "etc", "entrypoint.sh"))
 	if !strings.Contains(content, "sudo crond 2>/dev/null || true") {


### PR DESCRIPTION
## Summary

- On Docker Desktop for Mac bind mounts, `chown` can be refused for a path whose current owner UID doesn't match the host session (most commonly nested `.git` internals from a Composer VCS-installed package under `vendor/`, or files synced from a remote host with different numeric ownership).
- `docker/php/etc/entrypoint.sh` runs the whole script under `set -e` and had no failure guard on the `CHOWN_DIR_LIST` recursive chown, so a single such permission failure aborted the entrypoint before `php-fpm` was ever `exec`'d — leaving the readiness probe timing out with `111:Connection refused`.
- Guards that chown so any failure (regardless of which path caused it) logs a warning and the entrypoint continues to start php-fpm.

Closes #98

## Rationale

Root-cause debugging is in #98. The chown-fixup step is a best-effort convenience (matching the existing pattern already used elsewhere in this same file for UID/GID remap failures, `crond`, and CA trust refresh) — it should never be able to block container startup entirely, regardless of which specific file or directory triggers the underlying host/bind-mount ownership restriction.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -s -l .` shows no drift
- [x] `go test ./...` passes
- [x] Added `TestPHPEntrypointDoesNotAbortOnChownDirListFailure` asserting the chown is guarded and the failure path is a warning, not a `set -e` abort