### PR TITLE
fix(engine): avoid chowning bind-mounted project files

### DIFF
--- a/internal/blueprints/files/includes/base.yml
+++ b/internal/blueprints/files/includes/base.yml
@@ -53,7 +53,7 @@ services:
       {{ end }}
       - PUID={{ .Config.Stack.UserID }}
       - PGID={{ .Config.Stack.GroupID }}
-      - CHOWN_DIR_LIST="{{ range $i, $dir := .Config.Stack.ChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
+      - CHOWN_DIR_LIST="{{ range $i, $dir := .EntrypointChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
 
   {{ if $isHybrid }}
   apache:
@@ -78,7 +78,7 @@ services:
       - APACHE_XDEBUG_SESSION={{ .XdebugSessionPattern }}
       - PUID={{ .Config.Stack.UserID }}
       - PGID={{ .Config.Stack.GroupID }}
-      - CHOWN_DIR_LIST="{{ range $i, $dir := .Config.Stack.ChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
+      - CHOWN_DIR_LIST="{{ range $i, $dir := .EntrypointChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
   {{ end }}
 
   {{ if .RequiresPHP }}
@@ -125,7 +125,7 @@ services:
       NODE_VERSION: "{{ .Config.Stack.NodeVersion }}"
       PUID: {{ .Config.Stack.UserID }}
       PGID: {{ .Config.Stack.GroupID }}
-      CHOWN_DIR_LIST: "{{ range $i, $dir := .Config.Stack.ChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
+      CHOWN_DIR_LIST: "{{ range $i, $dir := .EntrypointChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "mail:host-gateway"
@@ -196,7 +196,7 @@ services:
       COMPOSER_VERSION: "{{ .ComposerVersion }}"
       PUID: {{ .Config.Stack.UserID }}
       PGID: {{ .Config.Stack.GroupID }}
-      CHOWN_DIR_LIST: "{{ range $i, $dir := .Config.Stack.ChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
+      CHOWN_DIR_LIST: "{{ range $i, $dir := .EntrypointChownDirList }}{{ if $i }} {{ end }}{{ $dir }}{{ end }}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "mail:host-gateway"

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"fmt"
-	"govard/internal/conventions"
 	"sort"
 	"strings"
 )
@@ -133,15 +132,10 @@ func (c Config) ResolveProjectExecUser(fallback string) string {
 	return fallback
 }
 
-// GetDefaultChownDirList returns the standard list of directories that require
-// consistent ownership for developer workflows. For instance, Magento 2 projects
-// require /var/www/html to be writable for generated code and static assets.
+// GetDefaultChownDirList returns internal directories that need consistent
+// ownership. Project sources and host caches rely on UID/GID mapping instead.
 func GetDefaultChownDirList(framework string) []string {
 	// Note: /home/www-data/.ssh is intentionally NOT included here.
 	// The SSH directory is always mounted :ro, so chown would fail.
-	list := []string{"/bash_history"}
-	if framework == "magento2" || framework == "mageos" {
-		list = append(list, conventions.DefaultWorkDir, conventions.HomeWWWData+"/.cache/composer")
-	}
-	return list
+	return []string{"/bash_history"}
 }

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"govard/internal/conventions"
 	"sort"
 	"strings"
 )
@@ -132,10 +133,24 @@ func (c Config) ResolveProjectExecUser(fallback string) string {
 	return fallback
 }
 
-// GetDefaultChownDirList returns internal directories that need consistent
-// ownership. Project sources and host caches rely on UID/GID mapping instead.
+// GetDefaultChownDirList returns directories that may need ownership repair.
 func GetDefaultChownDirList(framework string) []string {
 	// Note: /home/www-data/.ssh is intentionally NOT included here.
 	// The SSH directory is always mounted :ro, so chown would fail.
-	return []string{"/bash_history"}
+	list := []string{"/bash_history"}
+	if framework == "magento2" || framework == "mageos" {
+		list = append(list, conventions.DefaultWorkDir, conventions.HomeWWWData+"/.cache/composer")
+	}
+	return list
+}
+
+// GetEntrypointChownDirList excludes bind mounts that rely on UID/GID mapping.
+func GetEntrypointChownDirList(dirs []string) []string {
+	result := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		if dir != conventions.DefaultWorkDir && dir != conventions.HomeWWWData+"/.cache/composer" {
+			result = append(result, dir)
+		}
+	}
+	return result
 }

--- a/internal/engine/render.go
+++ b/internal/engine/render.go
@@ -31,6 +31,7 @@ func renderTemplateFuncMap() template.FuncMap {
 // RenderData holds all data needed for template rendering
 type RenderData struct {
 	Config                 Config
+	EntrypointChownDirList []string
 	RequiresPHP            bool
 	NGINXPublic            string
 	NGINXTemplate          string
@@ -414,21 +415,22 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 
 	// Prepare render data
 	renderData := RenderData{
-		Config:               config,
-		RequiresPHP:          RequiresPHP(config),
-		NGINXPublic:          fwConfig.NGINXPUBLIC,
-		NGINXTemplate:        fwConfig.NGINXTemplate,
-		DatabaseName:         fwConfig.DatabaseName,
-		ImageRepository:      imageRepo,
-		XdebugSessionPattern: buildXdebugSessionPattern(config.Stack.XdebugSession),
-		VarnishVclPath:       filepath.Join(GovardHomeDir(), "varnish", config.ProjectName, "default.vcl"),
-		RabbitMQConfPath:     filepath.Join(GovardHomeDir(), "rabbitmq", config.ProjectName, "rabbitmq.conf"),
-		PackageManager:       packageManager,
-		ComposerVersion:      config.Stack.ComposerVersion,
-		RuntimeDomainHosts:   runtimeDomainHosts,
-		HostGovardRootCAPath: govardRootCAPath,
-		WorkDir:              conventions.DefaultWorkDir,
-		HomeWWWData:          conventions.HomeWWWData,
+		Config:                 config,
+		EntrypointChownDirList: GetEntrypointChownDirList(config.Stack.ChownDirList),
+		RequiresPHP:            RequiresPHP(config),
+		NGINXPublic:            fwConfig.NGINXPUBLIC,
+		NGINXTemplate:          fwConfig.NGINXTemplate,
+		DatabaseName:           fwConfig.DatabaseName,
+		ImageRepository:        imageRepo,
+		XdebugSessionPattern:   buildXdebugSessionPattern(config.Stack.XdebugSession),
+		VarnishVclPath:         filepath.Join(GovardHomeDir(), "varnish", config.ProjectName, "default.vcl"),
+		RabbitMQConfPath:       filepath.Join(GovardHomeDir(), "rabbitmq", config.ProjectName, "rabbitmq.conf"),
+		PackageManager:         packageManager,
+		ComposerVersion:        config.Stack.ComposerVersion,
+		RuntimeDomainHosts:     runtimeDomainHosts,
+		HostGovardRootCAPath:   govardRootCAPath,
+		WorkDir:                conventions.DefaultWorkDir,
+		HomeWWWData:            conventions.HomeWWWData,
 	}
 	if config.Stack.WebRoot != "" {
 		renderData.NGINXPublic = config.Stack.WebRoot

--- a/tests/config_defaults_test.go
+++ b/tests/config_defaults_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"govard/internal/engine"
+	"slices"
 	"strings"
 	"testing"
 
@@ -17,12 +18,12 @@ func TestNormalizeConfigChownDirListDefaults(t *testing.T) {
 		{
 			name:      "Magento 2 defaults",
 			framework: "magento2",
-			want:      []string{"/bash_history"},
+			want:      []string{"/bash_history", "/var/www/html", "/home/www-data/.cache/composer"},
 		},
 		{
 			name:      "Mage-OS defaults",
 			framework: "mageos",
-			want:      []string{"/bash_history"},
+			want:      []string{"/bash_history", "/var/www/html", "/home/www-data/.cache/composer"},
 		},
 		{
 			name:      "Generic framework defaults",
@@ -53,7 +54,7 @@ func TestPrepareConfigForWriteOmitsDefaultChownDirList(t *testing.T) {
 	config := engine.Config{
 		Framework: "magento2",
 		Stack: engine.Stack{
-			ChownDirList: []string{"/bash_history"},
+			ChownDirList: []string{"/bash_history", "/var/www/html", "/home/www-data/.cache/composer"},
 		},
 	}
 
@@ -69,6 +70,15 @@ func TestPrepareConfigForWriteOmitsDefaultChownDirList(t *testing.T) {
 	content := string(data)
 	if strings.Contains(content, "chown_dir_list:") {
 		t.Fatalf("expected serialized config to omit chown_dir_list, got:\n%s", content)
+	}
+}
+
+func TestEntrypointChownDirListExcludesBindMounts(t *testing.T) {
+	dirs := []string{"/bash_history", "/var/www/html", "/home/www-data/.cache/composer", "/custom"}
+	want := []string{"/bash_history", "/custom"}
+	got := engine.GetEntrypointChownDirList(dirs)
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected entrypoint chown dirs %v, got %v", want, got)
 	}
 }
 

--- a/tests/config_defaults_test.go
+++ b/tests/config_defaults_test.go
@@ -17,12 +17,12 @@ func TestNormalizeConfigChownDirListDefaults(t *testing.T) {
 		{
 			name:      "Magento 2 defaults",
 			framework: "magento2",
-			want:      []string{"/bash_history", "/var/www/html", "/home/www-data/.cache/composer"},
+			want:      []string{"/bash_history"},
 		},
 		{
 			name:      "Mage-OS defaults",
 			framework: "mageos",
-			want:      []string{"/bash_history", "/var/www/html", "/home/www-data/.cache/composer"},
+			want:      []string{"/bash_history"},
 		},
 		{
 			name:      "Generic framework defaults",
@@ -53,7 +53,7 @@ func TestPrepareConfigForWriteOmitsDefaultChownDirList(t *testing.T) {
 	config := engine.Config{
 		Framework: "magento2",
 		Stack: engine.Stack{
-			ChownDirList: []string{"/bash_history", "/var/www/html", "/home/www-data/.cache/composer"},
+			ChownDirList: []string{"/bash_history"},
 		},
 	}
 

--- a/tests/testdata/framework_snapshots/magento2/compose.yml
+++ b/tests/testdata/framework_snapshots/magento2/compose.yml
@@ -19,7 +19,7 @@ services:
             - db-data:/var/lib/mysql
     php:
         environment:
-            CHOWN_DIR_LIST: /bash_history /var/www/html /home/www-data/.cache/composer
+            CHOWN_DIR_LIST: /bash_history
             COMPOSER_CACHE_DIR: /home/www-data/.cache/composer
             COMPOSER_HOME: /home/www-data/.composer
             COMPOSER_VERSION: latest
@@ -45,7 +45,7 @@ services:
             - NGINX_TEMPLATE=magento2.conf
             - PUID=1000
             - PGID=1000
-            - CHOWN_DIR_LIST="/bash_history /var/www/html /home/www-data/.cache/composer"
+            - CHOWN_DIR_LIST="/bash_history"
         hostname: snapshot-magento2-web
         image: ddtcorex/govard-nginx:1.28
         networks:

--- a/tests/testdata/framework_snapshots/mageos/compose.yml
+++ b/tests/testdata/framework_snapshots/mageos/compose.yml
@@ -19,7 +19,7 @@ services:
             - db-data:/var/lib/mysql
     php:
         environment:
-            CHOWN_DIR_LIST: /bash_history /var/www/html /home/www-data/.cache/composer
+            CHOWN_DIR_LIST: /bash_history
             COMPOSER_CACHE_DIR: /home/www-data/.cache/composer
             COMPOSER_HOME: /home/www-data/.composer
             COMPOSER_VERSION: latest
@@ -45,7 +45,7 @@ services:
             - NGINX_TEMPLATE=magento2.conf
             - PUID=1000
             - PGID=1000
-            - CHOWN_DIR_LIST="/bash_history /var/www/html /home/www-data/.cache/composer"
+            - CHOWN_DIR_LIST="/bash_history"
         hostname: snapshot-mageos-web
         image: ddtcorex/govard-nginx:1.28
         networks:


### PR DESCRIPTION
## Summary
- keep Magento project and Composer cache paths available to post-sync/bootstrap permission repair
- exclude those bind mounts only from boot-time `CHOWN_DIR_LIST`
- continue passing internal/custom directories to container entrypoints

## Context
#99 already makes entrypoint chown failures non-fatal. This PR is a follow-up that avoids walking large Docker Desktop bind mounts at container startup, preventing wasted work and repeated permission warnings while preserving `FixProjectPermissions` behavior after sync/bootstrap.

The Composer cache remains in the shared repair list for Linux or mixed-ownership recovery, but is excluded from startup chown because normal container access relies on PUID/PGID mapping.

## Tests
- focused config, entrypoint-filter, and golden snapshot tests
- full suite excluding two existing macOS temp-path alias assertions
- `go build ./cmd/govard`