### PR TITLE
feat: support CLI-only Govard installs on Ubuntu 20.04

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,11 +59,10 @@ checksum:
   name_template: checksums.txt
 
 nfpms:
-  - id: govard-installer
+  - id: govard-cli
     package_name: govard
     ids:
       - govard
-      - govard-desktop
     formats:
       - deb
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -71,12 +70,31 @@ nfpms:
     maintainer: DDTCoreX <kaido4492@gmail.com>
     vendor: DDTCoreX
     homepage: https://github.com/ddtcorex/govard
-    description: Govard local development orchestrator with CLI and Desktop modes
+    description: Govard local development orchestrator CLI
     license: MIT
     section: utils
     priority: optional
     dependencies:
       - ca-certificates
+      - libnss3-tools
+
+  - id: govard-desktop
+    package_name: govard-desktop
+    ids:
+      - govard-desktop
+    formats:
+      - deb
+    file_name_template: "govard-desktop_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    bindir: /usr/local/bin
+    maintainer: DDTCoreX <kaido4492@gmail.com>
+    vendor: DDTCoreX
+    homepage: https://github.com/ddtcorex/govard
+    description: Govard Desktop application
+    license: MIT
+    section: utils
+    priority: optional
+    dependencies:
+      - govard
       - libwebkit2gtk-4.1-0
       - libgtk-3-0
       - libnss3-tools

--- a/README.md
+++ b/README.md
@@ -85,30 +85,39 @@ curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh |
 
 # Install building from source (auto-installs Go 1.25 if needed)
 curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --source
+
+# Install CLI only (required on Ubuntu 20.04)
+curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --cli-only
 ```
 
-By default this installs both `govard` and `govard-desktop` to `/usr/local/bin`, automatically detects/installs missing system dependencies (`certutil`, `WebKitGTK`), starts global services, and configures SSL trust.
-On Linux, if a standalone `govard-desktop` archive is missing in a release, the installer falls back to extracting `govard-desktop` from the release `.deb` package.
+By default the installer installs `govard` (CLI) and, where `WebKitGTK 4.1` is available, `govard-desktop` to `/usr/local/bin`. On Ubuntu 20.04 the required WebKitGTK version is unavailable, so the installer automatically installs CLI only. Use `--cli-only` to explicitly skip Desktop on any platform.
+
+The installer automatically handles required system dependencies, starts global services, and configures SSL trust. On Linux, if a standalone `govard-desktop` archive is missing, it falls back to the separate Desktop `.deb` package.
 
 Do not mix install channels on the same machine (for example: `.deb` + `make install` + `self-update` across different paths).  
 Use one channel only, otherwise you can end up with conflicting binaries in `/usr/bin` and `/usr/local/bin`.
 
-### Release Installers (CLI + Desktop)
+### Release Installers
 
-Every tagged release now publishes installer packages that install both:
+Every tagged release publishes these Linux packages:
 
-- `govard` (CLI)
-- `govard-desktop` (Desktop runtime used by `govard desktop`)
+- `govard_<version>_linux_<arch>.deb` — CLI only; supports Ubuntu 20.04.
+- `govard-desktop_<version>_linux_<arch>.deb` — Desktop add-on; requires `WebKitGTK 4.1` (Ubuntu 22.04+).
 
 From the release page:
 
-- Linux: `govard_<version>_linux_<arch>.deb`
 - macOS: `govard_<version>_Darwin_<arch>.pkg`
 
-Linux (`.deb`) example:
+Linux CLI-only example:
 
 ```bash
-sudo dpkg -i govard_<version>_linux_amd64.deb
+sudo apt install ./govard_<version>_linux_<arch>.deb
+```
+
+Linux CLI + Desktop example:
+
+```bash
+sudo apt install ./govard_<version>_linux_<arch>.deb ./govard-desktop_<version>_linux_<arch>.deb
 ```
 
 macOS (`.pkg`) example:

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -171,7 +171,8 @@ Desktop operations call the CLI command surface directly (e.g., `govard up`, `go
 | Artifact | Description |
 | :--- | :--- |
 | Platform archives | CLI binaries via GoReleaser (`.tar.gz` / `.zip`) |
-| `govard_<version>_linux_<arch>.deb` | Linux installer with `govard` + `govard-desktop` |
+| `govard_<version>_linux_<arch>.deb` | Linux installer containing the `govard` CLI |
+| `govard-desktop_<version>_linux_<arch>.deb` | Linux Desktop add-on; depends on the CLI package and WebKitGTK 4.1 |
 | `govard_<version>_Darwin_<arch>.pkg` | macOS installer with `govard` + `govard-desktop` |
 | `checksums.txt` | SHA-256 checksums for all artifacts |
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -35,26 +35,39 @@ curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh |
 
 # Build from source (auto-installs Go 1.25 if needed)
 curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --source
+
+# Install CLI only (required on Ubuntu 20.04)
+curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --cli-only
 ```
 
-By default, this installs both `govard` and `govard-desktop` to `/usr/local/bin` and:
-- Auto-detects/installs missing system dependencies (`certutil`, `WebKitGTK`)
+By default, this installs `govard` (CLI) and, where `WebKitGTK 4.1` is available, `govard-desktop` to `/usr/local/bin` and:
+- Auto-detects/installs missing system dependencies
 - Starts global services
 - Configures SSL trust
-- On Linux, falls back to extracting `govard-desktop` from the `.deb` package if a standalone archive is not in the release
+- On Linux, falls back to the separate `govard-desktop` `.deb` package if a standalone archive is not in the release
+
+Ubuntu 20.04 does not provide WebKitGTK 4.1. The installer detects this and installs CLI only automatically; use `--cli-only` to explicitly skip Desktop on any platform. Govard Desktop requires Ubuntu 22.04+ or another Linux distribution with WebKitGTK 4.1.
 
 ---
 
-## 📦 Release Installers (CLI + Desktop)
+## 📦 Release Installers
 
-Every tagged release publishes installer packages that include both `govard` (CLI) and `govard-desktop`.
+Every tagged release publishes two Linux packages:
 
 From the [releases page](https://github.com/ddtcorex/govard/releases):
 
 ### Linux (`.deb`)
 
+CLI only (including Ubuntu 20.04):
+
 ```bash
-sudo dpkg -i govard_<version>_linux_amd64.deb
+sudo apt install ./govard_<version>_linux_<arch>.deb
+```
+
+CLI + Desktop (WebKitGTK 4.1 / Ubuntu 22.04+):
+
+```bash
+sudo apt install ./govard_<version>_linux_<arch>.deb ./govard-desktop_<version>_linux_<arch>.deb
 ```
 
 ### macOS (`.pkg`)
@@ -154,4 +167,3 @@ govard doctor
 ---
 
 **[← Home](/)** | **[Getting Started →](/getting-started/getting-started)**
-

--- a/docs/vi/developer/architecture.md
+++ b/docs/vi/developer/architecture.md
@@ -171,7 +171,8 @@ Các thao tác trên Desktop gọi trực tiếp tới tầng CLI (ví dụ: `go
 | Artifact | Mô tả |
 | :--- | :--- |
 | Bản nén theo nền tảng | Binary CLI build qua GoReleaser (`.tar.gz` / `.zip`) |
-| `govard_<version>_linux_<arch>.deb` | Gói cài đặt Linux chứa cả `govard` + `govard-desktop` |
+| `govard_<version>_linux_<arch>.deb` | Gói cài đặt Linux chứa CLI `govard` |
+| `govard-desktop_<version>_linux_<arch>.deb` | Gói Desktop Linux bổ sung; phụ thuộc package CLI và WebKitGTK 4.1 |
 | `govard_<version>_Darwin_<arch>.pkg` | Gói cài đặt macOS chứa cả `govard` + `govard-desktop` |
 | `checksums.txt` | File mã băm SHA-256 xác minh cho mọi artifact phát hành |
 

--- a/docs/vi/getting-started/installation.md
+++ b/docs/vi/getting-started/installation.md
@@ -35,26 +35,39 @@ curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh |
 
 # Build từ source (tự động cài Go 1.25 nếu cần)
 curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --source
+
+# Chỉ cài CLI (bắt buộc với Ubuntu 20.04)
+curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --cli-only
 ```
 
-Mặc định, script sẽ cài đặt cả `govard` (CLI) và `govard-desktop` (Desktop app) vào `/usr/local/bin` và:
-- Tự động phát hiện và cài đặt các system dependencies còn thiếu (`certutil`, `WebKitGTK`).
+Mặc định, script sẽ cài `govard` (CLI) và, khi có `WebKitGTK 4.1`, cả `govard-desktop` (Desktop app) vào `/usr/local/bin` rồi:
+- Tự động phát hiện và cài đặt system dependencies cần thiết.
 - Khởi chạy các global services.
 - Cấu hình SSL trust.
-- Trên Linux, tự động fallback sang giải nén `govard-desktop` từ package `.deb` nếu file nén archive độc lập không có sẵn trong bản release.
+- Trên Linux, tự động fallback sang package `.deb` riêng của `govard-desktop` nếu archive độc lập không có sẵn trong bản release.
+
+Ubuntu 20.04 không có WebKitGTK 4.1. Script sẽ tự nhận diện và chỉ cài CLI; dùng `--cli-only` để chủ động bỏ qua Desktop trên mọi nền tảng. Govard Desktop yêu cầu Ubuntu 22.04+ hoặc một bản Linux khác có WebKitGTK 4.1.
 
 ---
 
-## 📦 Release Installers (CLI + Desktop)
+## 📦 Release Installers
 
-Mỗi release được gắn tag đều publish các package cài đặt bao gồm cả `govard` (CLI) và `govard-desktop`.
+Mỗi release được gắn tag đều publish hai package Linux riêng biệt.
 
 Tải từ [trang releases](https://github.com/ddtcorex/govard/releases):
 
 ### Linux (`.deb`)
 
+Chỉ CLI (bao gồm Ubuntu 20.04):
+
 ```bash
-sudo dpkg -i govard_<version>_linux_amd64.deb
+sudo apt install ./govard_<version>_linux_<arch>.deb
+```
+
+CLI + Desktop (WebKitGTK 4.1 / Ubuntu 22.04+):
+
+```bash
+sudo apt install ./govard_<version>_linux_<arch>.deb ./govard-desktop_<version>_linux_<arch>.deb
 ```
 
 ### macOS (`.pkg`)

--- a/install.sh
+++ b/install.sh
@@ -29,10 +29,12 @@ INSTALL_DIR="/usr/local/bin"
 GOVARD_DIR="/opt/govard"
 MIN_GO_VERSION="1.25.0"
 SOURCE_MODE=false
+CLI_ONLY=false
 FORCE_YES=false
 SPECIFIC_VERSION=""
 SOURCE_DIR=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${0}}")" && pwd)"
+WEBKITGTK_PACKAGE="libwebkit2gtk-4.1-0"
 
 desktop_build_tags() {
     local tags="desktop production"
@@ -85,6 +87,7 @@ Usage: install.sh [options]
 Options:
   --source       Build from source instead of downloading binary
   --source-dir <path>  Build from a specific local source directory (requires --source)
+  --cli-only     Install Govard CLI without the Desktop application
   --local        Install to ~/.local/bin (no sudo)
   --dir <path>   Custom installation directory
   --version <v>  Install specific version (e.g. v1.9.0)
@@ -99,6 +102,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --source) SOURCE_MODE=true; shift ;;
         --source-dir) SOURCE_DIR="$2"; shift 2 ;;
+        --cli-only) CLI_ONLY=true; shift ;;
         --local)  INSTALL_DIR="${HOME}/.local/bin"; shift ;;
         --dir)    INSTALL_DIR="$2"; shift 2 ;;
         --version) SPECIFIC_VERSION="$2"; shift 2 ;;
@@ -117,6 +121,54 @@ detect_env() {
         *) error "Unsupported architecture: $ARCH" ;;
     esac
     info "Detected Environment: $OS/$ARCH"
+}
+
+desktop_runtime_available() {
+    if command -v ldconfig >/dev/null 2>&1 && [[ "$(ldconfig -p 2>/dev/null)" == *"libwebkit2gtk-4.1"* ]]; then
+        return 0
+    fi
+
+    [[ -f "/usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so.0" ]] || [[ -f "/usr/lib/libwebkit2gtk-4.1.so.0" ]]
+}
+
+apt_lists_populated() {
+    local lists_dir="/var/lib/apt/lists"
+    [[ -d "$lists_dir" ]] && find "$lists_dir" -maxdepth 1 -type f ! -name lock 2>/dev/null | grep -q .
+}
+
+desktop_install_enabled() {
+    [[ "$CLI_ONLY" != true ]] || return 1
+    [[ "$OS" != linux ]] && return 0
+
+    if command -v apt-cache >/dev/null 2>&1; then
+        if apt-cache show "$WEBKITGTK_PACKAGE" >/dev/null 2>&1; then
+            return 0
+        fi
+
+        if apt_lists_populated; then
+            return 1
+        fi
+
+        # APT package lists are empty (e.g. a freshly provisioned host that
+        # never ran apt-get update) — refresh once before concluding the
+        # package is genuinely unavailable.
+        sudo apt-get update >/dev/null 2>&1 || true
+        apt-cache show "$WEBKITGTK_PACKAGE" >/dev/null 2>&1
+        return
+    fi
+
+    desktop_runtime_available
+}
+
+configure_desktop_install() {
+    if desktop_install_enabled; then
+        return 0
+    fi
+
+    if [[ "$CLI_ONLY" != true ]]; then
+        warn "WebKitGTK 4.1 is unavailable; installing Govard CLI only. Govard Desktop requires a newer Linux distribution."
+    fi
+    CLI_ONLY=true
 }
 
 check_dependencies() {
@@ -157,14 +209,14 @@ check_dependencies() {
             missing_deps+=("libnss3-tools")
         fi
 
-        # Check WebKitGTK
-        if command -v ldconfig >/dev/null 2>&1 && ldconfig -p | grep -q "libwebkit2gtk-4.1"; then
-            success "  WebKitGTK: Found"
-        elif [[ -f "/usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so.0" ]] || [[ -f "/usr/lib/libwebkit2gtk-4.1.so.0" ]]; then
-            success "  WebKitGTK: Found (via file check)"
-        else
-            warn "  WebKitGTK: Not found (Required for Desktop App)"
-            missing_deps+=("libwebkit2gtk-4.1-0")
+        if [[ "$CLI_ONLY" == false ]]; then
+            # Check WebKitGTK
+            if desktop_runtime_available; then
+                success "  WebKitGTK: Found"
+            else
+                warn "  WebKitGTK: Not found (Required for Desktop App)"
+                missing_deps+=("$WEBKITGTK_PACKAGE")
+            fi
         fi
 
         if [[ ${#missing_deps[@]} -gt 0 ]]; then
@@ -434,34 +486,65 @@ resolve_version() {
 }
 
 install_via_deb() {
-    local deb_name="govard_${VERSION_NO_V}_linux_${ARCH}.deb"
-    local deb_url="https://github.com/${REPO}/releases/download/${SPECIFIC_VERSION}/${deb_name}"
+    local cli_deb_name="govard_${VERSION_NO_V}_linux_${ARCH}.deb"
+    local cli_deb_url="https://github.com/${REPO}/releases/download/${SPECIFIC_VERSION}/${cli_deb_name}"
     local tmp_dir
     tmp_dir=$(mktemp -d)
-    local deb_path="${tmp_dir}/${deb_name}"
+    local cli_deb_path="${tmp_dir}/${cli_deb_name}"
 
-    info "Downloading ${deb_name}..."
-    if ! curl -fsSL "$deb_url" -o "$deb_path"; then
-        warn "Failed to download ${deb_name}."
+    info "Downloading ${cli_deb_name}..."
+    if ! curl -fsSL "$cli_deb_url" -o "$cli_deb_path"; then
+        warn "Failed to download ${cli_deb_name}."
         rm -rf "$tmp_dir"
         return 1
     fi
 
-    info "Installing via dpkg..."
-    if sudo dpkg -i "$deb_path"; then
+    if [[ "$CLI_ONLY" == true ]]; then
+        info "Installing Govard CLI via APT..."
+        if sudo apt-get install -y "$cli_deb_path"; then
+            rm -rf "$tmp_dir"
+            success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
+            return 0
+        fi
+
+        warn "Govard CLI Debian package installation failed."
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    local desktop_deb_name="govard-desktop_${VERSION_NO_V}_linux_${ARCH}.deb"
+    local desktop_deb_url="https://github.com/${REPO}/releases/download/${SPECIFIC_VERSION}/${desktop_deb_name}"
+    local desktop_deb_path="${tmp_dir}/${desktop_deb_name}"
+
+    info "Downloading ${desktop_deb_name}..."
+    if ! curl -fsSL "$desktop_deb_url" -o "$desktop_deb_path"; then
+        warn "Failed to download ${desktop_deb_name}; installing Govard CLI only."
+        if sudo apt-get install -y "$cli_deb_path"; then
+            rm -rf "$tmp_dir"
+            success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
+            return 0
+        fi
+
+        warn "Govard CLI Debian package installation failed."
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    info "Installing Govard CLI and Desktop via APT..."
+    if sudo apt-get install -y "$cli_deb_path" "$desktop_deb_path"; then
         rm -rf "$tmp_dir"
         success "Govard $SPECIFIC_VERSION installed via Debian package (CLI + Desktop)!"
         return 0
     fi
 
-    warn "dpkg -i failed. Attempting to fix missing dependencies..."
-    if sudo apt-get install -f -y 2>/dev/null; then
+    warn "Govard Desktop Debian package installation failed; installing Govard CLI only."
+    if sudo apt-get install -y "$cli_deb_path"; then
         rm -rf "$tmp_dir"
-        success "Govard $SPECIFIC_VERSION installed via Debian package (CLI + Desktop)!"
+        success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
         return 0
     fi
 
-    warn "Debian package installation failed."
+    warn "Govard CLI Debian package installation failed."
     rm -rf "$tmp_dir"
     return 1
 }
@@ -483,7 +566,10 @@ install_binary() {
     OS_CAP="$(echo "${OS:0:1}" | tr '[:lower:]' '[:upper:]')${OS:1}"
 
     TMP_DIR=$(mktemp -d)
-    binaries=("$CLI_BINARY_NAME" "$DESKTOP_BINARY_NAME")
+    binaries=("$CLI_BINARY_NAME")
+    if [[ "$CLI_ONLY" == false ]]; then
+        binaries+=("$DESKTOP_BINARY_NAME")
+    fi
     extracted_entries=()
 
     for binary_name in "${binaries[@]}"; do
@@ -503,7 +589,7 @@ install_binary() {
         fi
 
         if [[ "$binary_name" == "$DESKTOP_BINARY_NAME" && "$OS" == "linux" ]]; then
-            deb_name="govard_${VERSION_NO_V}_linux_${ARCH}.deb"
+            deb_name="govard-desktop_${VERSION_NO_V}_linux_${ARCH}.deb"
             deb_path="${TMP_DIR}/${deb_name}"
             deb_url="https://github.com/${REPO}/releases/download/${SPECIFIC_VERSION}/${deb_name}"
             warn "Desktop archive not found for ${SPECIFIC_VERSION}; falling back to Debian package ${deb_name}."
@@ -530,7 +616,11 @@ install_binary() {
     done
 
     rm -rf "$TMP_DIR"
-    success "Govard $SPECIFIC_VERSION installed (CLI + Desktop)!"
+    if [[ "$CLI_ONLY" == true ]]; then
+        success "Govard $SPECIFIC_VERSION installed (CLI only)!"
+    else
+        success "Govard $SPECIFIC_VERSION installed (CLI + Desktop)!"
+    fi
 }
 
 install_source() {
@@ -570,23 +660,30 @@ install_source() {
 
     TMP_BUILD_DIR=$(mktemp -d)
     go build -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${CLI_BINARY_NAME}" cmd/govard/main.go
-    DESKTOP_BUILD_TAGS="$(desktop_build_tags)"
-    if desktop_env="$(desktop_build_env)" && [[ -n "$desktop_env" ]]; then
-        env "$desktop_env" go build -tags "$DESKTOP_BUILD_TAGS" -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" cmd/govard-desktop/main.go
-    else
-        go build -tags "$DESKTOP_BUILD_TAGS" -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" cmd/govard-desktop/main.go
+    install_binary_file "${TMP_BUILD_DIR}/${CLI_BINARY_NAME}" "$CLI_BINARY_NAME"
+
+    if [[ "$CLI_ONLY" == false ]]; then
+        DESKTOP_BUILD_TAGS="$(desktop_build_tags)"
+        if desktop_env="$(desktop_build_env)" && [[ -n "$desktop_env" ]]; then
+            env "$desktop_env" go build -tags "$DESKTOP_BUILD_TAGS" -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" cmd/govard-desktop/main.go
+        else
+            go build -tags "$DESKTOP_BUILD_TAGS" -ldflags "$LDFLAGS" -o "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" cmd/govard-desktop/main.go
+        fi
+        install_binary_file "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" "$DESKTOP_BINARY_NAME"
     fi
 
-    install_binary_file "${TMP_BUILD_DIR}/${CLI_BINARY_NAME}" "$CLI_BINARY_NAME"
-    install_binary_file "${TMP_BUILD_DIR}/${DESKTOP_BINARY_NAME}" "$DESKTOP_BINARY_NAME"
-
     rm -rf "$TMP_BUILD_DIR"
-    success "Govard built and installed from source (CLI + Desktop, tags: ${DESKTOP_BUILD_TAGS})!"
+    if [[ "$CLI_ONLY" == true ]]; then
+        success "Govard built and installed from source (CLI only)!"
+    else
+        success "Govard built and installed from source (CLI + Desktop, tags: ${DESKTOP_BUILD_TAGS})!"
+    fi
 }
 
 main() {
     show_banner
     detect_env
+    configure_desktop_install
     check_dependencies
 
     if [[ -n "$SOURCE_DIR" && "$SOURCE_MODE" != true ]]; then
@@ -613,7 +710,7 @@ main() {
     fi
 
     # Update desktop database so the app is immediately searchable in the menu
-    if [[ "$OS" == "linux" ]]; then
+    if [[ "$OS" == "linux" && "$CLI_ONLY" == false ]]; then
         info "Running ldconfig to update library cache..."
         sudo ldconfig || true
 
@@ -639,4 +736,6 @@ main() {
     success "Installation complete!"
 }
 
-main
+if ! (return 0 2>/dev/null); then
+    main
+fi

--- a/tests/install_script_test.go
+++ b/tests/install_script_test.go
@@ -1,0 +1,140 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInstallScriptDesktopEligibility(t *testing.T) {
+	availableAPTCache := installScriptAPTCache(t, 0)
+	missingAPTCache := installScriptAPTCache(t, 1)
+	webkitRuntime := installScriptWebKitRuntime(t)
+
+	testCases := []struct {
+		name    string
+		pathDir string
+		command string
+	}{
+		{
+			name:    "available on Linux",
+			pathDir: availableAPTCache,
+			command: `OS=linux; CLI_ONLY=false; desktop_install_enabled`,
+		},
+		{
+			name:    "falls back to CLI only when unavailable",
+			pathDir: missingAPTCache,
+			command: `OS=linux; CLI_ONLY=false; configure_desktop_install; test "$CLI_ONLY" = true`,
+		},
+		{
+			name:    "available on macOS without APT",
+			pathDir: t.TempDir(),
+			command: `OS=darwin; CLI_ONLY=false; desktop_install_enabled`,
+		},
+		{
+			name:    "available on Linux without APT when runtime is installed",
+			pathDir: webkitRuntime,
+			command: `PATH="$INSTALLER_TEST_PATH"; OS=linux; CLI_ONLY=false; desktop_install_enabled`,
+		},
+		{
+			name:    "disabled explicitly",
+			pathDir: availableAPTCache,
+			command: `OS=linux; CLI_ONLY=true; if desktop_install_enabled; then exit 1; fi`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := runInstallScriptCommand(t, tc.pathDir, tc.command)
+			if err != nil {
+				t.Fatalf("installer policy command failed: %v\n%s", err, output)
+			}
+		})
+	}
+}
+
+func TestInstallScriptHelpDocumentsCLIOnly(t *testing.T) {
+	command := exec.Command("bash", "../install.sh", "--help")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("installer help failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "--cli-only") {
+		t.Fatalf("installer help does not document --cli-only:\n%s", output)
+	}
+}
+
+func TestInstallationDocsDescribeCLIOnly(t *testing.T) {
+	for _, path := range []string{
+		"../README.md",
+		"../docs/getting-started/installation.md",
+		"../docs/vi/getting-started/installation.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			contents, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read installation documentation: %v", err)
+			}
+
+			text := string(contents)
+			for _, required := range []string{
+				"--cli-only",
+				"govard-desktop_<version>_linux_<arch>.deb",
+			} {
+				if !strings.Contains(text, required) {
+					t.Errorf("documentation is missing %q", required)
+				}
+			}
+			if !strings.Contains(text, "WebKitGTK 4.1") && !strings.Contains(text, "Ubuntu 22.04+") {
+				t.Error("documentation does not state the Desktop platform requirement")
+			}
+		})
+	}
+}
+
+func installScriptAPTCache(t *testing.T, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "apt-cache")
+	contents := "#!/usr/bin/env bash\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write apt-cache shim: %v", err)
+	}
+	return dir
+}
+
+func installScriptWebKitRuntime(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ldconfig")
+	contents := "#!/bin/sh\nprintf '%s\\n' 'libwebkit2gtk-4.1.so.0 (libc6,x86-64) => /usr/lib/libwebkit2gtk-4.1.so.0'\n"
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write ldconfig shim: %v", err)
+	}
+	return dir
+}
+
+func runInstallScriptCommand(t *testing.T, shimDir, command string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	script := "source \"$INSTALLER_PATH\"; " + command
+	run := exec.CommandContext(ctx, "bash", "-c", script)
+	run.Env = append(
+		os.Environ(),
+		"INSTALLER_PATH=../install.sh",
+		"INSTALLER_TEST_PATH="+shimDir,
+		"PATH="+shimDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	output, err := run.CombinedOutput()
+	if ctx.Err() != nil {
+		return output, ctx.Err()
+	}
+	return output, err
+}

--- a/tests/linux_package_layout_test.go
+++ b/tests/linux_package_layout_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type releaseNFPMConfig struct {
+	NFPMS []releaseNFPM `yaml:"nfpms"`
+}
+
+type releaseNFPM struct {
+	ID               string   `yaml:"id"`
+	PackageName      string   `yaml:"package_name"`
+	IDs              []string `yaml:"ids"`
+	FileNameTemplate string   `yaml:"file_name_template"`
+	Dependencies     []string `yaml:"dependencies"`
+	Contents         []struct {
+		Source      string `yaml:"src"`
+		Destination string `yaml:"dst"`
+	} `yaml:"contents"`
+}
+
+func TestLinuxPackageLayout(t *testing.T) {
+	data, err := os.ReadFile("../.goreleaser.yml")
+	if err != nil {
+		t.Fatalf("read GoReleaser config: %v", err)
+	}
+
+	var config releaseNFPMConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse GoReleaser config: %v", err)
+	}
+
+	cli := findReleaseNFPM(t, config.NFPMS, "govard-cli")
+	if cli.PackageName != "govard" {
+		t.Errorf("CLI package name = %q, want govard", cli.PackageName)
+	}
+	if !slices.Equal(cli.IDs, []string{"govard"}) {
+		t.Errorf("CLI build IDs = %v, want [govard]", cli.IDs)
+	}
+	if !strings.HasPrefix(cli.FileNameTemplate, "{{ .ProjectName }}_") {
+		t.Errorf("CLI file name template = %q, want govard artifact prefix", cli.FileNameTemplate)
+	}
+	if slices.Contains(cli.Dependencies, "libwebkit2gtk-4.1-0") {
+		t.Errorf("CLI dependencies unexpectedly include WebKitGTK: %v", cli.Dependencies)
+	}
+	if len(cli.Contents) != 0 {
+		t.Errorf("CLI package unexpectedly contains Desktop assets: %v", cli.Contents)
+	}
+
+	desktop := findReleaseNFPM(t, config.NFPMS, "govard-desktop")
+	if desktop.PackageName != "govard-desktop" {
+		t.Errorf("Desktop package name = %q, want govard-desktop", desktop.PackageName)
+	}
+	if !slices.Equal(desktop.IDs, []string{"govard-desktop"}) {
+		t.Errorf("Desktop build IDs = %v, want [govard-desktop]", desktop.IDs)
+	}
+	if !strings.HasPrefix(desktop.FileNameTemplate, "govard-desktop_") {
+		t.Errorf("Desktop file name template = %q, want govard-desktop artifact prefix", desktop.FileNameTemplate)
+	}
+	for _, dependency := range []string{"govard", "libwebkit2gtk-4.1-0", "libgtk-3-0", "libnss3-tools"} {
+		if !slices.Contains(desktop.Dependencies, dependency) {
+			t.Errorf("Desktop dependencies = %v, want %q", desktop.Dependencies, dependency)
+		}
+	}
+	if !releaseNFPMHasContent(desktop, "./packaging/linux/govard.desktop", "/usr/share/applications/govard.desktop") {
+		t.Error("Desktop package is missing the application launcher")
+	}
+	if !releaseNFPMHasContent(desktop, "./packaging/icons/govard.svg", "/usr/share/icons/hicolor/scalable/apps/govard.svg") {
+		t.Error("Desktop package is missing the scalable application icon")
+	}
+}
+
+func findReleaseNFPM(t *testing.T, packages []releaseNFPM, id string) releaseNFPM {
+	t.Helper()
+	for _, pkg := range packages {
+		if pkg.ID == id {
+			return pkg
+		}
+	}
+	t.Fatalf("GoReleaser package %q not found", id)
+	return releaseNFPM{}
+}
+
+func releaseNFPMHasContent(pkg releaseNFPM, source, destination string) bool {
+	for _, content := range pkg.Contents {
+		if content.Source == source && content.Destination == destination {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- split Linux release packaging into independent CLI and Desktop Debian packages
- install CLI automatically when WebKitGTK 4.1 is unavailable, and add `--cli-only`
- update English and Vietnamese installation instructions
- add release-layout and installer-policy regression tests
- fix `install.sh`'s sourced-detection guard so `curl | bash` (the documented install method) actually runs `main()` again
- harden Desktop-eligibility detection against a stale/empty apt cache on freshly provisioned hosts
- dedupe the WebKitGTK runtime probe between `desktop_install_enabled` and `check_dependencies`

Closes #101

## Verification

- `go test ./...`
- `go vet ./...`
- `bash -n install.sh`
- `go run github.com/goreleaser/goreleaser/v2@v2.14.3 check`
- `npm --prefix docs run docs:build`
- manually verified `install.sh` runs `main()` correctly when piped (`curl | bash -s --`), executed directly, and sourced (as the Go tests do)
