### PR TITLE
fix(install): announce fallback apt-get update, make its test hermetic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -152,6 +152,7 @@ desktop_install_enabled() {
         # APT package lists are empty (e.g. a freshly provisioned host that
         # never ran apt-get update) — refresh once before concluding the
         # package is genuinely unavailable.
+        info "APT package lists are empty; running 'sudo apt-get update' to check Desktop availability..."
         sudo apt-get update >/dev/null 2>&1 || true
         apt-cache show "$WEBKITGTK_PACKAGE" >/dev/null 2>&1
         return

--- a/tests/install_script_test.go
+++ b/tests/install_script_test.go
@@ -105,6 +105,20 @@ func installScriptAPTCache(t *testing.T, exitCode int) string {
 	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
 		t.Fatalf("write apt-cache shim: %v", err)
 	}
+
+	// desktop_install_enabled() falls back to `sudo apt-get update` when APT
+	// package lists are unpopulated (a real, machine-state-dependent
+	// condition - see apt_lists_populated() in install.sh). sudo typically
+	// enforces its own secure_path for the command it execs, ignoring our
+	// PATH override, so shimming apt-get here would not reliably intercept
+	// it. Shimming sudo itself does, keeping this test hermetic (no real
+	// network access or privilege escalation) regardless of whether
+	// /var/lib/apt/lists happens to be empty on the machine running the test.
+	sudoPath := filepath.Join(dir, "sudo")
+	if err := os.WriteFile(sudoPath, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write sudo shim: %v", err)
+	}
+
 	return dir
 }
 


### PR DESCRIPTION
## Summary

Fixes two small issues found while reviewing the CLI-only installer support merged in #103 (`db0b0d7` on `master`):

1. `desktop_install_enabled()` (`install.sh`) silently ran `sudo apt-get update` when APT package lists were unpopulated, before ever explaining itself — inconsistent with every other sudo call in the script. Now logs an `info()` line first.
2. `tests/install_script_test.go`'s "falls back to CLI only when unavailable" case only shimmed `apt-cache`, not `sudo` — on a machine whose real `/var/lib/apt/lists` happens to be empty, `go test` could trigger a genuine `sudo apt-get update`. `sudo` enforces its own `secure_path`, so a PATH-only `apt-get` shim would not reliably intercept it; shimming `sudo` itself does. Independently verified (outside the Go test, by sourcing `install.sh` directly with `apt_lists_populated` forced to fail) that the shim now correctly intercepts the call and the new `info()` message prints.

No behavior change to the installer's actual CLI-only-vs-Desktop decision logic — both fixes are additive (a log line, a test shim).

## Validation

```bash
go build ./...
go vet ./...
gofmt -s -l .
go test ./...
make test   # lint + fmt-check + vet + unit + frontend + integration (Docker available)
bash -n install.sh
```

All pass. Also manually confirmed the fix end-to-end by sourcing `install.sh` with `apt_lists_populated` overridden to force the fallback branch, and a logging `sudo` shim in `PATH` — confirmed the new `info()` message prints and the shim (not a real `sudo`) is invoked.

## Linked issue

Closes #105