### PR TITLE
feat(release): add persisted beta update channel for CLI and Desktop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -140,5 +140,6 @@ changelog:
   format: "{{ .Message }}"
 
 release:
+  prerelease: auto
   footer: |
     Automated release by GoReleaser.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Compiles backend and serves frontend at `http://localhost:34115`
 ## Project-Specific Notes
 
 - CI tracks `main`, `master`, `develop`; default is `master`
-- Release tags: `vX.Y.Z`
+- Release tags: `vX.Y.Z`; beta releases use `vX.Y.Z-beta.N` (e.g. `v1.60.0-beta.1`), tagged directly from HEAD — skip the Release Checklist's version-bump/CHANGELOG steps for a beta cut. `.goreleaser.yml`'s `prerelease: auto` marks the resulting GitHub Release as a prerelease automatically, so it's excluded from `GET /releases/latest` and won't reach stable-channel users; opt in via `govard self-update --channel beta`.
 - Integration tests require built binary (`bin/govard-test`) and Docker
 - When uncertain, prefer compatibility over broad refactors
 

--- a/desktop/frontend/main.js
+++ b/desktop/frontend/main.js
@@ -105,6 +105,7 @@ const getLiveRefs = () => ({
   settingsUpdateChangelog: byId("settingsUpdateChangelog"),
   checkUpdatesButton: byId("checkUpdatesButton"),
   installUpdateButton: byId("installUpdateButton"),
+  updateChannelSelect: byId("updateChannelSelect"),
   updatePrompt: byId("updatePrompt"),
   updatePromptCurrent: byId("updatePromptCurrent"),
   updatePromptLatest: byId("updatePromptLatest"),
@@ -1949,6 +1950,11 @@ const bindDynamicControlListeners = () => {
   if (refs.runInBackgroundToggle) {
     refs.runInBackgroundToggle.addEventListener("change", () => {
       settingsController.save();
+    });
+  }
+  if (refs.updateChannelSelect) {
+    refs.updateChannelSelect.addEventListener("change", () => {
+      settingsController.setUpdateChannel(refs.updateChannelSelect.value);
     });
   }
 

--- a/desktop/frontend/modules/settings.js
+++ b/desktop/frontend/modules/settings.js
@@ -66,6 +66,7 @@ export const createSettingsController = ({
     failed: false,
     message: "Version check has not been run yet.",
     changelog: "",
+    channel: "stable",
   };
 
   const normalizeUpdateResult = (payload = {}) => ({
@@ -181,6 +182,16 @@ export const createSettingsController = ({
 
   const load = async () => {
     try {
+      const channel = await bridge.getUpdateChannel();
+      updateState.channel = channel || "stable";
+    } catch (_channelErr) {
+      updateState.channel = "stable";
+    }
+    if (refs.updateChannelSelect) {
+      refs.updateChannelSelect.value = updateState.channel;
+    }
+
+    try {
       const raw = await bridge.getSettings();
       const settings = normalizeSettingsPayload(raw);
       if (refs.themeSelect) refs.themeSelect.value = settings.theme;
@@ -194,6 +205,7 @@ export const createSettingsController = ({
         refs.runInBackgroundToggle.checked = settings.runInBackground;
       }
       applyTheme(settings.theme);
+
       renderUpdateSection();
     } catch (_err) {
       applyTheme();
@@ -374,6 +386,28 @@ export const createSettingsController = ({
     };
   };
 
+  const setUpdateChannel = async (channel) => {
+    try {
+      const applied = await bridge.setUpdateChannel(channel);
+      updateState.channel = applied || channel;
+      const message = `Update channel set to ${updateState.channel}.`;
+      onStatus(message);
+      onToast(message, "success");
+      return { ok: true, channel: updateState.channel };
+    } catch (_err) {
+      const message = normalizeErrorMessage(
+        _err,
+        "Could not set update channel.",
+      );
+      if (refs.updateChannelSelect) {
+        refs.updateChannelSelect.value = updateState.channel;
+      }
+      onStatus(message);
+      onToast(message, "error");
+      return { ok: false, channel: updateState.channel, message };
+    }
+  };
+
   return {
     toggleDrawer,
     load,
@@ -381,6 +415,7 @@ export const createSettingsController = ({
     reset,
     checkForUpdates,
     installLatestUpdate,
+    setUpdateChannel,
     updateRefs,
   };
 };
@@ -554,7 +589,18 @@ export const renderSettingsDrawer = (container) => {
                       Idle
                     </span>
                   </div>
-                  
+
+                  <div class="flex items-center justify-between mb-5 -mt-1">
+                    <label for="updateChannelSelect" class="text-[11px] font-bold text-text-tertiary uppercase tracking-wider">Update channel</label>
+                    <select
+                      id="updateChannelSelect"
+                      class="bg-slate-50 dark:bg-[#162a1d] border border-slate-200 dark:border-white/10 rounded-lg px-3 py-1.5 text-xs font-semibold text-slate-900 dark:text-white outline-none focus:border-primary/50 cursor-pointer"
+                    >
+                      <option value="stable">Stable</option>
+                      <option value="beta">Beta</option>
+                    </select>
+                  </div>
+
                   <div class="mt-4 mb-6 p-5 bg-white dark:bg-black/20 rounded-2xl border border-slate-200 dark:border-white/5 flex flex-col gap-4">
                     <p
                       class="update-message-text text-[14px] font-medium text-slate-700 dark:text-slate-200 leading-snug flex items-center gap-3"

--- a/desktop/frontend/services/bridge.js
+++ b/desktop/frontend/services/bridge.js
@@ -308,6 +308,14 @@ export const desktopBridge = {
     const bridge = getBridge();
     return call(bridge?.InstallLatestUpdate?.bind(bridge));
   },
+  async getUpdateChannel() {
+    const bridge = getBridge();
+    return call(bridge?.GetUpdateChannel?.bind(bridge));
+  },
+  async setUpdateChannel(channel) {
+    const bridge = getBridge();
+    return call(bridge?.SetUpdateChannel?.bind(bridge), channel);
+  },
   async restartDesktopApp() {
     const bridge = getBridge();
     return call(bridge?.RestartDesktopApp?.bind(bridge));

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -71,6 +71,19 @@ go build -o govard cmd/govard/main.go
 
 ---
 
+## Cutting a Beta Release
+
+Beta releases use the tag format `vX.Y.Z-beta.N` (e.g. `v1.60.0-beta.1`),
+tagged directly from the current commit — no version bump in `root.go`,
+`app.go`, `package.json`, `wails.json`, or `CHANGELOG.md` is needed for a
+beta. Pushing the tag triggers the same `.github/workflows/release.yml`
+pipeline as a stable release; `.goreleaser.yml`'s `prerelease: auto` marks
+the resulting GitHub Release as a prerelease, so it won't appear via
+`GET /releases/latest` and won't reach stable-channel users automatically.
+Users opt in with `govard self-update --channel beta`.
+
+---
+
 ## Test Commands
 
 ### Preferred Makefile Commands

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -581,8 +581,15 @@ govard lock generate --file .govard/govard.lock
 Download release artifacts, verify checksums, and replace binaries atomically.
 
 ```bash
-govard self-update
+govard self-update                    # update within your current channel
+govard self-update --channel beta     # opt into beta releases (persists)
+govard self-update --channel stable   # switch back to stable (persists)
+govard self-update --version v1.60.0-beta.1  # install one specific version
 ```
+
+The update channel is remembered across runs (both the CLI and Govard
+Desktop read the same setting), so a plain `govard self-update` keeps
+following whichever channel you last selected.
 
 ### `govard upgrade`
 

--- a/docs/vi/developer/contributing.md
+++ b/docs/vi/developer/contributing.md
@@ -71,6 +71,19 @@ go build -o govard cmd/govard/main.go
 
 ---
 
+## Cắt bản Beta
+
+Bản beta dùng tag dạng `vX.Y.Z-beta.N` (ví dụ `v1.60.0-beta.1`), tag thẳng
+từ commit hiện tại — không cần bump version ở `root.go`, `app.go`,
+`package.json`, `wails.json`, hay thêm entry vào `CHANGELOG.md`. Push tag sẽ
+kích hoạt cùng pipeline `.github/workflows/release.yml` như bản stable;
+`prerelease: auto` trong `.goreleaser.yml` sẽ đánh dấu GitHub Release đó là
+prerelease, nên nó sẽ không xuất hiện qua `GET /releases/latest` và không
+tự động đến tay user đang ở channel stable. User chủ động opt-in bằng
+`govard self-update --channel beta`.
+
+---
+
 ## Các lệnh kiểm thử (Test Commands)
 
 ### Các lệnh Makefile khuyên dùng

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -583,8 +583,15 @@ govard lock generate --file .govard/govard.lock
 Tải về phiên bản Govard mới nhất, kiểm định mã checksum và thay thế các binary đã cài đặt một cách an toàn.
 
 ```bash
-govard self-update
+govard self-update                    # cập nhật theo channel hiện tại
+govard self-update --channel beta     # chuyển sang nhận bản beta (được lưu lại)
+govard self-update --channel stable   # quay lại bản stable (được lưu lại)
+govard self-update --version v1.60.0-beta.1  # cài đúng 1 phiên bản cụ thể
 ```
+
+Channel cập nhật được lưu lại qua các lần chạy (CLI và Govard Desktop dùng
+chung cấu hình này), nên `govard self-update` không kèm flag sẽ tiếp tục
+theo channel bạn đã chọn lần gần nhất.
 
 ### `govard upgrade`
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/wailsapp/wails/v2 v2.12.0
+	golang.org/x/mod v0.38.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a h1:+3jdDGGB8NGb1Zktc737jlt3/
 golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"govard/internal/conventions"
 	"io"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 	"govard/internal/engine"
 	_ "govard/internal/frameworks" // registers framework detection/config data via init()
 	"govard/internal/ui"
+	"govard/internal/updater"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -67,7 +69,22 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Govard",
 	Run: func(cmd *cobra.Command, args []string) {
 		ui.PrintBrand(Version)
+		if notice := versionChannelNotice(updater.GetChannel()); notice != "" {
+			pterm.Info.Println(notice)
+		}
 	},
+}
+
+func versionChannelNotice(channel string) string {
+	if channel == updater.ChannelStable {
+		return ""
+	}
+	return fmt.Sprintf("Update channel: %s", channel)
+}
+
+// VersionChannelNoticeForTest exposes versionChannelNotice for tests in /tests.
+func VersionChannelNoticeForTest(channel string) string {
+	return versionChannelNotice(channel)
 }
 
 func Execute() {

--- a/internal/cmd/self_update.go
+++ b/internal/cmd/self_update.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"govard/internal/conventions"
+	"govard/internal/updater"
 	"io"
 	"net/http"
 	"os"
@@ -31,6 +32,7 @@ const (
 	selfUpdateChecksumsFile         = "checksums.txt"
 	selfUpdateRepoEnvVar            = "GOVARD_REPO"
 	selfUpdateLatestURLEnvVar       = "GOVARD_SELF_UPDATE_LATEST_URL"
+	selfUpdateListURLEnvVar         = "GOVARD_SELF_UPDATE_LIST_URL"
 	selfUpdateReleaseBaseURLEnvVar  = "GOVARD_SELF_UPDATE_RELEASE_BASE_URL"
 	selfUpdateConfirmOverrideEnvVar = "GOVARD_SELF_UPDATE_CONFIRM"
 	selfUpdateDesktopTargetEnvVar   = "GOVARD_SELF_UPDATE_DESKTOP_TARGET"
@@ -40,6 +42,7 @@ const (
 
 var selfUpdateVersion string
 var selfUpdateAssumeYes bool
+var selfUpdateChannel string
 
 var selfUpdateCmd = &cobra.Command{
 	Use:   "self-update",
@@ -71,6 +74,14 @@ var selfUpdateCmd = &cobra.Command{
 		releaseTag := ""
 		repo := selfUpdateRepo()
 
+		if strings.TrimSpace(selfUpdateChannel) != "" {
+			if err := updater.SetChannel(selfUpdateChannel); err != nil {
+				return err
+			}
+			pterm.Info.Printf("Update channel set to %s.\n", updater.GetChannel())
+		}
+		effectiveChannel := updater.GetChannel()
+
 		var err error
 		if strings.TrimSpace(selfUpdateVersion) != "" {
 			releaseTag, err = validateReleaseTag(selfUpdateVersion)
@@ -78,8 +89,8 @@ var selfUpdateCmd = &cobra.Command{
 				return err
 			}
 		} else {
-			pterm.Info.Println("Resolving latest release...")
-			releaseTag, err = fetchLatestReleaseTag(client, repo)
+			pterm.Info.Printf("Resolving latest %s release...\n", effectiveChannel)
+			releaseTag, err = fetchChannelReleaseTag(client, repo, effectiveChannel)
 			if err != nil {
 				return err
 			}
@@ -209,6 +220,7 @@ var selfUpdateCmd = &cobra.Command{
 func init() {
 	selfUpdateCmd.Flags().StringVar(&selfUpdateVersion, "version", "", "Install a specific version (e.g. v1.0.1)")
 	selfUpdateCmd.Flags().BoolVar(&selfUpdateAssumeYes, "yes", false, "Skip confirmation prompt")
+	selfUpdateCmd.Flags().StringVar(&selfUpdateChannel, "channel", "", "Set and use an update channel (stable or beta); persists for future runs")
 }
 
 func normalizeReleaseTag(tag string) string {
@@ -224,7 +236,7 @@ func normalizeReleaseTag(tag string) string {
 
 func isValidReleaseTag(tag string) bool {
 	// Simple regex to ensure tag follows vX.Y.Z format, avoiding path traversal or command injection
-	matched, _ := regexp.MatchString(`^v\d+\.\d+\.\d+$`, tag)
+	matched, _ := regexp.MatchString(`^v\d+\.\d+\.\d+(-beta\.\d+)?$`, tag)
 	return matched
 }
 
@@ -281,6 +293,52 @@ func fetchLatestReleaseTag(client *http.Client, repo string) (string, error) {
 	}
 
 	return tag, nil
+}
+
+func selfUpdateReleaseListURL(repo string) string {
+	if override := strings.TrimSpace(os.Getenv(selfUpdateListURLEnvVar)); override != "" {
+		return strings.TrimRight(override, "/")
+	}
+	return fmt.Sprintf("https://api.github.com/repos/%s/releases", repo)
+}
+
+func fetchChannelReleaseTag(client *http.Client, repo, channel string) (string, error) {
+	if channel != updater.ChannelBeta {
+		return fetchLatestReleaseTag(client, repo)
+	}
+
+	body, err := downloadText(client, selfUpdateReleaseListURL(repo))
+	if err != nil {
+		return "", err
+	}
+
+	var releases []struct {
+		TagName string `json:"tag_name"`
+		Draft   bool   `json:"draft"`
+	}
+	if err := json.Unmarshal([]byte(body), &releases); err != nil {
+		return "", fmt.Errorf("decode release list payload: %w", err)
+	}
+
+	tags := make([]string, 0, len(releases))
+	for _, release := range releases {
+		if release.Draft {
+			continue
+		}
+		tags = append(tags, release.TagName)
+	}
+
+	newestTag, ok := updater.NewestReleaseTag(tags)
+	if !ok {
+		return "", errors.New("no valid beta releases found")
+	}
+
+	return validateReleaseTag(newestTag)
+}
+
+// FetchChannelReleaseTagForTest exposes fetchChannelReleaseTag for tests in /tests.
+func FetchChannelReleaseTagForTest(client *http.Client, repo, channel string) (string, error) {
+	return fetchChannelReleaseTag(client, repo, channel)
 }
 
 func buildReleaseAssetName(binaryName, releaseTag, goos, goarch string) (string, string, error) {

--- a/internal/desktop/test_helpers.go
+++ b/internal/desktop/test_helpers.go
@@ -349,6 +349,11 @@ func SummarizeDesktopSelfUpdateErrorForTest(runErr error, sanitizedOutput string
 	return summarizeDesktopSelfUpdateError(runErr, sanitizedOutput)
 }
 
+// BuildDesktopElevatedSelfUpdateArgsForTest exposes elevated pkexec argument construction for desktop update.
+func BuildDesktopElevatedSelfUpdateArgsForTest(envBinary, govardBinary, desktopTarget string) []string {
+	return buildDesktopElevatedSelfUpdateArgs(envBinary, govardBinary, desktopTarget)
+}
+
 // ResolveGovardBinaryForDesktopUpdateForTest exposes govard binary resolution for desktop update.
 func ResolveGovardBinaryForDesktopUpdateForTest() (string, error) {
 	return resolveGovardBinaryForDesktopUpdate()

--- a/internal/desktop/types.go
+++ b/internal/desktop/types.go
@@ -48,6 +48,7 @@ type UpdateCheckResult struct {
 	Outdated       bool   `json:"outdated"`
 	Message        string `json:"message"`
 	Changelog      string `json:"changelog"`
+	Channel        string `json:"channel"`
 }
 
 type UserInfo struct {

--- a/internal/desktop/update.go
+++ b/internal/desktop/update.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"govard/internal/conventions"
 	"govard/internal/updater"
 )
 
@@ -76,15 +77,7 @@ func runDesktopSelfUpdateCommand(govardBinary, desktopTarget string, elevated bo
 			envBinary = lookedUpEnv
 		}
 
-		args := []string{
-			envBinary,
-			"NO_COLOR=1",
-			"CLICOLOR=0",
-		}
-		if strings.TrimSpace(desktopTarget) != "" {
-			args = append(args, fmt.Sprintf("%s=%s", desktopSelfUpdateDesktopTargetEnvVar, desktopTarget))
-		}
-		args = append(args, govardBinary, "self-update", "--yes")
+		args := buildDesktopElevatedSelfUpdateArgs(envBinary, govardBinary, desktopTarget)
 
 		output, err = runDesktopPrivilegedSelfUpdate(pkexecPath, args)
 	} else {
@@ -105,6 +98,27 @@ func runDesktopSelfUpdateCommand(govardBinary, desktopTarget string, elevated bo
 		return "", errors.New(summarizeDesktopSelfUpdateError(err, trimmed))
 	}
 	return trimmed, nil
+}
+
+// buildDesktopElevatedSelfUpdateArgs builds the "pkexec /usr/bin/env ..." argument
+// list used to run "govard self-update" with elevated privileges. It forwards the
+// invoking process's resolved Govard home directory as an explicit GOVARD_HOME_DIR
+// env var (read from the invoking process's own environment before pkexec strips
+// it), so the elevated child resolves the exact same persisted update channel
+// (~/.govard/update-channel.json) as the invoking user, rather than silently
+// falling back to the elevated user's home directory (typically /root).
+func buildDesktopElevatedSelfUpdateArgs(envBinary, govardBinary, desktopTarget string) []string {
+	args := []string{
+		envBinary,
+		"NO_COLOR=1",
+		"CLICOLOR=0",
+		fmt.Sprintf("%s=%s", conventions.EnvGovardHome, conventions.GetGovardHome()),
+	}
+	if strings.TrimSpace(desktopTarget) != "" {
+		args = append(args, fmt.Sprintf("%s=%s", desktopSelfUpdateDesktopTargetEnvVar, desktopTarget))
+	}
+	args = append(args, govardBinary, "self-update", "--yes")
+	return args
 }
 
 func runDesktopPrivilegedSelfUpdate(pkexecPath string, baseArgs []string) ([]byte, error) {
@@ -184,11 +198,13 @@ var restartDesktopBinary = defaultRestartDesktopBinary
 
 func (app *App) CheckForUpdates() (UpdateCheckResult, error) {
 	current := normalizeDesktopVersionTag(Version)
+	channel := updater.GetChannel()
 	result := UpdateCheckResult{
 		CurrentVersion: current,
+		Channel:        channel,
 	}
 
-	release, err := updater.FetchLatestRelease(desktopUpdateHTTPClient)
+	release, err := updater.FetchChannelRelease(desktopUpdateHTTPClient, channel)
 	if err != nil {
 		result.Message = "Could not check for updates."
 		return result, err
@@ -204,6 +220,17 @@ func (app *App) CheckForUpdates() (UpdateCheckResult, error) {
 
 	result.Message = fmt.Sprintf("Govard Desktop is up to date (%s).", current)
 	return result, nil
+}
+
+func (app *App) GetUpdateChannel() (string, error) {
+	return updater.GetChannel(), nil
+}
+
+func (app *App) SetUpdateChannel(channel string) (string, error) {
+	if err := updater.SetChannel(channel); err != nil {
+		return "", err
+	}
+	return updater.GetChannel(), nil
 }
 
 func (app *App) InstallLatestUpdate() (string, error) {

--- a/internal/updater/channel.go
+++ b/internal/updater/channel.go
@@ -1,0 +1,68 @@
+package updater
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"govard/internal/conventions"
+)
+
+// Update channels recognized by Govard's self-update tooling.
+const (
+	ChannelStable = "stable"
+	ChannelBeta   = "beta"
+
+	updateChannelFileName = "update-channel.json"
+)
+
+type updateChannelState struct {
+	Channel string `json:"channel"`
+}
+
+// GetChannel returns the persisted update channel for this machine, defaulting
+// to ChannelStable when unset, unreadable, or invalid. Shared by the CLI and
+// Govard Desktop so both stay on the same channel.
+func GetChannel() string {
+	data, err := os.ReadFile(channelFilePath())
+	if err != nil {
+		return ChannelStable
+	}
+
+	var state updateChannelState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return ChannelStable
+	}
+	if state.Channel == ChannelBeta {
+		return ChannelBeta
+	}
+	return ChannelStable
+}
+
+// SetChannel validates and persists the update channel.
+func SetChannel(channel string) error {
+	normalized := strings.ToLower(strings.TrimSpace(channel))
+	if normalized != ChannelStable && normalized != ChannelBeta {
+		return fmt.Errorf("invalid update channel %q: must be %q or %q", channel, ChannelStable, ChannelBeta)
+	}
+
+	path := channelFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), conventions.DefaultDirPerm); err != nil {
+		return fmt.Errorf("create govard home directory: %w", err)
+	}
+
+	data, err := json.Marshal(updateChannelState{Channel: normalized})
+	if err != nil {
+		return fmt.Errorf("encode update channel: %w", err)
+	}
+	if err := os.WriteFile(path, data, conventions.DefaultFilePerm); err != nil {
+		return fmt.Errorf("write update channel file: %w", err)
+	}
+	return nil
+}
+
+func channelFilePath() string {
+	return filepath.Join(conventions.GetGovardHome(), updateChannelFileName)
+}

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -2,16 +2,21 @@ package updater
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/pterm/pterm"
+	"golang.org/x/mod/semver"
 )
 
 const updateCheckLatestURLEnvVar = "GOVARD_UPDATE_CHECK_URL"
+
+var officialBetaTagPattern = regexp.MustCompile(`^\d+\.\d+\.\d+-beta\.\d+$`)
 
 var (
 	updateCheckHTTPClient = &http.Client{Timeout: 2 * time.Second}
@@ -22,7 +27,7 @@ var (
 )
 
 func CheckForUpdates(current string) {
-	release, err := FetchLatestRelease(updateCheckHTTPClient)
+	release, err := FetchChannelRelease(updateCheckHTTPClient, GetChannel())
 	if err != nil {
 		return
 	}
@@ -100,13 +105,21 @@ func shouldNotifyUpdate(currentVersion, latestTag string) bool {
 		return true
 	}
 
-	// If current version is a development build (e.g. 1.31.0-2-gf2a0be7),
-	// check if the base version matches the latest tag to avoid redundant warnings.
-	if strings.Contains(current, "-") {
+	// If current version is a local development build (e.g. 1.31.0-2-gf2a0be7,
+	// or a "-dev" suffix), check if the base version matches the latest tag to
+	// avoid redundant warnings. This does NOT apply to an official "-beta.N"
+	// release tag, where the suffix is semantically meaningful (a prerelease
+	// of that base version is strictly older than the plain release).
+	if strings.Contains(current, "-") && !officialBetaTagPattern.MatchString(current) {
 		base := strings.SplitN(current, "-", 2)[0]
 		if latest == "v"+base {
 			return false
 		}
+	}
+
+	currentSemver := "v" + strings.TrimPrefix(current, "v")
+	if semver.IsValid(latest) && semver.IsValid(currentSemver) {
+		return semver.Compare(latest, currentSemver) > 0
 	}
 
 	return latest != "v"+current
@@ -137,4 +150,94 @@ func SetUpdateCheckNotifierForTest(fn func(latestTag, currentVersion string)) fu
 // ShouldNotifyUpdateForTest exposes update comparison logic for tests in /tests.
 func ShouldNotifyUpdateForTest(currentVersion, latestTag string) bool {
 	return shouldNotifyUpdate(currentVersion, latestTag)
+}
+
+const updateCheckListURLEnvVar = "GOVARD_UPDATE_CHECK_LIST_URL"
+
+// ReleasesListURL returns the GitHub releases-list API URL used to discover
+// beta releases, honoring the GOVARD_UPDATE_CHECK_LIST_URL override.
+func ReleasesListURL() string {
+	if override := strings.TrimSpace(os.Getenv(updateCheckListURLEnvVar)); override != "" {
+		return override
+	}
+	return "https://api.github.com/repos/ddtcorex/govard/releases"
+}
+
+// NewestReleaseTag returns the semver-greatest tag among tags, ignoring any
+// that aren't valid semver (e.g. malformed or missing the "v" prefix). ok is
+// false when no tag qualifies.
+func NewestReleaseTag(tags []string) (tag string, ok bool) {
+	for _, candidate := range tags {
+		candidate = strings.TrimSpace(candidate)
+		if !semver.IsValid(candidate) {
+			continue
+		}
+		if !ok || semver.Compare(candidate, tag) > 0 {
+			tag = candidate
+			ok = true
+		}
+	}
+	return tag, ok
+}
+
+// FetchChannelRelease returns the release Govard should treat as "latest" for
+// the given channel. ChannelStable behaves exactly like FetchLatestRelease
+// (GitHub already excludes prereleases from /releases/latest, so stable users
+// see no behavior change). ChannelBeta fetches the full release list and
+// picks the semver-greatest tag, so a stable patch published after a beta tag
+// can't win just because it's chronologically newer.
+func FetchChannelRelease(client *http.Client, channel string) (LatestRelease, error) {
+	if channel != ChannelBeta {
+		return FetchLatestRelease(client)
+	}
+	return fetchNewestRelease(client)
+}
+
+func fetchNewestRelease(client *http.Client) (LatestRelease, error) {
+	if client == nil {
+		client = updateCheckHTTPClient
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ReleasesListURL(), nil)
+	if err != nil {
+		return LatestRelease{}, fmt.Errorf("prepare release list request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "govard")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return LatestRelease{}, fmt.Errorf("request release list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return LatestRelease{}, fmt.Errorf("request release list failed with status %d", resp.StatusCode)
+	}
+
+	var releases []struct {
+		TagName string `json:"tag_name"`
+		Body    string `json:"body"`
+		Draft   bool   `json:"draft"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return LatestRelease{}, fmt.Errorf("decode release list payload: %w", err)
+	}
+
+	bodyByTag := map[string]string{}
+	tags := make([]string, 0, len(releases))
+	for _, release := range releases {
+		if release.Draft {
+			continue
+		}
+		tag := strings.TrimSpace(release.TagName)
+		tags = append(tags, tag)
+		bodyByTag[tag] = release.Body
+	}
+
+	newestTag, ok := NewestReleaseTag(tags)
+	if !ok {
+		return LatestRelease{}, errors.New("no valid releases found in release list")
+	}
+	return LatestRelease{Tag: newestTag, Body: bodyByTag[newestTag]}, nil
 }

--- a/tests/desktop_update_test.go
+++ b/tests/desktop_update_test.go
@@ -184,6 +184,132 @@ func TestDesktopSummarizeSelfUpdateErrorAuthorizationDenied(t *testing.T) {
 	}
 }
 
+func TestDesktopGetUpdateChannelDefaultsToStable(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	desktop.ResetStateForTest()
+
+	app := desktop.NewApp()
+	channel, err := app.GetUpdateChannel()
+	if err != nil {
+		t.Fatalf("GetUpdateChannel failed: %v", err)
+	}
+	if channel != "stable" {
+		t.Fatalf("expected stable channel, got %q", channel)
+	}
+}
+
+func TestDesktopSetUpdateChannelPersists(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	desktop.ResetStateForTest()
+
+	app := desktop.NewApp()
+	applied, err := app.SetUpdateChannel("beta")
+	if err != nil {
+		t.Fatalf("SetUpdateChannel failed: %v", err)
+	}
+	if applied != "beta" {
+		t.Fatalf("expected applied channel beta, got %q", applied)
+	}
+
+	channel, err := app.GetUpdateChannel()
+	if err != nil {
+		t.Fatalf("GetUpdateChannel failed: %v", err)
+	}
+	if channel != "beta" {
+		t.Fatalf("expected persisted channel beta, got %q", channel)
+	}
+}
+
+func TestDesktopSetUpdateChannelRejectsInvalidValue(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	desktop.ResetStateForTest()
+
+	app := desktop.NewApp()
+	if _, err := app.SetUpdateChannel("nightly"); err == nil {
+		t.Fatal("expected SetUpdateChannel to reject an invalid channel")
+	}
+}
+
+func TestDesktopCheckForUpdatesUsesBetaChannelFeed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	desktop.ResetStateForTest()
+
+	app := desktop.NewApp()
+	if _, err := app.SetUpdateChannel("beta"); err != nil {
+		t.Fatalf("SetUpdateChannel failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"tag_name":"v9.9.9-beta.1"}]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GOVARD_UPDATE_CHECK_LIST_URL", server.URL)
+	previousVersion := desktop.Version
+	desktop.Version = "1.0.0"
+	t.Cleanup(func() {
+		desktop.Version = previousVersion
+	})
+
+	result, err := app.CheckForUpdates()
+	if err != nil {
+		t.Fatalf("CheckForUpdates failed: %v", err)
+	}
+	if result.Channel != "beta" {
+		t.Fatalf("expected result.Channel = beta, got %q", result.Channel)
+	}
+	if result.LatestVersion != "v9.9.9-beta.1" {
+		t.Fatalf("expected latest version v9.9.9-beta.1, got %q", result.LatestVersion)
+	}
+}
+
+func TestDesktopBuildElevatedSelfUpdateArgsForwardsGovardHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GOVARD_HOME_DIR", home)
+
+	args := desktop.BuildDesktopElevatedSelfUpdateArgsForTest("/usr/bin/env", "/usr/local/bin/govard", "")
+
+	expected := fmt.Sprintf("GOVARD_HOME_DIR=%s", home)
+	found := false
+	for _, arg := range args {
+		if arg == expected {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected elevated pkexec args to include %q, got %v", expected, args)
+	}
+}
+
+func TestDesktopBuildElevatedSelfUpdateArgsForwardsGovardHomeAlongsideDesktopTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GOVARD_HOME_DIR", home)
+
+	args := desktop.BuildDesktopElevatedSelfUpdateArgsForTest("/usr/bin/env", "/usr/local/bin/govard", "/opt/govard/govard-desktop")
+
+	expectedHome := fmt.Sprintf("GOVARD_HOME_DIR=%s", home)
+	expectedTarget := "GOVARD_SELF_UPDATE_DESKTOP_TARGET=/opt/govard/govard-desktop"
+	foundHome := false
+	foundTarget := false
+	for _, arg := range args {
+		if arg == expectedHome {
+			foundHome = true
+		}
+		if arg == expectedTarget {
+			foundTarget = true
+		}
+	}
+	if !foundHome {
+		t.Fatalf("expected elevated pkexec args to include %q, got %v", expectedHome, args)
+	}
+	if !foundTarget {
+		t.Fatalf("expected elevated pkexec args to include %q, got %v", expectedTarget, args)
+	}
+}
+
 func TestDesktopResolveGovardBinaryForUpdatePrefersSibling(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	desktop.ResetStateForTest()

--- a/tests/frontend/settings_core.test.mjs
+++ b/tests/frontend/settings_core.test.mjs
@@ -165,3 +165,140 @@ test("applyTheme respects prefers-color-scheme for theme=system", () => {
   delete globalThis.document;
   delete globalThis.window;
 });
+
+test("renderSettingsDrawer includes update channel select", () => {
+  const container = { innerHTML: "" };
+  renderSettingsDrawer(container);
+
+  assert.equal(
+    container.innerHTML.includes('id="updateChannelSelect"'),
+    true,
+    "expected update channel select in settings drawer",
+  );
+});
+
+test("load reads update channel from bridge", async () => {
+  globalThis.document = { documentElement: { classList: createClassList() } };
+  globalThis.window = { matchMedia: () => ({ matches: false }) };
+
+  const refs = {
+    updateChannelSelect: { value: "" },
+  };
+  const bridge = {
+    getSettings: async () => ({}),
+    getUpdateChannel: async () => "beta",
+  };
+
+  const controller = createSettingsController({
+    bridge,
+    refs,
+    onStatus: () => {},
+    onToast: () => {},
+  });
+
+  await controller.load();
+
+  assert.equal(refs.updateChannelSelect.value, "beta");
+  delete globalThis.document;
+  delete globalThis.window;
+});
+
+test("load reads update channel even when getSettings fails", async () => {
+  globalThis.document = { documentElement: { classList: createClassList() } };
+  globalThis.window = { matchMedia: () => ({ matches: false }) };
+
+  const refs = {
+    updateChannelSelect: { value: "" },
+  };
+  const bridge = {
+    getSettings: async () => {
+      throw new Error("boom");
+    },
+    getUpdateChannel: async () => "beta",
+  };
+
+  const controller = createSettingsController({
+    bridge,
+    refs,
+    onStatus: () => {},
+    onToast: () => {},
+  });
+
+  await controller.load();
+
+  assert.equal(refs.updateChannelSelect.value, "beta");
+  delete globalThis.document;
+  delete globalThis.window;
+});
+
+test("setUpdateChannel persists channel via bridge and updates status", async () => {
+  let statusMessage = "";
+  const bridge = {
+    setUpdateChannel: async (channel) => channel,
+  };
+
+  const controller = createSettingsController({
+    bridge,
+    refs: {},
+    onStatus: (msg) => {
+      statusMessage = msg;
+    },
+    onToast: () => {},
+  });
+
+  const result = await controller.setUpdateChannel("beta");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.channel, "beta");
+  assert.equal(statusMessage, "Update channel set to beta.");
+});
+
+test("setUpdateChannel surfaces bridge errors", async () => {
+  const bridge = {
+    setUpdateChannel: async () => {
+      throw new Error("invalid update channel");
+    },
+  };
+
+  const controller = createSettingsController({
+    bridge,
+    refs: {},
+    onStatus: () => {},
+    onToast: () => {},
+  });
+
+  const result = await controller.setUpdateChannel("nightly");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.message, "invalid update channel");
+});
+
+test("setUpdateChannel resyncs select to last-known-good channel on failure", async () => {
+  const refs = {
+    updateChannelSelect: { value: "stable" },
+  };
+  const bridge = {
+    setUpdateChannel: async () => {
+      throw new Error("invalid update channel");
+    },
+  };
+
+  const controller = createSettingsController({
+    bridge,
+    refs,
+    onStatus: () => {},
+    onToast: () => {},
+  });
+
+  // Simulate the user picking "beta" in the <select> before the rejected call.
+  refs.updateChannelSelect.value = "beta";
+
+  const result = await controller.setUpdateChannel("beta");
+
+  assert.equal(result.ok, false);
+  assert.equal(
+    refs.updateChannelSelect.value,
+    "stable",
+    "select should snap back to the last persisted channel after a rejected update",
+  );
+});

--- a/tests/root_version_test.go
+++ b/tests/root_version_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"testing"
+
+	"govard/internal/cmd"
+	"govard/internal/updater"
+)
+
+func TestVersionChannelNoticeForTestStableIsSilent(t *testing.T) {
+	if got := cmd.VersionChannelNoticeForTest(updater.ChannelStable); got != "" {
+		t.Fatalf("VersionChannelNoticeForTest(stable) = %q, want empty", got)
+	}
+}
+
+func TestVersionChannelNoticeForTestBetaAnnouncesChannel(t *testing.T) {
+	got := cmd.VersionChannelNoticeForTest(updater.ChannelBeta)
+	want := "Update channel: beta"
+	if got != want {
+		t.Fatalf("VersionChannelNoticeForTest(beta) = %q, want %q", got, want)
+	}
+}

--- a/tests/self_update_test.go
+++ b/tests/self_update_test.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -48,6 +50,9 @@ func TestValidateReleaseTagForTest(t *testing.T) {
 		{name: "empty", in: "", wantErr: true},
 		{name: "invalid suffix", in: "v1.2.3-rc1", wantErr: true},
 		{name: "path traversal", in: "../../1.2.3", wantErr: true},
+		{name: "valid beta", in: "v1.60.0-beta.1", want: "v1.60.0-beta.1"},
+		{name: "invalid beta missing number", in: "v1.2.3-beta", wantErr: true},
+		{name: "invalid beta trailing dot segment", in: "v1.2.3-beta.1.2", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -353,6 +358,60 @@ func TestDetectMixedInstallChannelPairsForTestIncludesConflictingCopies(t *testi
 	}
 	if pairs[0][0] != localGovard || pairs[0][1] != systemGovard {
 		t.Fatalf("unexpected pair %v", pairs[0])
+	}
+}
+
+func TestFetchChannelReleaseTagForTestBetaPicksSemverMax(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"tag_name":"v1.0.0-beta.1"},{"tag_name":"v1.0.0-beta.2"}]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GOVARD_SELF_UPDATE_LIST_URL", server.URL)
+
+	tag, err := cmd.FetchChannelReleaseTagForTest(server.Client(), "ignored/repo", "beta")
+	if err != nil {
+		t.Fatalf("FetchChannelReleaseTagForTest() error = %v", err)
+	}
+	if tag != "v1.0.0-beta.2" {
+		t.Fatalf("tag = %q, want %q", tag, "v1.0.0-beta.2")
+	}
+}
+
+func TestFetchChannelReleaseTagForTestStableDelegatesToLatest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v2.0.0"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GOVARD_SELF_UPDATE_LATEST_URL", server.URL)
+
+	tag, err := cmd.FetchChannelReleaseTagForTest(server.Client(), "ignored/repo", "stable")
+	if err != nil {
+		t.Fatalf("FetchChannelReleaseTagForTest() error = %v", err)
+	}
+	if tag != "v2.0.0" {
+		t.Fatalf("tag = %q, want %q", tag, "v2.0.0")
+	}
+}
+
+func TestFetchChannelReleaseTagForTestBetaIgnoresDrafts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"tag_name":"v3.0.0-beta.9","draft":true},{"tag_name":"v3.0.0-beta.1"}]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GOVARD_SELF_UPDATE_LIST_URL", server.URL)
+
+	tag, err := cmd.FetchChannelReleaseTagForTest(server.Client(), "ignored/repo", "beta")
+	if err != nil {
+		t.Fatalf("FetchChannelReleaseTagForTest() error = %v", err)
+	}
+	if tag != "v3.0.0-beta.1" {
+		t.Fatalf("tag = %q, want %q (draft must be excluded)", tag, "v3.0.0-beta.1")
 	}
 }
 

--- a/tests/updater_channel_test.go
+++ b/tests/updater_channel_test.go
@@ -1,0 +1,56 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"govard/internal/updater"
+)
+
+func TestGetChannelDefaultsToStable(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+
+	if got := updater.GetChannel(); got != updater.ChannelStable {
+		t.Fatalf("GetChannel() = %q, want %q", got, updater.ChannelStable)
+	}
+}
+
+func TestSetChannelPersistsAndRoundTrips(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+
+	if err := updater.SetChannel("beta"); err != nil {
+		t.Fatalf("SetChannel(beta) error = %v", err)
+	}
+	if got := updater.GetChannel(); got != updater.ChannelBeta {
+		t.Fatalf("GetChannel() = %q, want %q", got, updater.ChannelBeta)
+	}
+
+	if err := updater.SetChannel("stable"); err != nil {
+		t.Fatalf("SetChannel(stable) error = %v", err)
+	}
+	if got := updater.GetChannel(); got != updater.ChannelStable {
+		t.Fatalf("GetChannel() = %q, want %q", got, updater.ChannelStable)
+	}
+}
+
+func TestSetChannelRejectsInvalidValue(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+
+	if err := updater.SetChannel("nightly"); err == nil {
+		t.Fatal("SetChannel(nightly) expected error, got nil")
+	}
+}
+
+func TestGetChannelIgnoresCorruptFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GOVARD_HOME_DIR", home)
+
+	if err := os.WriteFile(filepath.Join(home, "update-channel.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt channel file: %v", err)
+	}
+
+	if got := updater.GetChannel(); got != updater.ChannelStable {
+		t.Fatalf("GetChannel() = %q, want %q for corrupt file", got, updater.ChannelStable)
+	}
+}

--- a/tests/updater_checker_test.go
+++ b/tests/updater_checker_test.go
@@ -63,6 +63,42 @@ func TestShouldNotifyUpdateForTest(t *testing.T) {
 			latestTag:      "v1.1.0",
 			want:           false,
 		},
+		{
+			name:           "official beta tag superseded by stable release of same base version",
+			currentVersion: "1.60.0-beta.1",
+			latestTag:      "v1.60.0",
+			want:           true,
+		},
+		{
+			name:           "official beta tag same version no notify",
+			currentVersion: "1.60.0-beta.1",
+			latestTag:      "v1.60.0-beta.1",
+			want:           false,
+		},
+		{
+			name:           "official beta tag newer beta available",
+			currentVersion: "1.60.0-beta.1",
+			latestTag:      "v1.60.0-beta.2",
+			want:           true,
+		},
+		{
+			name:           "official beta tag latest is stale older beta",
+			currentVersion: "1.60.0-beta.2",
+			latestTag:      "v1.60.0-beta.1",
+			want:           false,
+		},
+		{
+			name:           "latest is older than current (rollback/local build scenario)",
+			currentVersion: "1.0.2",
+			latestTag:      "v1.0.1",
+			want:           false,
+		},
+		{
+			name:           "latest equals current with v prefix already on current",
+			currentVersion: "v1.0.1",
+			latestTag:      "v1.0.1",
+			want:           false,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -148,5 +184,107 @@ func TestCheckForUpdatesSkipsNotifierOnInvalidPayload(t *testing.T) {
 
 	if notifyCalls != 0 {
 		t.Fatalf("expected notifier to be skipped for invalid payload, got %d call(s)", notifyCalls)
+	}
+}
+
+func TestNewestReleaseTagPicksSemverMax(t *testing.T) {
+	tag, ok := updater.NewestReleaseTag([]string{"v1.60.0-beta.1", "v1.59.5", "v1.60.0-beta.2"})
+	if !ok {
+		t.Fatal("expected a newest tag")
+	}
+	if tag != "v1.60.0-beta.2" {
+		t.Fatalf("newest tag = %q, want %q", tag, "v1.60.0-beta.2")
+	}
+}
+
+func TestNewestReleaseTagIgnoresInvalidSemver(t *testing.T) {
+	tag, ok := updater.NewestReleaseTag([]string{"not-a-version", "v1.0.0"})
+	if !ok || tag != "v1.0.0" {
+		t.Fatalf("NewestReleaseTag = (%q, %v), want (\"v1.0.0\", true)", tag, ok)
+	}
+}
+
+func TestNewestReleaseTagNoneQualify(t *testing.T) {
+	_, ok := updater.NewestReleaseTag([]string{"garbage"})
+	if ok {
+		t.Fatal("expected ok=false when no tag is valid semver")
+	}
+}
+
+func TestFetchChannelReleaseBetaPicksSemverMaxAcrossOutOfOrderList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Chronologically the stable patch is listed first (published most
+		// recently) but is semver-older than the second beta - this is the
+		// list-order trap NewestReleaseTag must not fall into.
+		_, _ = w.Write([]byte(`[
+			{"tag_name":"v1.59.5","body":"stable patch"},
+			{"tag_name":"v1.60.0-beta.2","body":"newer beta"},
+			{"tag_name":"v1.60.0-beta.1","body":"older beta"}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GOVARD_UPDATE_CHECK_LIST_URL", server.URL)
+
+	release, err := updater.FetchChannelRelease(server.Client(), updater.ChannelBeta)
+	if err != nil {
+		t.Fatalf("FetchChannelRelease() error = %v", err)
+	}
+	if release.Tag != "v1.60.0-beta.2" {
+		t.Fatalf("release.Tag = %q, want %q", release.Tag, "v1.60.0-beta.2")
+	}
+	if release.Body != "newer beta" {
+		t.Fatalf("release.Body = %q, want %q", release.Body, "newer beta")
+	}
+}
+
+func TestFetchChannelReleaseStableUsesLatestEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.59.0"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GOVARD_UPDATE_CHECK_URL", server.URL)
+
+	release, err := updater.FetchChannelRelease(server.Client(), updater.ChannelStable)
+	if err != nil {
+		t.Fatalf("FetchChannelRelease() error = %v", err)
+	}
+	if release.Tag != "v1.59.0" {
+		t.Fatalf("release.Tag = %q, want %q", release.Tag, "v1.59.0")
+	}
+}
+
+func TestCheckForUpdatesUsesPersistedBetaChannel(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	if err := updater.SetChannel(updater.ChannelBeta); err != nil {
+		t.Fatalf("SetChannel(beta) error = %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"tag_name":"v9.9.9-beta.1"}]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GOVARD_UPDATE_CHECK_LIST_URL", server.URL)
+	defer updater.SetUpdateCheckHTTPClientForTest(server.Client())()
+
+	notifyCalls := 0
+	var gotLatestTag string
+	defer updater.SetUpdateCheckNotifierForTest(func(latestTag, currentVersion string) {
+		notifyCalls++
+		gotLatestTag = latestTag
+	})()
+
+	updater.CheckForUpdates("1.0.0")
+
+	if notifyCalls != 1 {
+		t.Fatalf("expected notifier to be called once, got %d", notifyCalls)
+	}
+	if gotLatestTag != "v9.9.9-beta.1" {
+		t.Fatalf("latest tag = %q, want %q", gotLatestTag, "v9.9.9-beta.1")
 	}
 }


### PR DESCRIPTION
## Summary

- Lets users opt into beta releases via `govard self-update --channel beta` (persists across runs) or a Stable/Beta toggle in Govard Desktop Settings — both read/write the same channel state.
- Beta release discovery picks the semver-greatest tag from GitHub's release list (avoiding a chronological-order trap where a stable patch published after a beta would otherwise win); stable channel behavior is unchanged (`GET /releases/latest`, already excludes prereleases).
- `.goreleaser.yml` now marks `vX.Y.Z-beta.N` tags as GitHub prereleases so they never reach stable-channel users automatically.

## Why

Govard had no way for users to try upcoming builds before stable, and no lightweight path for maintainers to cut a test build without the full stable release checklist. See linked issue for full motivation.

## Changes

- [x] Code updated
- [x] Tests added or updated (unit tests for channel persistence, channel-aware release selection incl. out-of-order-list handling, beta-tag semver comparison, CLI flag, Desktop Wails methods, elevated-self-update env forwarding, frontend toggle — all in `tests/` and `tests/frontend/`)
- [x] Documentation updated (`docs/reference/cli-commands.md`, `docs/developer/contributing.md`, both EN + VI, `CLAUDE.md`)

## Validation

```bash
make test-unit    # all passing
make test-frontend  # 71/71 passing
gofmt -s -l .     # clean
go vet ./...      # clean
```

Implemented via subagent-driven-development (10 tasks, each independently task-reviewed) plus a final whole-branch review that caught and fixed one cross-task issue: the persisted channel was silently lost when Desktop's self-update ran elevated via `pkexec` (env reset wipes `HOME`, so the update channel resolved to the wrong user's home directory) — fixed by forwarding `GOVARD_HOME_DIR` explicitly into the elevated invocation.

## Linked Issues

Closes #107