### PR TITLE
fix(sanitize): anchor sandbox-comment regex to avoid dropping real rows

### DIFF
--- a/internal/engine/sql_sanitize.go
+++ b/internal/engine/sql_sanitize.go
@@ -9,8 +9,16 @@ import (
 )
 
 var (
-	sqlDefinerPattern       = regexp.MustCompile(`DEFINER\s*=\s*[^*]+\*`)
-	sqlSandboxPattern       = regexp.MustCompile(`.*999999.*sandbox.*`)
+	sqlDefinerPattern = regexp.MustCompile(`DEFINER\s*=\s*[^*]+\*`)
+	// Matches only the literal mysqlbinlog "sandbox mode" comment artifact
+	// (e.g. `/*!999999\- enable the sandbox mode */`), anchored to the
+	// `/*!999999` version-comment delimiter and closing `*/`. Must NOT be
+	// a bare substring match: mysqldump uses --extended-insert by default,
+	// so a whole table's rows can share one line, and real data containing
+	// both the digits "999999" and the word "sandbox" (e.g. a PayPal/Braintree
+	// "sandbox" config value next to an unrelated numeric ID) would otherwise
+	// cause that entire INSERT statement to be silently dropped.
+	sqlSandboxPattern       = regexp.MustCompile(`/\*!999999.*sandbox.*\*/`)
 	sqlRowFormatPattern     = regexp.MustCompile(`ROW_FORMAT\s*=\s*FIXED`)
 	sqlCollation0900Pattern = regexp.MustCompile(`utf8mb4_0900_ai_ci`)
 	sqlCollation520Pattern  = regexp.MustCompile(`utf8(mb4)?_unicode_520_ci`)
@@ -52,7 +60,7 @@ func SanitizeSQLLine(line string) (string, bool) {
 	hasRowFormat := strings.Contains(line, "ROW_FORMAT")
 	has0900 := strings.Contains(line, "utf8mb4_0900_ai_ci")
 	has520 := strings.Contains(line, "_unicode_520_ci")
-	hasSandbox := strings.Contains(line, "sandbox")
+	hasSandbox := strings.Contains(line, "/*!999999")
 
 	// If none of these exist, return the line as-is immediately.
 	if !hasDefiner && !hasRowFormat && !has0900 && !has520 && !hasSandbox {

--- a/tests/sql_sanitize_test.go
+++ b/tests/sql_sanitize_test.go
@@ -79,9 +79,17 @@ func TestSanitizeSQLLine(t *testing.T) {
 		},
 		{
 			name:     "Remove Sandbox lines",
-			line:     "/*... 999999.*enable the sandbox mode ...*/",
+			line:     `/*!999999\- enable the sandbox mode */`,
 			expected: "",
 			keep:     false,
+		},
+		{
+			name: "Keep extended-insert row containing sandbox and 999999 as real data",
+			line: "INSERT INTO `core_config_data` VALUES (1,'default',0,'general/store_information/name','MyStore')," +
+				"(999999,'default',0,'somekey','someval'),(2,'default',0,'payment/paypal/environment','sandbox');",
+			expected: "INSERT INTO `core_config_data` VALUES (1,'default',0,'general/store_information/name','MyStore')," +
+				"(999999,'default',0,'somekey','someval'),(2,'default',0,'payment/paypal/environment','sandbox');",
+			keep: true,
 		},
 		{
 			name:     "Strip DEFINER",


### PR DESCRIPTION
## Summary

- `sync --db` and `db import --stream-db` were silently dropping rows because
  `SanitizeSQLDump`'s sandbox-comment regex (`.*999999.*sandbox.*`) matched any
  dump line containing both substrings, not just the specific mysqlbinlog artifact
  comment (`/*!999999\- enable the sandbox mode */`) it was meant to strip.
- Since `mysqldump --extended-insert` (the default here) puts a whole table's rows
  on one line, real data containing `"999999"` (e.g. an ID) and `"sandbox"`
  (e.g. a PayPal/Braintree environment setting) anywhere on that line caused the
  entire INSERT statement to be dropped with no error.
- `db import -f <file>` doesn't sanitize file-based imports at all, which is why it
  imported full data while the streaming paths (`sync --db`, `db import --stream-db`)
  came up short — same root symptom, same root cause.
- Anchored `sqlSandboxPattern` to the real `/*!999999 ... */` comment delimiters, and
  changed the fast-path substring gate from `"sandbox"` to the distinctive
  `"/*!999999"` marker.

Closes #109

## Test plan

- [x] Added regression test reproducing the false-positive drop on a synthetic
      `--extended-insert`-style line (`tests/sql_sanitize_test.go`)
- [x] Updated the existing "Remove Sandbox lines" test to use the real comment
      format (`/*!999999\- enable the sandbox mode */`) and confirmed it's still
      dropped
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] `gofmt -s -l .` shows no drift on changed files