### PR TITLE
fix(sync): guard db sync against a stopped local DB container

### DIFF
--- a/internal/cmd/sync_rsync.go
+++ b/internal/cmd/sync_rsync.go
@@ -86,6 +86,15 @@ func buildDatabaseSyncAction(config engine.Config, source SyncEndpoint, destinat
 		desc := fmt.Sprintf("ssh %s \"%s\" | docker exec -i %s sh -lc \"%s\"", remote.RemoteTarget(source.RemoteCfg), dumpCmdStr, localDBContainer, importCmdStr)
 
 		return desc, func() error {
+			// The local container is the import target here, so it must be up
+			// before we start streaming into it - otherwise `docker exec`
+			// against it can behave unpredictably (e.g. hang) instead of
+			// failing fast with a clear error (see runStreamDBImport/
+			// buildDBImportCommand, which already guard this for `db import`).
+			if err := ensureLocalDBRunning(localDBContainer); err != nil {
+				return err
+			}
+
 			spinner, _ := pterm.DefaultSpinner.Start("Fetching remote database size...")
 			totalSize, _ := GetDatabaseSize(config, source.Name, source.RemoteCfg, remoteCredentials, noNoise, noPII)
 			spinner.Success()
@@ -106,6 +115,13 @@ func buildDatabaseSyncAction(config engine.Config, source SyncEndpoint, destinat
 		desc := fmt.Sprintf("docker exec -i %s sh -lc \"%s\" | ssh %s \"%s\"", localDBContainer, dumpCmdStr, remote.RemoteTarget(destination.RemoteCfg), importCmdStr)
 
 		return desc, func() error {
+			// The local container is the dump source here, so it must be up
+			// before we start reading from it - see the comment in the
+			// remote-to-local branch above for why this matters.
+			if err := ensureLocalDBRunning(localDBContainer); err != nil {
+				return err
+			}
+
 			spinner, _ := pterm.DefaultSpinner.Start("Fetching local database size...")
 			totalSize, _ := GetDatabaseSize(config, "local", engine.RemoteConfig{}, localCredentials, noNoise, noPII)
 			spinner.Success()

--- a/tests/sync_plan_test.go
+++ b/tests/sync_plan_test.go
@@ -214,6 +214,53 @@ func TestSyncPlanDatabaseUsesTablePrefixForIgnoredTables(t *testing.T) {
 	}
 }
 
+// TestSyncPlanDatabaseActionFailsFastWhenLocalContainerNotRunning is a
+// regression test: `sync --db` used to build and start the remote dump /
+// local import pipeline without ever checking the local DB container was
+// up, so against a stopped/missing container it could hang indefinitely
+// (docker exec behaving unpredictably) instead of failing with a clear
+// error - unlike `db import --stream-db`, which already guarded this. The
+// database action must now fail fast, before touching docker exec at all.
+func TestSyncPlanDatabaseActionFailsFastWhenLocalContainerNotRunning(t *testing.T) {
+	config := engine.Config{
+		ProjectName: "test-project",
+		Framework:   "custom",
+	}
+
+	endpoints := cmd.ResolveSyncEndpointsForTest(
+		cmd.SyncEndpoint{
+			Name:     "production",
+			IsLocal:  false,
+			RootPath: "/var/www/html",
+			RemoteCfg: engine.RemoteConfig{
+				Host: "production.example.com",
+				Path: "/var/www/html",
+			},
+		},
+		cmd.SyncEndpoint{Name: "local", IsLocal: true, RootPath: "/home/user/project"},
+	)
+
+	opts := cmd.SyncExecutionOptionsForTest(false, "", true)
+
+	plan, err := cmd.BuildSyncExecutionPlanForTest(config, endpoints, opts)
+	if err != nil {
+		t.Fatalf("BuildSyncExecutionPlanForTest() error = %v", err)
+	}
+	if len(plan.DatabaseActions) != 1 {
+		t.Fatalf("expected 1 database action, got %d", len(plan.DatabaseActions))
+	}
+
+	// No real "test-project-db-1" container exists in this hermetic test
+	// environment, so running the action must surface that immediately.
+	actionErr := plan.DatabaseActions[0]()
+	if actionErr == nil {
+		t.Fatal("expected database action to fail when the local container is not running, got nil error")
+	}
+	if !strings.Contains(actionErr.Error(), "is not running") {
+		t.Fatalf("expected a clear 'not running' error, got: %v", actionErr)
+	}
+}
+
 func TestSyncPlanDatabaseStopsWhenRemoteCredentialsCannotBeResolved(t *testing.T) {
 	// Magento2 resolves DB credentials by probing the remote over SSH for .env/env.php.
 	// Against a host that can't be reached, that probe fails -- the sync must stop


### PR DESCRIPTION
## Summary

- `sync --db` (both directions) built and ran the docker exec dump/import
  pipeline against the local DB container without ever checking it was
  running, unlike `db import --stream-db` / `db dump`/`db import -f`, which
  already guard this via `ensureLocalDBRunning`.
- Against a stopped/missing local container, `docker exec` can behave
  unpredictably instead of failing fast - in the reported case, the whole
  `sync --db` command hung indefinitely with no error.
- Root-caused via a `SIGQUIT` goroutine dump of the stuck process: the main
  goroutine was blocked in `importCmd.Wait()` (`db.go:1113`) after the remote
  dump had already finished - so the remote/SSH side was never the problem.
  Confirmed with the reporting user: running `govard env up` first (bringing
  the local container up) made the exact same `sync --db` command succeed.
- Added the same `ensureLocalDBRunning` guard to both sync-direction action
  closures in `buildDatabaseSyncAction`, right before the docker exec command
  is built/run - so a stopped container now fails immediately with
  `database container <name> is not running` instead of hanging.

Closes #111

## Test plan

- [x] Added `TestSyncPlanDatabaseActionFailsFastWhenLocalContainerNotRunning`
      (`tests/sync_plan_test.go`) - runs the actual returned DB action closure
      against a hermetic test environment with no real container, asserting
      it fails fast with a clear "is not running" error instead of hanging
- [x] Existing `TestSyncPlanScopes` / `TestSyncPlanDatabaseStopsWhenRemoteCredentialsCannotBeResolved`
      still pass (the guard lives inside the action closure, not at plan-build
      time, so hermetic plan-building tests are unaffected)
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] `gofmt -s -l .` shows no drift on changed files