### PR TITLE
fix(release): compute previous stable tag for GoReleaser changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
+      - name: Determine previous stable tag
+        id: prev_tag
+        run: |
+          PREV_TAG=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags \
+            | grep -v -- '-' \
+            | grep -vFx "${GITHUB_REF_NAME}" \
+            | head -n1)
+          echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --previous-tag=${{ steps.prev_tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- `v1.60.0`'s GitHub release notes shipped empty (just the GoReleaser footer) because GoReleaser's default "previous tag" resolution picked up `v1.60.0-beta.2` instead of `v1.59.0`, and the only commit in between (`chore: release v1.60.0`) is excluded by `changelog.filters`.
- Added a step to `.github/workflows/release.yml` that computes the latest **non-prerelease** tag (excluding the tag currently being released) and passes it to GoReleaser via `--previous-tag`, so the changelog always diffs against the last stable release regardless of intervening beta tags.

Closes #116

## Test plan
- [x] Verified locally: for `v1.60.0`, the new lookup logic (`git for-each-ref` sorted by creatordate, filtered to tags without `-`, excluding self) resolves to `v1.59.0` — matching the range that produced the correct local `CHANGELOG.md` entry.
- [ ] Next real stable-release cut (with at least one beta tag ahead of it) confirms the GitHub Release page shows a populated changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)