### PR TITLE
docs: add release downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/ddtcorex/govard)](https://go.dev/)
 [![License](https://img.shields.io/github/license/ddtcorex/govard)](LICENSE)
 [![Releases](https://img.shields.io/github/v/release/ddtcorex/govard)](https://github.com/ddtcorex/govard/releases)
+[![Release downloads](https://img.shields.io/github/downloads/ddtcorex/govard/total?label=Release%20downloads)](https://github.com/ddtcorex/govard/releases)
 [![CI Pipeline](https://github.com/ddtcorex/govard/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/ddtcorex/govard/actions/workflows/ci-pipeline.yml)
 
 **Govard** is a professional-grade local development orchestrator engineered in Go. It is designed to replace legacy bash-based tools with a high-performance, native binary that manages complex containerized environments with a focus on stability, speed, and a premium developer experience.


### PR DESCRIPTION
## Summary
- add a Shields.io badge for cumulative GitHub Release asset downloads
- link the badge to the Govard Releases page

## Verification
- `git diff --check`
- `go test ./...`
- verified badge endpoint returns HTTP 200 with `image/svg+xml`