### PR TITLE
docs: add AGENTS.md symlink so Codex CLI follows CLAUDE.md rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Go-based local development orchestrator for PHP and web projects (Magento, Laravel, Symfony, WordPress, etc.).
 
+`AGENTS.md` at the repo root is a symlink to this file, so Codex CLI (which reads `AGENTS.md`, not `CLAUDE.md`) follows the same rules. Edit `CLAUDE.md` only — never edit `AGENTS.md` directly or replace the symlink with a copy.
+
 ## Quick Reference
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` at the repo root as a symlink to `CLAUDE.md`, so Codex CLI (which reads `AGENTS.md`, not `CLAUDE.md`) picks up the exact same conventions Claude Code already follows — single source of truth, zero drift risk.
- Note the symlink at the top of `CLAUDE.md` so it's clear which file to edit.

## Rationale

Codex CLI has no visibility into `CLAUDE.md` today. This was the root cause behind several convention violations found while rescuing an interrupted Codex feature branch (PR #123): a `CHANGELOG.md` edit on a feature branch, a hardcoded framework-name check outside the isolation rule, a stale PR description after a squash, and a real regression dismissed as "unrelated" without checking `master`. None of those rules could have been followed by Codex because it never read them.

`AGENTS.md` is force-added because this machine's global git ignore excludes it (and `CLAUDE.md`) by default as a personal-workspace convention; this repo already deliberately overrides that for `CLAUDE.md` so the whole team shares conventions, and the same override now extends to `AGENTS.md`.

## Test plan

- [x] Docs-only change (a symlink + a 2-line note). `go build ./...` still succeeds; no `go:embed` directive globs the repo root, so the new file has no build impact.
- [x] Verified the symlink resolves and its content is byte-identical to `CLAUDE.md`.

Closes #127