### PR TITLE
fix(build): stop make test/build from regenerating desktop CSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,21 @@ install: ## Build and install Govard CLI + Desktop binaries from current source 
 install-release: ## Install latest release Govard CLI + Desktop binaries to system
 	./install.sh -y
 
+# build-frontend regenerates the desktop app's embedded CSS from its Tailwind
+# source. Only run it deliberately after editing desktop/frontend/assets/styles-src.css
+# and commit the result - cmd/govard/main.go (built below) does not import
+# desktop/frontend's embed.FS at all, and cmd/govard-desktop (built by install.sh)
+# embeds whatever is already committed, so neither needs this as a prerequisite.
 build-frontend:
 	@echo "Building frontend assets..."
 	@cd desktop/frontend && yarn install && yarn run build:css
 
-build: generate build-frontend ## Build Govard binary for the current platform
+build: generate ## Build Govard binary for the current platform
 	@echo "Building Govard..."
 	mkdir -p $(BUILD_DIR)
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) cmd/govard/main.go
 
-build-test-binary: build-frontend
+build-test-binary:
 	@echo "Building test binary..."
 	mkdir -p $(BUILD_DIR)
 	go build -mod=mod -ldflags "$(LDFLAGS)" -tags integration -o $(TEST_BINARY) cmd/govard/main.go


### PR DESCRIPTION
## Summary

- Removed `build-frontend` as a prerequisite of `build` and `build-test-binary` (used by `test-integration`/`make test`). Neither target needs it: `cmd/govard/main.go` never imports `desktop/frontend`'s `embed.FS`, and `install.sh` builds `cmd/govard-desktop` directly against whatever CSS is already committed, without calling `build-frontend`.
- `build-frontend` remains available as its own target, with a comment explaining when to actually run it (after editing `styles-src.css`, then commit the regenerated `styles.css`).

## Rationale

Every `make test`/`make build` run re-minified `desktop/frontend/assets/styles.css` via Tailwind, producing a several-hundred-KB byte-level diff (ordering/whitespace from the minifier, not real content changes) that had to be manually reverted before every commit. This was especially disruptive during iterative work needing many `make test` runs (e.g. PR #123).

## Test plan

- [x] `make test` run to completion — `git status` shows no change to `desktop/frontend/assets/styles.css`.
- [x] `make build` run to completion — same, plus verified `./bin/govard version` still works.
- [x] `make build-frontend` still works standalone when run explicitly.

Closes #129