### PR TITLE
fix(compose): persist redis/valkey and rabbitmq data across env down/up

### DIFF
--- a/internal/blueprints/files/includes/rabbitmq.yml
+++ b/internal/blueprints/files/includes/rabbitmq.yml
@@ -7,6 +7,10 @@ services:
     image: {{ $.ImageRepository }}rabbitmq:{{ $queueVersion }}
     volumes:
       - '{{ .RabbitMQConfPath }}:/etc/rabbitmq/rabbitmq.conf:ro'
+      - rabbitmq-data{{ if .Config.Profile }}-{{ .Config.Profile }}{{ end }}:/var/lib/rabbitmq
     networks:
       - govard-net
+
+volumes:
+  rabbitmq-data{{ if .Config.Profile }}-{{ .Config.Profile }}{{ end }}:
 {{ end }}

--- a/internal/blueprints/files/includes/redis.yml
+++ b/internal/blueprints/files/includes/redis.yml
@@ -5,6 +5,11 @@ services:
   redis:
     hostname: {{ .Config.ProjectName }}-redis
     image: {{ if eq $cache "valkey" }}{{ $.ImageRepository }}valkey:{{ $cacheVersion }}{{ else }}{{ $.ImageRepository }}redis:{{ $cacheVersion }}{{ end }}
+    volumes:
+      - cache-data{{ if .Config.Profile }}-{{ .Config.Profile }}{{ end }}:/data
     networks:
       - govard-net
+
+volumes:
+  cache-data{{ if .Config.Profile }}-{{ .Config.Profile }}{{ end }}:
 {{ end }}

--- a/internal/blueprints/files/proxy.yml
+++ b/internal/blueprints/files/proxy.yml
@@ -1,6 +1,6 @@
 services:
   caddy:
-    image: caddy:latest
+    image: caddy:2.11.4
     container_name: govard-proxy-caddy
     restart: always
     command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile --resume
@@ -16,7 +16,7 @@ services:
       - govard-proxy
 
   mail:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.30.7
     container_name: govard-proxy-mail
     restart: always
     environment:
@@ -58,7 +58,7 @@ services:
       - govard-proxy
 
   portainer:
-    image: portainer/portainer-ce:latest
+    image: portainer/portainer-ce:2.39.5
     container_name: govard-proxy-portainer
     restart: always
     command: --admin-password '$$2y$$05$$kPildpVdhSHibCqqR8HFWO2XpZl2mWCo4eJ84LCZJrInbIQIiJu5u'


### PR DESCRIPTION
Closes #131

## Summary
- `redis.yml`/`rabbitmq.yml` didn't mount an explicit volume for their images' unbound Dockerfile `VOLUME` paths (`/data`, `/var/lib/rabbitmq`), so every `env down` + `env up` cycle created a fresh anonymous volume and silently wiped cache/queue data, orphaning the previous volume.
- Added explicit named volumes `cache-data`/`rabbitmq-data` (with the existing `-{{ .Config.Profile }}` suffix pattern used by `db-data`/`search-data`), so data now persists across the cycle instead of resetting.
- While investigating the same class of issue for images: pinned `caddy`, `axllent/mailpit`, and `portainer/portainer-ce` in the shared proxy stack (`proxy.yml`) to specific versions instead of `:latest`, since every re-pull under a mutable tag was leaving the previous image dangling. `ddtcorex/govard-dnsmasq` only has a `latest` tag published (no versioned alternative), kept as `:latest` by design.

## Test plan
- [x] `go test ./...` — all unit tests pass
- [x] `make test` (lint + fmt-check + vet + unit + integration) — full suite pass
- [x] `gofmt -s -l .` — no drift
- [x] Rendered the redis/rabbitmq compose output via `engine.RenderBlueprint` and validated with real `docker compose config` — valid YAML/schema
- [x] Validated `proxy.yml` with `docker compose config` after the version pins
- [x] Confirmed via `docker image inspect` that `ddtcorex/govard-redis`/`govard-valkey` declare `VOLUME /data` and `ddtcorex/govard-rabbitmq` declares `VOLUME /var/lib/rabbitmq`, and that the pinned proxy versions (`caddy:2.11.4`, `mailpit:v1.30.7`, `portainer-ce:2.39.5`) exist on Docker Hub and match the currently-running containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)