### PR TITLE
feat(docker): publish versioned tags for the dnsmasq image

### DIFF
--- a/docker/dnsmasq/Dockerfile
+++ b/docker/dnsmasq/Dockerfile
@@ -1,4 +1,10 @@
-FROM alpine:latest
+ARG ALPINE_VERSION=3.24
+FROM alpine:${ALPINE_VERSION}
+ARG ALPINE_VERSION
+
+LABEL dev.govard.image.name="dnsmasq"
+LABEL dev.govard.dnsmasq.version="${ALPINE_VERSION}"
+
 RUN apk add --no-cache dnsmasq
 EXPOSE 53/tcp 53/udp
 ENTRYPOINT ["dnsmasq", "-k"]

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -332,6 +332,13 @@ target "varnish" {
 
 # ─── Dnsmasq ───────────────────────────────────────────────────────────────
 target "dnsmasq" {
+  name    = "dnsmasq-${replace(version, ".", "-")}"
   context = "docker/dnsmasq"
-  tags    = ["${DOCKER_ORG}dnsmasq:latest"]
+  matrix = {
+    version = ["3.24", "latest"]
+  }
+  args = {
+    ALPINE_VERSION = version == "latest" ? "3.24" : version
+  }
+  tags = ["${DOCKER_ORG}dnsmasq:${version}"]
 }

--- a/internal/blueprints/files/proxy.yml
+++ b/internal/blueprints/files/proxy.yml
@@ -45,7 +45,7 @@ services:
       - govard-proxy
 
   dnsmasq:
-    image: ddtcorex/govard-dnsmasq:latest
+    image: ddtcorex/govard-dnsmasq:3.24
     container_name: govard-proxy-dnsmasq
     restart: always
     cap_add:


### PR DESCRIPTION
Closes #133

## Summary
- `dnsmasq` was the only image target in `docker/docker-bake.hcl` with no version matrix — always built and pushed as a single mutable `latest` tag, so every re-pull left the previous digest dangling once the proxy container was recreated (same failure mode as the volume issue in #131/#132).
- Parameterized `docker/dnsmasq/Dockerfile` with `ARG ALPINE_VERSION` (default `3.24`, matching what `alpine:latest` currently resolves to) and added a `matrix = { version = ["3.24", "latest"] }` to the bake target, following the same pattern already used by `apache`/`nginx`/`varnish` (pinned versions alongside a floating `latest`).
- Built and pushed both tags to Docker Hub (`ddtcorex/govard-dnsmasq:3.24` and `:latest`, same digest).
- Pinned `proxy.yml` to `ddtcorex/govard-dnsmasq:3.24`.

## Test plan
- [x] `docker buildx bake -f docker/docker-bake.hcl --print dnsmasq` — resolves to two targets (`dnsmasq-3-24`, `dnsmasq-latest`) with correct args/tags
- [x] `docker buildx bake -f docker/docker-bake.hcl --load dnsmasq` — both tags build locally; `apk add dnsmasq` installs cleanly on `alpine:3.24`
- [x] `docker buildx bake -f docker/docker-bake.hcl --push dnsmasq` — pushed successfully; verified live on Docker Hub via API, both tags resolve to the same digest
- [x] `docker pull ddtcorex/govard-dnsmasq:3.24` — succeeds, matches the pushed digest
- [x] `docker compose -f internal/blueprints/files/proxy.yml config` — valid after the pin
- [x] `go test ./...` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)