### PR TITLE
chore: release v1.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.62.0] - 2026-08-12
+
+### ✨ New Features
+
+- **On-Demand Magento Frontend Runtime:** `govard env up` now starts application infrastructure only for Magento 2/Mage-OS projects; frontend tooling starts explicitly with `govard frontend start`. Hyva projects get the theme-owned `browser-sync` plus Tailwind watchers; Luma projects get `grunt watch` with LiveReload exposed through Caddy. Both auto-inject their client script into real page loads via a dedicated HTML-injection proxy. `govard frontend stop`/`govard frontend logs` manage the frontend runtime independently of the application stack.
+- **Versioned dnsmasq Image:** The dnsmasq proxy image now publishes a real version tag (parameterized by `ALPINE_VERSION`), matching every other bake target, instead of only floating `:latest`.
+
+### 🛠 Improvements
+
+- **Persistent Redis/Valkey and RabbitMQ Data:** Added explicit named volumes for redis/valkey and RabbitMQ, matching the existing db-data/search-data pattern, so `govard env down` + `env up` no longer silently wipes cache/queue data via orphaned anonymous volumes.
+- Pinned Caddy, Mailpit, Portainer, and dnsmasq in the shared proxy stack to specific versions instead of `:latest`, so re-pulls stop leaving dangling images behind.
+- `make test`/`make build` no longer regenerate `desktop/frontend/assets/styles.css` as a side effect; run `make build-frontend` explicitly after editing `styles-src.css`.
+
+### 🐛 Bug Fixes
+
+- **Dependabot Alert GHSA-fxqj-rqcc-2cmp:** Bumped the pinned postcss version (via yarn `resolutions`) to 8.5.26, the first release with a complete fix for the `sourceMappingURL` arbitrary `.map` file read.
+
+### 📚 Documentation
+
+- Added an `AGENTS.md` symlink to `CLAUDE.md` so Codex CLI picks up the same project conventions as Claude Code.
+
 ## [1.61.0] - 2026-08-10
 
 ### ✨ New Features

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.61.0"
+    "productVersion": "1.62.0"
   }
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.61.0"
+var Version = "1.62.0"
 
 var verbose bool
 

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.61.0"
+var Version = "1.62.0"
 
 type App struct {
 	ctx context.Context


### PR DESCRIPTION
## Summary
- Bumps version to 1.62.0 in `internal/cmd/root.go`, `internal/desktop/app.go`, `desktop/frontend/package.json`, and `desktop/wails.json`.
- Adds the v1.62.0 CHANGELOG entry covering everything shipped since v1.61.0:
  - **New:** on-demand Magento frontend runtime (`govard frontend start/stop/logs`, #123), versioned dnsmasq image (#134)
  - **Improvements:** persistent redis/valkey + RabbitMQ volumes (#132), pinned proxy image versions, `make test`/`make build` no longer regenerate desktop CSS (#130)
  - **Fix:** postcss bump for Dependabot alert GHSA-fxqj-rqcc-2cmp (#136)
  - **Docs:** AGENTS.md symlink for Codex CLI (#128)

## Test plan
- [x] `make test` (lint + fmt + vet + unit + integration) passes
- [x] `make build` succeeds; `./bin/govard version` runs (version string resolves from `git describe`, will read `v1.62.0` once this is merged and tagged)
- [ ] After merge: tag `v1.62.0` on `master` and push the tag to trigger `.github/workflows/release.yml`