### PR TITLE
fix(engine): skip re-downloading composer.phar when version already active

### DIFF
--- a/internal/engine/composer_compatibility.go
+++ b/internal/engine/composer_compatibility.go
@@ -82,15 +82,7 @@ func ensureSpecificComposerVersion(config Config, version string) error {
 		}
 	}
 
-	script := fmt.Sprintf(`
-		case "%[1]s" in
-			1)   [ -f /usr/local/bin/composer1 ]   && echo "Using pre-baked Composer version 1..." && ln -sf /usr/local/bin/composer1 $(which composer) && exit 0 ;;
-			2)   [ -f /usr/local/bin/composer2 ]   && echo "Using pre-baked Composer version 2..." && ln -sf /usr/local/bin/composer2 $(which composer) && exit 0 ;;
-			2.2) [ -f /usr/local/bin/composer2lts ] && echo "Using pre-baked Composer version 2.2..." && ln -sf /usr/local/bin/composer2lts $(which composer) && exit 0 ;;
-		esac
-		echo "Ensuring Composer version %[1]s (downloading from %[2]s)..."
-		curl -sSfL %[2]s -o /tmp/composer.phar && chmod +x /tmp/composer.phar && mv /tmp/composer.phar $(which composer)
-	`, version, downloadUrl)
+	script := buildComposerEnsureScript(version, downloadUrl)
 
 	cmd := exec.Command("docker", "exec", "-u", "root", containerName, "sh", "-c", script)
 	out, err := cmd.CombinedOutput()
@@ -105,6 +97,33 @@ func ensureSpecificComposerVersion(config Config, version string) error {
 
 	pterm.Success.Printf("Composer %s is now active.\n", version)
 	return nil
+}
+
+// buildComposerEnsureScript builds the in-container shell script that makes
+// the given Composer version active. It skips the network download when a
+// pre-baked binary already matches, or when the currently active `composer`
+// already reports the exact target version — otherwise `env up` would
+// re-download composer.phar from getcomposer.org on every single run.
+func buildComposerEnsureScript(version, downloadUrl string) string {
+	return fmt.Sprintf(`
+		case "%[1]s" in
+			1)   [ -f /usr/local/bin/composer1 ]   && echo "Using pre-baked Composer version 1..." && ln -sf /usr/local/bin/composer1 $(which composer) && exit 0 ;;
+			2)   [ -f /usr/local/bin/composer2 ]   && echo "Using pre-baked Composer version 2..." && ln -sf /usr/local/bin/composer2 $(which composer) && exit 0 ;;
+			2.2) [ -f /usr/local/bin/composer2lts ] && echo "Using pre-baked Composer version 2.2..." && ln -sf /usr/local/bin/composer2lts $(which composer) && exit 0 ;;
+		esac
+		CURRENT_VERSION=$(composer --version 2>/dev/null | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+		if [ "$CURRENT_VERSION" = "%[1]s" ]; then
+			echo "Composer %[1]s is already active, skipping download."
+			exit 0
+		fi
+		echo "Ensuring Composer version %[1]s (downloading from %[2]s)..."
+		curl -sSfL %[2]s -o /tmp/composer.phar && chmod +x /tmp/composer.phar && mv /tmp/composer.phar $(which composer)
+	`, version, downloadUrl)
+}
+
+// BuildComposerEnsureScriptForTest exposes buildComposerEnsureScript for tests.
+func BuildComposerEnsureScriptForTest(version, downloadUrl string) string {
+	return buildComposerEnsureScript(version, downloadUrl)
 }
 
 func isMinorComposerVersion(version string) bool {

--- a/tests/composer_compatibility_test.go
+++ b/tests/composer_compatibility_test.go
@@ -1,0 +1,80 @@
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"govard/internal/engine"
+)
+
+// runComposerEnsureScript executes the generated script hermetically via the
+// host's own /bin/sh, with fake `composer`/`curl` binaries standing in for
+// the ones that would normally exist inside a project's PHP container.
+func runComposerEnsureScript(t *testing.T, version, fakeInstalledVersion string) (output string, curlCalled bool) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("script targets POSIX sh, not available on windows")
+	}
+
+	binDir := t.TempDir()
+	curlMarker := filepath.Join(t.TempDir(), "curl-called")
+
+	composerScript := "#!/bin/sh\necho \"Composer version " + fakeInstalledVersion + " 2024-01-01 12:00:00\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "composer"), []byte(composerScript), 0o755); err != nil {
+		t.Fatalf("write fake composer: %v", err)
+	}
+
+	curlScript := "#!/bin/sh\n" +
+		"touch '" + curlMarker + "'\n" +
+		"while [ \"$#\" -gt 0 ]; do\n" +
+		"  if [ \"$1\" = \"-o\" ]; then\n" +
+		"    shift\n" +
+		"    echo fake-phar-content > \"$1\"\n" +
+		"  fi\n" +
+		"  shift\n" +
+		"done\n"
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte(curlScript), 0o755); err != nil {
+		t.Fatalf("write fake curl: %v", err)
+	}
+
+	downloadedPhar := filepath.Join(t.TempDir(), "composer.phar")
+	script := engine.BuildComposerEnsureScriptForTest(version, "http://example.invalid/composer.phar")
+	script = strings.ReplaceAll(script, "/tmp/composer.phar", downloadedPhar)
+
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = append(os.Environ(), "PATH="+binDir+":"+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\noutput: %s", err, out)
+	}
+
+	_, statErr := os.Stat(curlMarker)
+	return string(out), statErr == nil
+}
+
+func TestComposerEnsureScriptSkipsDownloadWhenVersionAlreadyActive(t *testing.T) {
+	output, curlCalled := runComposerEnsureScript(t, "2.9.8", "2.9.8")
+
+	if curlCalled {
+		t.Fatalf("expected curl NOT to run when the active Composer version already matches, output: %s", output)
+	}
+	if !strings.Contains(output, "already active, skipping download") {
+		t.Fatalf("expected skip message in output, got: %s", output)
+	}
+}
+
+func TestComposerEnsureScriptDownloadsWhenVersionDiffers(t *testing.T) {
+	output, curlCalled := runComposerEnsureScript(t, "2.9.8", "2.8.0")
+
+	if !curlCalled {
+		t.Fatalf("expected curl to run when the active Composer version differs, output: %s", output)
+	}
+	if strings.Contains(output, "skipping download") {
+		t.Fatalf("did not expect skip message, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- `ensureSpecificComposerVersion` had a pre-baked fast path only for literal versions `1`, `2`, `2.2` — any other explicit version (e.g. minor `2.9` resolved to patch `2.9.8`) always fell through to a `curl` download of `composer.phar` on every `govard env up`, even when the container already had that exact version.
- Extracted the in-container script into `buildComposerEnsureScript` and added a check of the container's active `composer --version`: skip the download when it already matches the target version.

Closes #138

## Test plan
- [x] New hermetic test (`tests/composer_compatibility_test.go`) runs the generated script via the host's `sh` with fake `composer`/`curl` binaries on `PATH` — no Docker/network required.
  - `TestComposerEnsureScriptSkipsDownloadWhenVersionAlreadyActive`: verifies `curl` is NOT invoked when the active version already matches.
  - `TestComposerEnsureScriptDownloadsWhenVersionDiffers`: verifies `curl` IS invoked when versions differ (regression guard on the existing download path).
- [x] Confirmed the bug: temporarily reverted the fix (`git stash`) — the test helper `BuildComposerEnsureScriptForTest` didn't exist on old code, confirming there was previously no skip path to test.
- [x] `go build ./...`, `go vet ./...`, `gofmt -s -l` clean
- [x] `go test ./...` — full suite passes