### PR TITLE
fix(engine): normalize literal "default" profile in ResolveEffectiveProfile

### DIFF
--- a/internal/engine/profile_shift.go
+++ b/internal/engine/profile_shift.go
@@ -152,7 +152,16 @@ func PrepareInfraForShift(projectName string, config Config) {
 
 // ResolveEffectiveProfile resolves the effective profile for a project.
 // Priority: 1. explicit profile (--profile flag), 2. project registry (last-used), 3. empty (default)
+//
+// The literal name "default" is treated as the empty/no-profile sentinel,
+// matching `config profile switch default` (internal/cmd/profile.go), so
+// `--profile default` never diverges into its own "-default"-suffixed
+// compose file, volumes, or containers.
 func ResolveEffectiveProfile(projectPath, explicitProfile string) string {
+	explicitProfile = strings.TrimSpace(explicitProfile)
+	if explicitProfile == "default" {
+		explicitProfile = ""
+	}
 	if explicitProfile != "" {
 		return explicitProfile
 	}

--- a/tests/profile_switch_test.go
+++ b/tests/profile_switch_test.go
@@ -179,6 +179,21 @@ func TestResolveEffectiveProfile(t *testing.T) {
 	}
 }
 
+// TestResolveEffectiveProfileLiteralDefault ensures `--profile default` resolves
+// to the empty profile, exactly like `config profile switch default` does
+// (internal/cmd/profile.go normalizes the "default" argument to "" before
+// saving it to the registry). Without this, "env up --profile default" would
+// diverge from the registry-driven default and suffix compose/volume names
+// with "-default" instead of leaving them unsuffixed.
+func TestResolveEffectiveProfileLiteralDefault(t *testing.T) {
+	tempDir := t.TempDir()
+
+	result := engine.ResolveEffectiveProfile(tempDir, "default")
+	if result != "" {
+		t.Errorf(`ResolveEffectiveProfile(%q, "default") = %q, want "" (literal "default" must normalize to the empty/no-profile sentinel)`, tempDir, result)
+	}
+}
+
 func TestProfileSwitchSavesPreviousProfile(t *testing.T) {
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- `govard env up --profile default` diverged from `govard config profile switch default` — it created a separate, `-default`-suffixed compose file/containers/volumes instead of the real (unsuffixed) default environment.
- Root cause: `engine.ResolveEffectiveProfile`, the single choke point every `--profile`-aware command routes through (`env up`, `db`, `frontend`, `init`, `observability`, `doctor fix`), passed the literal `"default"` flag value straight through instead of normalizing it to the empty/no-profile sentinel, unlike `config profile switch` which already did that normalization for its own argument.
- Fix: normalize `"default"` -> `""` inside `ResolveEffectiveProfile` itself, so every caller gets consistent behavior for free.

Closes #140

## Test plan

- [x] Added `TestResolveEffectiveProfileLiteralDefault` in `tests/profile_switch_test.go` — reproduced the bug as a failing test before the fix, confirmed green after.
- [x] `go build ./...`, `go vet ./...`, `gofmt -s -l` — clean.
- [x] Full `make test` (lint, fmt-check, vet, unit, integration, frontend) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)