### PR TITLE
chore: release v1.62.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.62.1] - 2026-08-12
+
+### 🐛 Bug Fixes
+
+- **`env up --profile default` Matched `config profile switch default`:** `ResolveEffectiveProfile`, the shared resolution point behind every `--profile`-aware command (`env up`, `db`, `frontend`, `init`, `observability`, `doctor fix`), passed the literal `"default"` flag value straight through instead of normalizing it to the empty/no-profile sentinel like `config profile switch` already did. This made `--profile default` stand up a separate, `-default`-suffixed compose file, containers, and volumes instead of reusing the real default environment.
+- **Composer Version Re-Downloads on Every `env up`:** `ensureSpecificComposerVersion` only had a fast path for the literal versions `1`, `2`, `2.2`; any explicit patch/minor version (e.g. `2.9` resolving to `2.9.8`) re-downloaded `composer.phar` from getcomposer.org on every `govard env up`, even when the container already had that exact version installed. It now checks the container's active `composer --version` first.
+
 ## [1.62.0] - 2026-08-12
 
 ### ✨ New Features

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.62.0",
+  "version": "1.62.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.62.0"
+    "productVersion": "1.62.1"
   }
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.62.0"
+var Version = "1.62.1"
 
 var verbose bool
 

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.62.0"
+var Version = "1.62.1"
 
 type App struct {
 	ctx context.Context


### PR DESCRIPTION
## Summary

- Bumps version strings across `root.go`, `app.go`, `package.json`, and `wails.json` to 1.62.1.
- Adds the v1.62.1 CHANGELOG entry for the two fixes shipped since v1.62.0:
  - `env up --profile default` now matches `config profile switch default` (#141)
  - Composer no longer re-downloads `composer.phar` when the exact version is already active (#139)

## Test plan

- [x] `make test` (lint, fmt-check, vet, unit, integration, frontend) passes
- [x] `make build && ./bin/govard version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)