### PR TITLE
fix(engine): explicit --profile default must override registry, not fall through to it

### DIFF
--- a/internal/engine/profile_shift.go
+++ b/internal/engine/profile_shift.go
@@ -156,11 +156,14 @@ func PrepareInfraForShift(projectName string, config Config) {
 // The literal name "default" is treated as the empty/no-profile sentinel,
 // matching `config profile switch default` (internal/cmd/profile.go), so
 // `--profile default` never diverges into its own "-default"-suffixed
-// compose file, volumes, or containers.
+// compose file, volumes, or containers. It must return immediately rather
+// than fall through to the registry lookup below: that lookup exists for
+// "no --profile flag given at all", and an explicit "default" has to win
+// over whatever profile the registry has saved, not be treated as absent.
 func ResolveEffectiveProfile(projectPath, explicitProfile string) string {
 	explicitProfile = strings.TrimSpace(explicitProfile)
 	if explicitProfile == "default" {
-		explicitProfile = ""
+		return ""
 	}
 	if explicitProfile != "" {
 		return explicitProfile

--- a/tests/profile_switch_test.go
+++ b/tests/profile_switch_test.go
@@ -194,6 +194,33 @@ func TestResolveEffectiveProfileLiteralDefault(t *testing.T) {
 	}
 }
 
+// TestResolveEffectiveProfileLiteralDefaultOverridesRegistry ensures an
+// explicit `--profile default` always wins, even when the project registry
+// has a different last-used profile saved (e.g. from a prior
+// `config profile switch upgrade` or a previous `env up --profile upgrade`).
+// Reproduces a live regression: normalizing "default" to "" before the
+// "was an explicit flag given at all?" check made it indistinguishable from
+// "no --profile flag passed", so it fell through to the registry lookup and
+// resurrected the stale "upgrade" profile instead of the requested default.
+func TestResolveEffectiveProfileLiteralDefaultOverridesRegistry(t *testing.T) {
+	tempDir := t.TempDir()
+	registryPath := filepath.Join(t.TempDir(), "projects.json")
+	t.Setenv(engine.ProjectRegistryPathEnvVar, registryPath)
+
+	entry := engine.ProjectRegistryEntry{
+		Path:    tempDir,
+		Profile: "upgrade",
+	}
+	if err := engine.UpsertProjectRegistryEntry(entry); err != nil {
+		t.Fatal(err)
+	}
+
+	result := engine.ResolveEffectiveProfile(tempDir, "default")
+	if result != "" {
+		t.Errorf(`ResolveEffectiveProfile(%q, "default") = %q, want "" (explicit "default" must override the registry's saved "upgrade" profile)`, tempDir, result)
+	}
+}
+
 func TestProfileSwitchSavesPreviousProfile(t *testing.T) {
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- Regression in v1.62.1 (#141): `govard env up --profile default` resurrected the project's last-used registry profile (e.g. `upgrade`) instead of resolving to the default/empty profile.
- Root cause: the v1.62.1 fix normalized the literal `"default"` value to `""` *before* the "was an explicit flag given at all?" check, making it indistinguishable from "no `--profile` flag passed" and falling through to the registry-fallback branch.
- Fix: return `""` immediately for the literal `"default"` case instead of reassigning `explicitProfile` and falling through.

Closes #143

## Test plan

- [x] Added `TestResolveEffectiveProfileLiteralDefaultOverridesRegistry` — sets up a registry entry with a different saved profile, reproduces the bug as a failing test, confirmed green after the fix.
- [x] `go build ./...`, `go vet ./...`, `gofmt -s -l` — clean.
- [x] Full `make test` (lint, fmt-check, vet, unit, integration, frontend) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)