### PR TITLE
chore: release v1.62.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.62.2] - 2026-08-12
+
+### 🐛 Bug Fixes
+
+- **`env up --profile default` Regression (v1.62.1):** The previous fix normalized the literal `"default"` flag value to `""` before checking whether an explicit `--profile` flag had been given at all, making an explicit `--profile default` indistinguishable from "no flag passed" and letting it fall through to the project registry's saved profile (e.g. resurrecting `upgrade` instead of resolving to the default). `--profile default` now returns the empty/no-profile sentinel immediately, overriding the registry as intended.
+
 ## [1.62.1] - 2026-08-12
 
 ### 🐛 Bug Fixes

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.62.1",
+  "version": "1.62.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.62.1"
+    "productVersion": "1.62.2"
   }
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.62.1"
+var Version = "1.62.2"
 
 var verbose bool
 

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.62.1"
+var Version = "1.62.2"
 
 type App struct {
 	ctx context.Context


### PR DESCRIPTION
## Summary

- Bumps version strings across `root.go`, `app.go`, `package.json`, and `wails.json` to 1.62.2.
- Adds the v1.62.2 CHANGELOG entry for the regression fix shipped since v1.62.1: `--profile default` was falling through to the project registry's saved profile instead of overriding it (#144).

## Test plan

- [x] `make test` (lint, fmt-check, vet, unit, integration, frontend) passes
- [x] `make build && ./bin/govard version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)