### PR TITLE
fix(db): correct misleading '.env/env.php' warning when remote DB probe fails

### DIFF
--- a/internal/cmd/db_credentials.go
+++ b/internal/cmd/db_credentials.go
@@ -559,7 +559,7 @@ func formatRemoteDBProbeWarning(remoteName string, err error) string {
 	if err == nil {
 		return ""
 	}
-	return fmt.Sprintf("Could not auto-detect DB credentials for '%s' from remote metadata (.env/env.php) (%v). Falling back to default credentials.", remoteName, err)
+	return fmt.Sprintf("Could not auto-detect DB credentials for '%s' by probing the remote project configuration (%v). Falling back to default credentials.", remoteName, err)
 }
 
 func BuildRemoteMySQLDumpCommandForTest(host string, port int, username string, password string, database string, compress bool) string {

--- a/tests/sync_plan_test.go
+++ b/tests/sync_plan_test.go
@@ -262,7 +262,7 @@ func TestSyncPlanDatabaseActionFailsFastWhenLocalContainerNotRunning(t *testing.
 }
 
 func TestSyncPlanDatabaseStopsWhenRemoteCredentialsCannotBeResolved(t *testing.T) {
-	// Magento2 resolves DB credentials by probing the remote over SSH for .env/env.php.
+	// Magento2 resolves DB credentials by probing the remote over SSH for app/etc/env.php.
 	// Against a host that can't be reached, that probe fails -- the sync must stop
 	// with a clear error instead of silently falling back to guessed credentials.
 	config := engine.Config{


### PR DESCRIPTION
## Summary

When a remote DB credential probe fails, `formatRemoteDBProbeWarning` printed:

```
Could not auto-detect DB credentials for 'dev' from remote metadata (.env/env.php) (...). Falling back to default credentials.
```

govard never reads `.env/env.php` — the Magento 2 probe runs `cd '<remote path>' && php -r '...include "app/etc/env.php"...'` over SSH, and other frameworks probe their own config files. The stale path in the message made users believe `env.php` was being loaded from the wrong location (`open db -e dev` on Magento 2, plus `db`, `snapshot` and `sync --db` all surface this warning on probe failure).

This PR makes the wording accurate and framework-neutral, and fixes the matching stale comment in the sync-plan test.

## Changes

- `internal/cmd/db_credentials.go` — warning now reads `Could not auto-detect DB credentials for '<remote>' by probing the remote project configuration (...). Falling back to default credentials.`
- `tests/sync_plan_test.go` — comment now names the real file (`app/etc/env.php`).

No functional behavior change.

## Test plan

- `go build ./...`, `go vet ./internal/cmd/... ./tests/...`, `make lint` (0 issues), `make fmt-check`, `make generate-check`
- `go test ./...` — all unit tests pass
- `node --test tests/frontend/*.test.mjs` — 71/71 pass
- `go test -tags integration ./tests/integration/ -run "TestOpenDBEnvironmentSelection|TestOpenTargetsRemoteEnvironment|TestOpenAndShortcutBrowserCommands|TestDBCommandValidationAndRuntime|TestSync"` — pass
- Reproduced `govard open db -e dev` with a failing probe to confirm the probe command sent over SSH targets `app/etc/env.php` and that the only `.env/env.php` occurrences in the repo were this warning string and the test comment.

Closes #146