### PR TITLE
feat(wordpress): version-aware WP-CLI install (skip download when active version matches)

### DIFF
--- a/internal/frameworks/wordpress/compatibility.go
+++ b/internal/frameworks/wordpress/compatibility.go
@@ -3,6 +3,7 @@ package wordpress
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"govard/internal/conventions"
@@ -17,6 +18,33 @@ var wpCLIVersionMap = map[int]string{
 	4: "2.4.0",
 	5: "2.8.1",
 	6: "2.10.0",
+}
+
+// recommendedWPCliVersion returns the WP-CLI version govard pins for a
+// WordPress major version, or "" when no specific version is recommended
+// (an unknown major — or one newer than the map — falls back to the latest
+// WP-CLI, just like resolveWPCliURL).
+func recommendedWPCliVersion(wpMajor int) string {
+	return wpCLIVersionMap[wpMajor]
+}
+
+// wpCliVersionPattern matches the numeric X.Y.Z release in WP-CLI's
+// `wp --version` output (e.g. "WP-CLI 2.8.1").
+var wpCliVersionPattern = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// parseWPCliVersion extracts the active WP-CLI version (X.Y.Z) from
+// `wp --version` output, or "" when none is present.
+func parseWPCliVersion(raw string) string {
+	return wpCliVersionPattern.FindString(raw)
+}
+
+// wpVersionMatches reports whether the active WP-CLI version (from
+// `wp --version`) equals the expected one.
+func wpVersionMatches(raw, want string) bool {
+	if want == "" {
+		return false
+	}
+	return parseWPCliVersion(raw) == want
 }
 
 const (
@@ -38,16 +66,29 @@ func FixWordPressCompatibility(config engine.Config) error {
 
 	containerName := fmt.Sprintf("%s%s", config.ProjectName, conventions.PHPSuffix)
 
-	// Check if wp is already available in PATH
-	if wpExists(containerName) {
+	// Detect the WordPress version and the WP-CLI version pinned for it.
+	wpMajor := detectWordPressVersion(containerName)
+	pinned := recommendedWPCliVersion(wpMajor)
+
+	// Fast path — mirrors the Composer fast path (see ensureSpecificComposerVersion
+	// in internal/engine/composer_compatibility.go): skip the download when the
+	// container already runs the recommended WP-CLI version, instead of
+	// overwriting the phar on every env up. This is also what lets the pinned
+	// version actually be enforced: the previous existence-only check would keep
+	// an outdated WP-CLI once the recommendation for a WordPress major changed.
+	// When nothing is pinned (WordPress major undetectable, or no recommendation
+	// for it), keep the original behavior and only install when wp is absent.
+	if pinned != "" {
+		if active := getWPVersion(containerName); wpVersionMatches(active, pinned) {
+			pterm.Info.Printf("WP-CLI %s is already active, skipping download.\n", pinned)
+			return nil
+		}
+	} else if wpExists(containerName) {
 		return nil
 	}
 
 	pterm.Info.Println("Installing WP-CLI in WordPress container...")
-
-	// Detect WordPress version to select appropriate WP-CLI
-	wpVersion := detectWordPressVersion(containerName)
-	wpCLIURL := resolveWPCliURL(wpVersion)
+	wpCLIURL := resolveWPCliURL(wpMajor)
 	pterm.Info.Printf("Downloading WP-CLI from %s\n", wpCLIURL)
 
 	// Download and install WP-CLI phar
@@ -184,4 +225,19 @@ func stringToInt(s string) int {
 		result = result*10 + int(c-'0')
 	}
 	return result
+}
+
+// RecommendedWPCliVersionForTest exposes recommendedWPCliVersion to the external /tests package.
+func RecommendedWPCliVersionForTest(wpMajor int) string {
+	return recommendedWPCliVersion(wpMajor)
+}
+
+// ParseWPCliVersionForTest exposes parseWPCliVersion to the external /tests package.
+func ParseWPCliVersionForTest(raw string) string {
+	return parseWPCliVersion(raw)
+}
+
+// WPCliVersionMatchesForTest exposes wpVersionMatches to the external /tests package.
+func WPCliVersionMatchesForTest(raw, want string) bool {
+	return wpVersionMatches(raw, want)
 }

--- a/internal/frameworks/wordpress/compatibility.go
+++ b/internal/frameworks/wordpress/compatibility.go
@@ -18,6 +18,7 @@ var wpCLIVersionMap = map[int]string{
 	4: "2.4.0",
 	5: "2.8.1",
 	6: "2.10.0",
+	7: "2.12.0",
 }
 
 // recommendedWPCliVersion returns the WP-CLI version govard pins for a
@@ -48,9 +49,12 @@ func wpVersionMatches(raw, want string) bool {
 }
 
 const (
-	// wpCLIBaseURL is the official WP-CLI phar download URL
+	// wpCLIBaseURL is the official WP-CLI builds repository, which nowadays only
+	// publishes the latest wp-cli.phar (versioned phars were removed from it).
 	wpCLIBaseURL = "https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar"
-	// wpCLIPharName is the main phar file name (not latest)
+	// wpCLIReleaseBaseURL hosts the per-version phar downloads (GitHub Releases).
+	wpCLIReleaseBaseURL = "https://github.com/wp-cli/wp-cli/releases/download"
+	// wpCLIPharName is the main phar file name (latest)
 	wpCLIPharName = "wp-cli.phar"
 	// wpCLISystemPath is the full system path where wp binary will be installed
 	wpCLISystemPath = "/usr/local/bin/wp"
@@ -194,13 +198,15 @@ func detectWordPressVersion(containerName string) int {
 func resolveWPCliURL(wpMajorVersion int) string {
 	// Check version map
 	if version, ok := wpCLIVersionMap[wpMajorVersion]; ok {
-		url := fmt.Sprintf("%s/wp-cli-%s.phar", wpCLIBaseURL, version)
+		// Versioned phars only exist on GitHub Releases - the builds repository
+		// no longer publishes wp-cli-<version>.phar (they return 404).
+		url := fmt.Sprintf("%s/v%s/wp-cli-%s.phar", wpCLIReleaseBaseURL, version, version)
 		pterm.Debug.Printf("Using WP-CLI %s for WordPress %d.x\n", version, wpMajorVersion)
 		return url
 	}
 
 	// Use the main wp-cli.phar for unknown versions (always available)
-	pterm.Debug.Println("Using latest WP-CLI (version not detected or >= 7)")
+	pterm.Debug.Println("Using latest WP-CLI (version not detected or newer than the map)")
 	return fmt.Sprintf("%s/%s", wpCLIBaseURL, wpCLIPharName)
 }
 
@@ -214,6 +220,11 @@ func stringToInt(s string) int {
 		result = result*10 + int(c-'0')
 	}
 	return result
+}
+
+// ResolveWPCliURLForTest exposes resolveWPCliURL to the external /tests package.
+func ResolveWPCliURLForTest(wpMajor int) string {
+	return resolveWPCliURL(wpMajor)
 }
 
 // RecommendedWPCliVersionForTest exposes recommendedWPCliVersion to the external /tests package.

--- a/internal/frameworks/wordpress/compatibility.go
+++ b/internal/frameworks/wordpress/compatibility.go
@@ -68,23 +68,27 @@ func FixWordPressCompatibility(config engine.Config) error {
 
 	// Detect the WordPress version and the WP-CLI version pinned for it.
 	wpMajor := detectWordPressVersion(containerName)
-	pinned := recommendedWPCliVersion(wpMajor)
+	active := getWPVersion(containerName)
 
 	// Fast path — mirrors the Composer fast path (see ensureSpecificComposerVersion
-	// in internal/engine/composer_compatibility.go): skip the download when the
-	// container already runs the recommended WP-CLI version, instead of
-	// overwriting the phar on every env up. This is also what lets the pinned
-	// version actually be enforced: the previous existence-only check would keep
-	// an outdated WP-CLI once the recommendation for a WordPress major changed.
-	// When nothing is pinned (WordPress major undetectable, or no recommendation
-	// for it), keep the original behavior and only install when wp is absent.
-	if pinned != "" {
-		if active := getWPVersion(containerName); wpVersionMatches(active, pinned) {
-			pterm.Info.Printf("WP-CLI %s is already active, skipping download.\n", pinned)
+	// in internal/engine/composer_compatibility.go). When a specific version is
+	// pinned for this WordPress major, skip the download when the container
+	// already runs that exact version — this also enforces the pin, since the
+	// previous existence-only check would keep an outdated WP-CLI forever once
+	// the recommendation changed. When nothing is pinned (major undetectable or
+	// newer than the map, i.e. latest), only install when wp is absent — but
+	// still confirm an existing install so re-runs are never silent.
+	if active != "" {
+		if pinned := recommendedWPCliVersion(wpMajor); pinned != "" {
+			if wpVersionMatches(active, pinned) {
+				pterm.Info.Printf("WP-CLI %s is already active, skipping download.\n", pinned)
+				return nil
+			}
+			// pinned != "" but the active version differs -> upgrade below.
+		} else {
+			pterm.Info.Printf("WP-CLI %s is already available, skipping install.\n", parseWPCliVersion(active))
 			return nil
 		}
-	} else if wpExists(containerName) {
-		return nil
 	}
 
 	pterm.Info.Println("Installing WP-CLI in WordPress container...")
@@ -135,21 +139,6 @@ WRAPPER_EOF
 	}
 
 	return nil
-}
-
-// wpExists checks if wp CLI is available in the container.
-func wpExists(containerName string) bool {
-	script := `command -v wp >/dev/null 2>&1 && wp --version 2>/dev/null | head -1 || echo "not_found"`
-	args := []string{"exec", "-u", "root", containerName, "sh", "-c", script}
-	out, err := exec.Command("docker", args...).CombinedOutput()
-	if err == nil {
-		version := strings.TrimSpace(string(out))
-		if version != "" && version != "not_found" {
-			pterm.Debug.Printf("WP-CLI already available: %s\n", version)
-			return true
-		}
-	}
-	return false
 }
 
 // getWPVersion returns the installed WP-CLI version.

--- a/tests/compatibility_wordpress_test.go
+++ b/tests/compatibility_wordpress_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"testing"
+
+	wordpress "govard/internal/frameworks/wordpress"
+)
+
+func TestParseWPCliVersion(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"WP-CLI 2.8.1", "2.8.1"},
+		{"WP-CLI 2.10.0", "2.10.0"},
+		{"WP-CLI 1.4.0", "1.4.0"},
+		{"", ""},
+		{"WP-CLI x.y.z", ""},
+		{"no version here", ""},
+		{"php warning noise\nWP-CLI 2.8.1\n", "2.8.1"},
+	}
+	for _, c := range cases {
+		if got := wordpress.ParseWPCliVersionForTest(c.raw); got != c.want {
+			t.Errorf("ParseWPCliVersionForTest(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestWPCliVersionMatches(t *testing.T) {
+	cases := []struct {
+		raw   string
+		want  string
+		match bool
+	}{
+		{"WP-CLI 2.10.0", "2.10.0", true},
+		{"WP-CLI 2.8.1", "2.10.0", false},
+		{"WP-CLI 1.4.0", "2.10.0", false},
+		{"", "2.10.0", false},
+		{"WP-CLI 2.10.0", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		if got := wordpress.WPCliVersionMatchesForTest(c.raw, c.want); got != c.match {
+			t.Errorf("WPCliVersionMatchesForTest(%q, %q) = %v, want %v", c.raw, c.want, got, c.match)
+		}
+	}
+}
+
+func TestRecommendedWPCliVersion(t *testing.T) {
+	cases := []struct {
+		major int
+		want  string
+	}{
+		{4, "2.4.0"},
+		{5, "2.8.1"},
+		{6, "2.10.0"},
+		{7, ""},
+		{0, ""},
+	}
+	for _, c := range cases {
+		if got := wordpress.RecommendedWPCliVersionForTest(c.major); got != c.want {
+			t.Errorf("RecommendedWPCliVersionForTest(%d) = %q, want %q", c.major, got, c.want)
+		}
+	}
+}

--- a/tests/compatibility_wordpress_test.go
+++ b/tests/compatibility_wordpress_test.go
@@ -63,12 +63,28 @@ func TestRecommendedWPCliVersion(t *testing.T) {
 		{4, "2.4.0"},
 		{5, "2.8.1"},
 		{6, "2.10.0"},
-		{7, ""},
+		{7, "2.12.0"},
 		{0, ""},
 	}
 	for _, c := range cases {
 		if got := wordpress.RecommendedWPCliVersionForTest(c.major); got != c.want {
 			t.Errorf("RecommendedWPCliVersionForTest(%d) = %q, want %q", c.major, got, c.want)
+		}
+	}
+}
+
+func TestResolveWPCliURL(t *testing.T) {
+	cases := []struct {
+		major int
+		want  string
+	}{
+		{6, "https://github.com/wp-cli/wp-cli/releases/download/v2.10.0/wp-cli-2.10.0.phar"},
+		{7, "https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar"},
+		{0, "https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar"},
+	}
+	for _, c := range cases {
+		if got := wordpress.ResolveWPCliURLForTest(c.major); got != c.want {
+			t.Errorf("ResolveWPCliURLForTest(%d) = %q, want %q", c.major, got, c.want)
 		}
 	}
 }
@@ -141,8 +157,8 @@ func TestFixWordPressCompatibilityUpgradesWhenVersionStale(t *testing.T) {
 	if !strings.Contains(dockerLog, "curl -sSfL") {
 		t.Fatalf("expected WP-CLI download when active version is stale, docker log: %s", dockerLog)
 	}
-	if !strings.Contains(dockerLog, "wp-cli-2.10.0.phar") {
-		t.Fatalf("expected download of the pinned 2.10.0 phar for WordPress 6.x, docker log: %s", dockerLog)
+	if !strings.Contains(dockerLog, "releases/download/v2.10.0/wp-cli-2.10.0.phar") {
+		t.Fatalf("expected download of the pinned 2.10.0 phar from GitHub Releases, docker log: %s", dockerLog)
 	}
 	if strings.Contains(output, "skipping download") {
 		t.Fatalf("did not expect a skip message for a stale install, got: %q", output)

--- a/tests/compatibility_wordpress_test.go
+++ b/tests/compatibility_wordpress_test.go
@@ -1,9 +1,18 @@
 package tests
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
+	"govard/internal/engine"
 	wordpress "govard/internal/frameworks/wordpress"
+
+	"github.com/pterm/pterm"
 )
 
 func TestParseWPCliVersion(t *testing.T) {
@@ -61,5 +70,89 @@ func TestRecommendedWPCliVersion(t *testing.T) {
 		if got := wordpress.RecommendedWPCliVersionForTest(c.major); got != c.want {
 			t.Errorf("RecommendedWPCliVersionForTest(%d) = %q, want %q", c.major, got, c.want)
 		}
+	}
+}
+
+// runFixWordPressCompatibility invokes the real FixWordPressCompatibility with a
+// fake docker binary standing in for the project PHP container. The fake docker
+// reports a WordPress 6.x install (wp-includes/version.php -> 6.8.1) and either
+// exposes wp at the given version, or fails wp lookups until the install exec
+// (the one containing curl) runs, which "installs" wp in the fake container.
+func runFixWordPressCompatibility(t *testing.T, wpPresent bool, activeWPVersion string) (dockerLog string, output string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("fake docker shim targets POSIX sh")
+	}
+
+	shimDir := t.TempDir()
+	logPath := filepath.Join(shimDir, "docker.log")
+
+	present := "1"
+	if !wpPresent {
+		present = "0"
+	}
+
+	script := fmt.Sprintf("#!/bin/sh\nset -eu\necho \"$*\" >> %s\nstate=\"$(dirname %s)/.wp_installed\"\ncase \"$*\" in\n  *wp-includes/version.php*)\n    echo \"6.8.1\"\n    exit 0\n    ;;\n  *\"curl -sSfL\"*)\n    touch \"$state\"\n    exit 0\n    ;;\n  *\"wp --version\"*|*\"command -v wp\"*)\n    if [ \"%s\" != \"1\" ] && [ ! -f \"$state\" ]; then exit 127; fi\n    echo \"WP-CLI %s\"\n    exit 0\n    ;;\nesac\nexit 0\n", logPath, logPath, present, activeWPVersion)
+
+	dockerPath := filepath.Join(shimDir, "docker")
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var captured bytes.Buffer
+	pterm.SetDefaultOutput(&captured)
+	defer pterm.SetDefaultOutput(os.Stdout)
+
+	config := engine.Config{ProjectName: "wp-test", Framework: "wordpress"}
+	if err := wordpress.FixWordPressCompatibility(config); err != nil {
+		t.Fatalf("FixWordPressCompatibility: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake docker log: %v", err)
+	}
+	return string(logData), captured.String()
+}
+
+func TestFixWordPressCompatibilitySkipsDownloadWhenVersionMatches(t *testing.T) {
+	dockerLog, output := runFixWordPressCompatibility(t, true, "2.10.0")
+
+	if strings.Contains(dockerLog, "curl -sSfL") {
+		t.Fatalf("expected no WP-CLI download when active version matches the pinned one, docker log: %s", dockerLog)
+	}
+	if !strings.Contains(output, "already active, skipping download") {
+		t.Fatalf("expected a skip message on re-runs, got: %q", output)
+	}
+	if !strings.Contains(output, "WP-CLI 2.10.0") {
+		t.Fatalf("expected the skip message to name the active version, got: %q", output)
+	}
+}
+
+func TestFixWordPressCompatibilityUpgradesWhenVersionStale(t *testing.T) {
+	dockerLog, output := runFixWordPressCompatibility(t, true, "2.8.1")
+
+	if !strings.Contains(dockerLog, "curl -sSfL") {
+		t.Fatalf("expected WP-CLI download when active version is stale, docker log: %s", dockerLog)
+	}
+	if !strings.Contains(dockerLog, "wp-cli-2.10.0.phar") {
+		t.Fatalf("expected download of the pinned 2.10.0 phar for WordPress 6.x, docker log: %s", dockerLog)
+	}
+	if strings.Contains(output, "skipping download") {
+		t.Fatalf("did not expect a skip message for a stale install, got: %q", output)
+	}
+}
+
+func TestFixWordPressCompatibilityInstallsWhenMissing(t *testing.T) {
+	dockerLog, output := runFixWordPressCompatibility(t, false, "")
+
+	if !strings.Contains(dockerLog, "curl -sSfL") {
+		t.Fatalf("expected WP-CLI download when wp is missing, docker log: %s", dockerLog)
+	}
+	if strings.Contains(output, "skipping download") {
+		t.Fatalf("did not expect a skip message for a missing install, got: %q", output)
 	}
 }

--- a/tests/compatibility_wordpress_test.go
+++ b/tests/compatibility_wordpress_test.go
@@ -75,10 +75,11 @@ func TestRecommendedWPCliVersion(t *testing.T) {
 
 // runFixWordPressCompatibility invokes the real FixWordPressCompatibility with a
 // fake docker binary standing in for the project PHP container. The fake docker
-// reports a WordPress 6.x install (wp-includes/version.php -> 6.8.1) and either
-// exposes wp at the given version, or fails wp lookups until the install exec
-// (the one containing curl) runs, which "installs" wp in the fake container.
-func runFixWordPressCompatibility(t *testing.T, wpPresent bool, activeWPVersion string) (dockerLog string, output string) {
+// either reports a WordPress 6.x install (wp-includes/version.php -> 6.8.1) or
+// an undetectable one, and either exposes wp at the given version, or fails wp
+// lookups until the install exec (the one containing curl) runs, which
+// "installs" wp in the fake container.
+func runFixWordPressCompatibility(t *testing.T, wpPresent bool, activeWPVersion string, majorDetectable bool) (dockerLog string, output string) {
 	t.Helper()
 
 	if runtime.GOOS == "windows" {
@@ -88,12 +89,14 @@ func runFixWordPressCompatibility(t *testing.T, wpPresent bool, activeWPVersion 
 	shimDir := t.TempDir()
 	logPath := filepath.Join(shimDir, "docker.log")
 
-	present := "1"
-	if !wpPresent {
-		present = "0"
+	flag := func(b bool) string {
+		if b {
+			return "1"
+		}
+		return "0"
 	}
 
-	script := fmt.Sprintf("#!/bin/sh\nset -eu\necho \"$*\" >> %s\nstate=\"$(dirname %s)/.wp_installed\"\ncase \"$*\" in\n  *wp-includes/version.php*)\n    echo \"6.8.1\"\n    exit 0\n    ;;\n  *\"curl -sSfL\"*)\n    touch \"$state\"\n    exit 0\n    ;;\n  *\"wp --version\"*|*\"command -v wp\"*)\n    if [ \"%s\" != \"1\" ] && [ ! -f \"$state\" ]; then exit 127; fi\n    echo \"WP-CLI %s\"\n    exit 0\n    ;;\nesac\nexit 0\n", logPath, logPath, present, activeWPVersion)
+	script := fmt.Sprintf("#!/bin/sh\nset -eu\necho \"$*\" >> %s\nstate=\"$(dirname %s)/.wp_installed\"\ncase \"$*\" in\n  *wp-includes/version.php*)\n    if [ \"%s\" = \"1\" ]; then echo \"6.8.1\"; else echo \"\"; fi\n    exit 0\n    ;;\n  *\"curl -sSfL\"*)\n    touch \"$state\"\n    exit 0\n    ;;\n  *\"wp --version\"*|*\"command -v wp\"*)\n    if [ \"%s\" != \"1\" ] && [ ! -f \"$state\" ]; then exit 127; fi\n    echo \"WP-CLI %s\"\n    exit 0\n    ;;\nesac\nexit 0\n", logPath, logPath, flag(majorDetectable), flag(wpPresent), activeWPVersion)
 
 	dockerPath := filepath.Join(shimDir, "docker")
 	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
@@ -119,7 +122,7 @@ func runFixWordPressCompatibility(t *testing.T, wpPresent bool, activeWPVersion 
 }
 
 func TestFixWordPressCompatibilitySkipsDownloadWhenVersionMatches(t *testing.T) {
-	dockerLog, output := runFixWordPressCompatibility(t, true, "2.10.0")
+	dockerLog, output := runFixWordPressCompatibility(t, true, "2.10.0", true)
 
 	if strings.Contains(dockerLog, "curl -sSfL") {
 		t.Fatalf("expected no WP-CLI download when active version matches the pinned one, docker log: %s", dockerLog)
@@ -133,7 +136,7 @@ func TestFixWordPressCompatibilitySkipsDownloadWhenVersionMatches(t *testing.T) 
 }
 
 func TestFixWordPressCompatibilityUpgradesWhenVersionStale(t *testing.T) {
-	dockerLog, output := runFixWordPressCompatibility(t, true, "2.8.1")
+	dockerLog, output := runFixWordPressCompatibility(t, true, "2.8.1", true)
 
 	if !strings.Contains(dockerLog, "curl -sSfL") {
 		t.Fatalf("expected WP-CLI download when active version is stale, docker log: %s", dockerLog)
@@ -147,12 +150,26 @@ func TestFixWordPressCompatibilityUpgradesWhenVersionStale(t *testing.T) {
 }
 
 func TestFixWordPressCompatibilityInstallsWhenMissing(t *testing.T) {
-	dockerLog, output := runFixWordPressCompatibility(t, false, "")
+	dockerLog, output := runFixWordPressCompatibility(t, false, "", true)
 
 	if !strings.Contains(dockerLog, "curl -sSfL") {
 		t.Fatalf("expected WP-CLI download when wp is missing, docker log: %s", dockerLog)
 	}
 	if strings.Contains(output, "skipping download") {
 		t.Fatalf("did not expect a skip message for a missing install, got: %q", output)
+	}
+}
+
+func TestFixWordPressCompatibilityConfirmsWhenMajorUndetectable(t *testing.T) {
+	dockerLog, output := runFixWordPressCompatibility(t, true, "2.10.0", false)
+
+	if strings.Contains(dockerLog, "curl -sSfL") {
+		t.Fatalf("expected no WP-CLI download when wp is present but the WordPress major is undetectable, docker log: %s", dockerLog)
+	}
+	if !strings.Contains(output, "already available, skipping install") {
+		t.Fatalf("expected a confirmation message even when the WordPress major is undetectable, got: %q", output)
+	}
+	if !strings.Contains(output, "WP-CLI 2.10.0") {
+		t.Fatalf("expected the message to name the active version, got: %q", output)
 	}
 }


### PR DESCRIPTION
## Summary

Version-aware WP-CLI handling mirroring the Composer fast path (`ensureSpecificComposerVersion`), plus two real-world fixes found while verifying on a WordPress 7.0 project:

1. **Version-aware install (pinned WP major):** skip the download when the active `wp --version` already matches the pinned version, and print `WP-CLI &lt;version&gt; is already active, skipping download.` — the same cache confirmation Composer shows. This also **enforces the pin** (the old existence-only check kept an outdated WP-CLI forever once the recommendation changed).
2. **Always confirm:** when nothing is pinned (major undetectable / newer than the map -> latest), still print `WP-CLI &lt;active&gt; is already available, skipping install.` instead of returning silently.
3. **Fix broken versioned downloads:** the wp-cli builds repository no longer publishes `wp-cli-&lt;version&gt;.phar` (all 404), so WP-CLI installs were failing for every WordPress 4/5/6 project. Versioned phars now come from GitHub Releases (`github.com/wp-cli/wp-cli/releases/download/vX.Y.Z/wp-cli-X.Y.Z.phar`, verified 200 for 2.4.0..2.12.0); the latest fallback (`wp-cli.phar`) is unchanged.
4. **Cover WordPress 7:** added `7 -> "2.12.0"` (current stable WP-CLI) to `wpCLIVersionMap` so WP 7 projects get a pinned version and the composer-style confirmation instead of the silent "latest" path.

## Changes

- `internal/frameworks/wordpress/compatibility.go` — `recommendedWPCliVersion`, `parseWPCliVersion`, `wpVersionMatches`, `resolveWPCliURL` (GitHub Releases), map entry for WP 7, restructured `FixWordPressCompatibility` guard (always confirm; dropped the now-unused `wpExists`).
- `tests/compatibility_wordpress_test.go` — hermetic unit tests (parsing, matching, version map, URL resolution) **plus behavioral tests running the real `FixWordPressCompatibility` against a fake `docker` binary**: skip (no download + message), upgrade-when-stale (downloads the pinned phar from GitHub Releases), install-when-missing, confirm-when-major-undetectable.

## Test plan

- `go test ./tests/ -run "TestParseWPCliVersion|TestWPCliVersionMatches|TestRecommendedWPCliVersion|TestResolveWPCliURL|TestFixWordPressCompatibility"` — pass
- `go test ./...`, `go build ./...`, `go vet ./...` — pass
- `gofmt`, `make fmt-check`, `make generate-check` — clean
- `golangci-lint run ./internal/frameworks/wordpress/... ./tests/...` — 0 issues

Closes #148