### PR TITLE
fix(audit): handle lint log file close errors flagged by CodeQL

### DIFF
--- a/internal/audit/lint_external.go
+++ b/internal/audit/lint_external.go
@@ -131,7 +131,11 @@ func (provider *ExternalLintProvider) Run(ctx context.Context, request LintReque
 	if err != nil {
 		return LintReport{}, fmt.Errorf("open external lint log: %w", err)
 	}
-	defer logFile.Close()
+	defer func() {
+		if cerr := logFile.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "govard: close external lint log %s: %v\n", logFile.Name(), cerr)
+		}
+	}()
 	container := ContainerRunRequest{
 		Name:  containerName(request),
 		Image: imageWithDigest(provider.config.Image, imageDigest),

--- a/internal/audit/lint_govard.go
+++ b/internal/audit/lint_govard.go
@@ -240,7 +240,11 @@ func (backend *GovardLintBackend) Run(ctx context.Context, request LintRequest) 
 	if err != nil {
 		return LintReport{}, fmt.Errorf("open govard lint log: %w", err)
 	}
-	defer logFile.Close()
+	defer func() {
+		if cerr := logFile.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "govard: close govard lint log %s: %v\n", logFile.Name(), cerr)
+		}
+	}()
 
 	container := backend.containerRequest(request, plan, resolved, toolchainDigest, cacheDir)
 	// Only container-safe values are logged: no credential path, no secret,


### PR DESCRIPTION
## Summary

CodeQL flagged both lint backends' `defer logFile.Close()` (`go/unhandled-writable-file-close`, alerts #29 and #30): the returned error was silently discarded, so a failure closing the debug log (e.g. disk full, EIO) would drop the tail of the log without any indication.

## Changes

- `internal/audit/lint_external.go`: `ExternalLintProvider.Run` now closes `logFile` via a deferred closure that reports a close failure to stderr instead of discarding it.
- `internal/audit/lint_govard.go`: `GovardLintBackend.Run`, same pattern.

This only affects the side-channel debug log (`external-lint.log` / `govard-lint.log`), not the actual report (read separately from `report.json`), so no behavior change to lint results or exit codes — just no longer silently swallowing the close error.

## Why not propagate the error to the caller

Both `Run` functions have many existing return points without named returns; threading the close error into every return site would be a much larger, riskier change for a debug-log-only failure mode that in practice only occurs on disk/FS errors. Reporting it (rather than fully swallowing it) satisfies the CodeQL query without restructuring control flow.

## Validation

```bash
go build ./...
go vet ./...
gofmt -s -l internal/audit/lint_external.go internal/audit/lint_govard.go   # clean
go test $(go list ./... | grep -v '^govard/tests/integration$') -short      # ok
```

Full `make test`/`make fmt-check` isn't clean right now due to two unrelated untracked scratch directories (`awesome-devtools-pr/`, `awesome-go-pr/`) sitting in the repo root from unrelated work — not part of this branch or this repo's git tree.

Closes CodeQL alerts #29, #30 (`internal/audit/lint_govard.go:243`, `internal/audit/lint_external.go:134`).