### PR TITLE
fix: serialize composer downloads to avoid arm64 emulation timeouts

### DIFF
--- a/docker/audit-magento/Dockerfile
+++ b/docker/audit-magento/Dockerfile
@@ -24,6 +24,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG GOVARD_MAGELINT_PHP_VERSIONS="7.4,8.0,8.1,8.2,8.3,8.4,8.5"
 ENV GOVARD_MAGELINT_PHP_VERSIONS="${GOVARD_MAGELINT_PHP_VERSIONS}"
 ENV COMPOSER_ALLOW_SUPERUSER=1
+# QEMU-emulated arm64 builds run Composer's usual parallel downloads through a
+# software-emulated CPU; several concurrent TLS handshakes then compete for the
+# same emulated cycles and can all miss their connect timeout together (seen as
+# simultaneous "SSL connection timeout" failures across unrelated packages).
+# Serializing downloads keeps each handshake within its timeout regardless of
+# host emulation speed.
+ENV COMPOSER_DISABLE_PARALLEL_DOWNLOADS=1
 
 RUN set -eux; \
     apt-get update; \
@@ -80,8 +87,16 @@ COPY toolchains /opt/govard/toolchains
 RUN set -eux; \
     for version in $(printf '%s' "${GOVARD_MAGELINT_PHP_VERSIONS}" | tr ',' ' '); do \
         cd "/opt/govard/toolchains/php-${version}"; \
-        "php${version}" /usr/local/bin/composer install \
-            --no-interaction --no-progress --no-dev --optimize-autoloader; \
+        attempt=1; \
+        until "php${version}" /usr/local/bin/composer install \
+            --no-interaction --no-progress --no-dev --optimize-autoloader; do \
+            if [ "${attempt}" -ge 3 ]; then \
+                echo "composer install for php${version} failed after ${attempt} attempts" >&2; \
+                exit 1; \
+            fi; \
+            sleep "$(( attempt * 10 ))"; \
+            attempt=$(( attempt + 1 )); \
+        done; \
         "php${version}" "/opt/govard/toolchains/php-${version}/vendor/bin/phpcs" -i | grep -q Magento2; \
         "php${version}" "/opt/govard/toolchains/php-${version}/vendor/bin/phpstan" --version >/dev/null; \
     done; \


### PR DESCRIPTION
## Summary

- The `v1.63.0-beta.1` release run failed while building the `magelint` image's `linux/arm64` leg: Composer's parallel downloader opened several concurrent TLS handshakes that all missed their connect timeout together under QEMU-emulated crypto (`curl error 28 ... SSL connection timeout` across 10 unrelated packages within ~45s).
- Sets `COMPOSER_DISABLE_PARALLEL_DOWNLOADS=1` so downloads run serially, and wraps each toolchain's `composer install` in a 3-attempt retry as a backstop (same pattern already used for the Trivy DB fetch in `audit-magelint-image.yml`).

Closes #153

## Test plan

- [x] Built the `runtime` stage for `linux/arm64` under local QEMU emulation (single-PHP-version build-arg override for a faster iteration cycle) — `composer install` completed in 35.5s with zero download failures
- [x] `bash docker/audit-magento/tests/contract_test.sh` — 23/23 pass
- [x] `gofmt -s -l docker/audit-magento` — clean
- [x] `make test` — pass
- [ ] Full 7-PHP-version matrix under `linux/arm64` — not reproduced locally (the `apt-get install` step alone took ~56 minutes in the failed CI run); the real `release.yml` run is the first full-matrix verification of this fix
- [ ] Re-publish `ghcr.io/ddtcorex/govard-magelint` for the beta and confirm GHCR package visibility is Public — deliberately left for explicit sign-off since it touches shared release infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)