### PR TITLE
fix: use the real Composer env var to serialize arm64 downloads

### DIFF
--- a/docker/audit-magento/Dockerfile
+++ b/docker/audit-magento/Dockerfile
@@ -24,13 +24,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG GOVARD_MAGELINT_PHP_VERSIONS="7.4,8.0,8.1,8.2,8.3,8.4,8.5"
 ENV GOVARD_MAGELINT_PHP_VERSIONS="${GOVARD_MAGELINT_PHP_VERSIONS}"
 ENV COMPOSER_ALLOW_SUPERUSER=1
-# QEMU-emulated arm64 builds run Composer's usual parallel downloads through a
-# software-emulated CPU; several concurrent TLS handshakes then compete for the
-# same emulated cycles and can all miss their connect timeout together (seen as
-# simultaneous "SSL connection timeout" failures across unrelated packages).
-# Serializing downloads keeps each handshake within its timeout regardless of
-# host emulation speed.
-ENV COMPOSER_DISABLE_PARALLEL_DOWNLOADS=1
+# QEMU-emulated arm64 builds run Composer's usual parallel downloads (default
+# COMPOSER_MAX_PARALLEL_HTTP=12) through a software-emulated CPU; several
+# concurrent TLS handshakes then compete for the same emulated cycles and can
+# all miss their connect timeout together (seen as simultaneous "SSL
+# connection timeout" failures across unrelated packages). Capping this at 1
+# keeps each handshake within its timeout regardless of host emulation speed.
+ENV COMPOSER_MAX_PARALLEL_HTTP=1
 
 RUN set -eux; \
     apt-get update; \


### PR DESCRIPTION
## Summary

- PR #154 set `COMPOSER_DISABLE_PARALLEL_DOWNLOADS=1` to fix the arm64 Composer download timeouts. That variable **does not exist** in Composer — it was a fabricated name, silently ignored, so the fix never took effect. The `v1.63.0-beta.2` release run (job [96304912326](https://github.com/ddtcorex/govard/actions/runs/32328655857/job/96304912326)) hit the exact same simultaneous `SSL connection timeout` failures across the same packages as the original `beta.1` failure.
- Replaces it with the real, documented variable: `COMPOSER_MAX_PARALLEL_HTTP` (confirmed against Composer's own source — read via `Platform::getEnv('COMPOSER_MAX_PARALLEL_HTTP')` in `HttpDownloader`'s constructor, clamped to 1-50, defaulting to 12). Setting it to `1` genuinely serializes downloads.

Closes the remaining scope of #153 (arm64 build reliability).

## Test plan

- [x] Confirmed `COMPOSER_MAX_PARALLEL_HTTP` against Composer's source (`HttpDownloader.php`), not just documentation
- [x] Rebuilt the `runtime` stage for `linux/arm64` under local QEMU with `--no-cache` (single-PHP-version build-arg override) — `composer install` completed in 59.3s with zero download failures, ~1.7x slower than the previous (ineffective) attempt's 35.5s, consistent with downloads now genuinely serialized rather than the default 12-way concurrency
- [x] `bash docker/audit-magento/tests/contract_test.sh` — 23/23 pass
- [x] `gofmt -s -l docker/audit-magento` — clean
- [ ] Full 7-PHP-version matrix under `linux/arm64` on a real GitHub Actions runner — local QEMU is not a reliable proxy for the runner where both real failures occurred, so this still needs a real release run to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)