### PR TITLE
docs: add concrete govard audit run examples per target mode

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -94,6 +94,29 @@ directory:
 `--mode project` and `--mode standalone` force a classification and fail when the
 directory does not support it.
 
+```bash
+# project: run from the Magento project root
+cd ~/projects/storefront
+govard audit run
+
+# module_in_project: run from inside an app/code module
+cd ~/projects/storefront/app/code/Acme/Catalog
+govard audit run
+
+# module_in_project: run from inside a vendor package (Composer type magento2-module)
+cd ~/projects/storefront/vendor/acme/module-catalog
+govard audit run
+
+# standalone: run from a module with no Magento project above it
+cd ~/work/module-catalog
+govard audit run --php 8.1,8.5
+```
+
+Each of these selects its mode automatically from the current directory —
+`--mode` only needs to be passed to force or refuse a classification (for
+example `--mode project` fails outside a project root instead of silently
+reclassifying).
+
 #### PHP versions
 
 The lint image provides `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, and `8.5`.

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -95,6 +95,28 @@ mục hiện tại:
 `--mode project` và `--mode standalone` buộc một phân loại cụ thể và sẽ lỗi khi
 thư mục không thỏa điều kiện.
 
+```bash
+# project: chạy từ project root của Magento
+cd ~/projects/storefront
+govard audit run
+
+# module_in_project: chạy từ trong một module ở app/code
+cd ~/projects/storefront/app/code/Acme/Catalog
+govard audit run
+
+# module_in_project: chạy từ trong một package ở vendor (Composer type magento2-module)
+cd ~/projects/storefront/vendor/acme/module-catalog
+govard audit run
+
+# standalone: chạy từ một module không có Magento project nào ở cấp trên
+cd ~/work/module-catalog
+govard audit run --php 8.1,8.5
+```
+
+Mỗi lệnh trên tự nhận diện mode từ thư mục hiện tại — `--mode` chỉ cần dùng khi
+muốn buộc hoặc từ chối một phân loại cụ thể (ví dụ `--mode project` sẽ lỗi khi
+chạy ngoài project root thay vì tự phân loại lại).
+
 #### Phiên bản PHP
 
 Lint image cung cấp `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4` và `8.5`.


### PR DESCRIPTION
## Summary

- The `#### Target modes` table in `docs/reference/cli-commands.md` (and `docs/vi/reference/cli-commands.md`) explains `project` / `module_in_project` / `standalone` conceptually but never showed the actual `cd` + `govard audit run` combination that selects each one.
- Adds one runnable example per mode right after the table, for both language versions.

Prompted by validating the native-magelint audit against a real project: ran all three modes (whole project, an `app/code` module, a `vendor/<pkg>` module) and confirmed target detection matched the docs' table exactly, but had to explain the actual commands out-of-band since the docs didn't show them.

## Test plan

- [x] Both files render as valid Markdown (code fences balanced, no broken tables)
- [x] Examples match the exact commands used during real validation (adapted to generic paths instead of naming the specific client project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)