### PR TITLE
chore: release v1.63.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.63.0] - 2026-08-20
+
+### ✨ New Features
+
+- **Govard-Native Magento Audit:** `govard audit run` lints Magento 2/Mage-OS projects, in-project `app/code`/`vendor` modules, and standalone modules against a Govard-owned, self-built multi-PHP (7.4, 8.0-8.5) Magelint image. Supports `--mode` (`auto`/`project`/`module_in_project`/`standalone`), `--php` version narrowing for standalone targets, `--lint-provider` for an explicit external CI gate (never an automatic fallback), reusable result caching, and exact rerun-by-session-id. See `govard audit --help` and `docs/reference/cli-commands.md`.
+- `govard audit toolchain status|pull|build` manages the machine-wide lint image independently of any project.
+
+### 🛠 Improvements
+
+- WP-CLI installs are now version-aware, mirroring the Composer fast path: skips the download when the active `wp --version` already matches the version pinned for the detected WordPress major, actually enforces that pin instead of keeping a stale binary forever, and always confirms the active version rather than sometimes returning silently. Versioned phars now download from GitHub Releases (the wp-cli builds repository stopped publishing them); WordPress 7 is now covered by the version map.
+- The Magelint image's CI build is now skipped when its embedded build context is unchanged since the last successful publish (a content-addressed cache tag plus a registry-side manifest copy) — cuts a routine release's image step from roughly an hour to seconds.
+
+### 🐛 Bug Fixes
+
+- `govard open db -e <env>` (and `db`, `snapshot`, `sync --db`) printed a misleading warning claiming credentials were read from a nonexistent `.env/env.php` path when a remote DB probe failed; it now names the configuration that was actually probed.
+- `govard audit` compared the active PHP version profile-blindly: a project with a named profile overriding `stack.php_version` incorrectly reported a PHP mismatch.
+- The Magelint image was missing the `gd` PHP extension required by every installable `magento/framework` release, failing standalone-mode Composer resolution across the whole PHP matrix.
+- Composer downloads inside the Magelint image's `arm64` build (under QEMU emulation) now run serialized (`COMPOSER_MAX_PARALLEL_HTTP=1`) instead of the default 12-way parallel, fixing simultaneous SSL-handshake timeouts that had failed the multi-arch image publish.
+- A lint backend's debug log file close error is now surfaced instead of silently discarded.
+
 ## [1.62.2] - 2026-08-12
 
 ### 🐛 Bug Fixes

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.62.2",
+  "version": "1.63.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.62.2"
+    "productVersion": "1.63.0"
   }
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.62.2"
+var Version = "1.63.0"
 
 var verbose bool
 

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.62.2"
+var Version = "1.63.0"
 
 type App struct {
 	ctx context.Context

--- a/tests/bootstrap_prestashop_test.go
+++ b/tests/bootstrap_prestashop_test.go
@@ -161,10 +161,10 @@ return array (
 }
 
 func TestBuildPrestaShopShopURLSQL(t *testing.T) {
-	sql := prestashop.BuildPrestaShopShopURLSQLForTest("shop_", "castelas-sutunam.test")
+	sql := prestashop.BuildPrestaShopShopURLSQLForTest("shop_", "sample-shop.test")
 
-	expected := "UPDATE shop_shop_url SET domain = 'castelas-sutunam.test', domain_ssl = 'castelas-sutunam.test' WHERE id_shop_url = 1; " +
-		"UPDATE shop_configuration SET value = 'castelas-sutunam.test' WHERE name IN ('PS_SHOP_DOMAIN', 'PS_SHOP_DOMAIN_SSL');"
+	expected := "UPDATE shop_shop_url SET domain = 'sample-shop.test', domain_ssl = 'sample-shop.test' WHERE id_shop_url = 1; " +
+		"UPDATE shop_configuration SET value = 'sample-shop.test' WHERE name IN ('PS_SHOP_DOMAIN', 'PS_SHOP_DOMAIN_SSL');"
 	if sql != expected {
 		t.Fatalf("expected SQL:\n%s\ngot:\n%s", expected, sql)
 	}


### PR DESCRIPTION
## Summary

- Bumps version strings across `root.go`, `app.go`, `desktop/frontend/package.json`, and `desktop/wails.json` to `1.63.0`.
- Adds the v1.63.0 CHANGELOG entry covering:
  - **New:** Govard-native Magento audit (`govard audit run`/`audit toolchain`) — see [#151](https://github.com/ddtcorex/govard/pull/151).
  - **Improved:** version-aware WP-CLI installs ([#149](https://github.com/ddtcorex/govard/pull/149)); Magelint image CI build now skips when its context is unchanged ([#156](https://github.com/ddtcorex/govard/pull/156)).
  - **Fixed:** misleading remote-DB-probe warning path ([#147](https://github.com/ddtcorex/govard/pull/147)); profile-blind PHP-version check in `govard audit`; missing `gd` extension and arm64 QEMU Composer-download timeout in the Magelint image ([#154](https://github.com/ddtcorex/govard/pull/154), [#155](https://github.com/ddtcorex/govard/pull/155)); a swallowed lint-backend log-close error.
- Generalizes a test fixture domain string (`tests/bootstrap_prestashop_test.go`) that carried no functional meaning beyond the literal characters.

## Test plan

- [x] `make test` (lint, fmt-check, vet, unit, integration, frontend) passes
- [x] `make build && ./bin/govard version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)