### PR TITLE
fix: resilient per-image pull with local fallback and ES/OS version resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ At a glance, these are the areas where Govard delivers stronger day-to-day value
 - **Inter-Project Connectivity**: Projects can securely communicate with each other (e.g., `curl https://other-project.test`) by explicitly declaring dependencies via `linked_projects`. This ensures network isolation by default and enables targeted container refreshes.
 - **Queue Support**: Optional RabbitMQ service for async workloads.
 - **High Performance**: Built with Go and uses the native Docker SDK for direct container orchestration.
-- **Local Image Fallback**: Automatically builds missing Govard-managed images locally from embedded blueprints if they cannot be pulled from Docker Hub. Disable this retry with `--no-fallback`.
+- **Resilient Image Pull & Local Image Fallback**: Images are pulled one by one, so a single unavailable image (e.g. an elasticsearch tag missing from the registry) no longer stops the remaining pulls. Missing Govard-managed images are automatically built locally from embedded blueprints; disable the retry with `--no-fallback`.
 - **Smart Templating**: Uses Go `text/template` to render dynamic Docker Compose files from framework-specific blueprints.
 - **Magento 2 Optimized**: Deep integration for Magento 2, including automated `env.php` configuration, table prefix propagation, Varnish 7.x support, and Redis caching.
 - **Remote Management (Flagship)**: Manage named remotes for sync/deploy/db workflows with scope-based capabilities (`files,media,db,deploy`) and flexible auth modes (`keychain`, `ssh-agent`, `keyfile`).

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -296,6 +296,19 @@ govard env cleanup
 | `--update-lock` | Auto-update `govard.lock` on mismatches |
 | `--no-tuning` | Skip framework auto-configuration prompts |
 
+**`govard env pull` behavior:**
+
+Images are pulled one by one. If an image cannot be pulled (removed from the
+registry, unsupported tag, network failure), Govard retries the remaining
+images and builds Govard-managed failures locally instead of aborting the
+whole pull. Pass `--no-fallback` to disable the local build retry.
+
+Search images: Govard-managed `elasticsearch`/`opensearch` tags track the
+minor version (e.g. `7.17`), while `search_version` in `.govard.yml` accepts
+either minor (`7.17`) or full patch (`7.17.28`) versions. A patch version is
+pulled as-is when published; otherwise the minor image is used and the local
+fallback build targets the closest real upstream release.
+
 **Files re-rendered on `env up`:**
 - `~/.govard/compose/<project-hash>.yml`
 - `~/.govard/nginx/<project>/default.conf`

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -293,6 +293,19 @@ govard env cleanup
 | `--update-lock` | Tự động cập nhật `govard.lock` nếu phát hiện sai lệch |
 | `--no-tuning` | Bỏ qua các prompt cấu hình tự động cho framework |
 
+**Hành vi của `govard env pull`:**
+
+Image được pull từng cái một. Nếu một image không thể pull (bị xóa khỏi
+registry, tag không được hỗ trợ, lỗi mạng), Govard vẫn pull tiếp các image
+còn lại và build locally các image do Govard quản lý thay vì dừng toàn bộ
+quá trình. Dùng `--no-fallback` để tắt cơ chế build local thay thế.
+
+Image search: tag `elasticsearch`/`opensearch` do Govard quản lý theo
+phiên bản minor (vd. `7.17`), trong khi `search_version` trong `.govard.yml`
+chấp nhận cả minor (`7.17`) lẫn patch đầy đủ (`7.17.28`). Version patch
+được pull nguyên trạng khi có trên registry; nếu không thì dùng image minor
+và bản build local fallback sẽ nhắm đúng bản upstream thật gần nhất.
+
 **Các file được render lại khi chạy `env up`:**
 - `~/.govard/compose/<project-hash>.yml`
 - `~/.govard/nginx/<project>/default.conf`

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -226,28 +226,52 @@ func proxyEnvToCompose(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		pterm.NewStyle(pterm.BgLightBlue, pterm.FgBlack, pterm.Bold).Println(" Pulling Project Images ")
 		fmt.Println()
+		fallbackLocal := !hasFlag("--no-fallback")
+		extraPullArgs := make([]string, 0, len(args))
+		for _, arg := range args[1:] {
+			if arg == "--no-fallback" || strings.HasPrefix(arg, "--no-fallback=") {
+				continue
+			}
+			extraPullArgs = append(extraPullArgs, arg)
+		}
+		pullArgs := append([]string{"pull", "--ignore-buildable"}, extraPullArgs...)
+
 		err := engine.RunCompose(cmd.Context(), engine.ComposeOptions{
 			ProjectDir:  cwd,
 			ProjectName: config.ProjectName,
 			ComposeFile: composePath,
-			Args:        args,
+			Args:        pullArgs,
 			Stdout:      cmd.OutOrStdout(),
 			Stderr:      cmd.ErrOrStderr(),
 			Stdin:       os.Stdin,
 		})
 		if err != nil {
+			// A single broken image must not stop the remaining pulls:
+			// retry image by image so only failing ones fall back or fail.
 			pterm.Warning.Printf("docker compose pull failed: %v\n", err)
-			pterm.Info.Println("Attempting local Govard image build fallback...")
+			pterm.Info.Println("Retrieving project images one by one...")
 
-			built, fallbackErr := engine.FallbackBuildMissingGovardImagesFromCompose(composePath, cmd.OutOrStdout(), cmd.ErrOrStderr())
-			if fallbackErr != nil {
-				return fmt.Errorf("pull project images: %w (local fallback failed: %v)", err, fallbackErr)
+			result, resilientErr := engine.RunResilientImagePullsFromCompose(cmd.Context(), composePath, engine.ResilientPullOptions{
+				FallbackLocalBuild: fallbackLocal,
+			}, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			if resilientErr != nil {
+				return fmt.Errorf("pull project images: %w", resilientErr)
 			}
 
-			if len(built) > 0 {
-				pterm.Success.Printf("Local fallback built %d image(s): %v\n", len(built), built)
-			} else {
-				pterm.Info.Println("No missing Govard-managed images required local build.")
+			if len(result.Pulled) > 0 {
+				pterm.Success.Printf("Pulled %d image(s): %s\n", len(result.Pulled), strings.Join(result.Pulled, ", "))
+			}
+			if len(result.ReusedLocal) > 0 {
+				pterm.Success.Printf("Kept %d existing local image(s): %s\n", len(result.ReusedLocal), strings.Join(result.ReusedLocal, ", "))
+			}
+			if len(result.BuiltLocally) > 0 {
+				pterm.Success.Printf("Local fallback built %d image(s): %s\n", len(result.BuiltLocally), strings.Join(result.BuiltLocally, ", "))
+			}
+			for _, failure := range result.Failed {
+				pterm.Warning.Printf("Could not prepare %s: %v\n", failure.Image, failure.Err)
+			}
+			if len(result.Failed) == 0 {
+				pterm.Info.Println("All project images are available.")
 			}
 		}
 		built, rebuildErr := engine.RebuildIncompatibleGovardImagesFromCompose(composePath, cmd.OutOrStdout(), cmd.ErrOrStderr())

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -289,7 +289,7 @@ func buildUpPipelineStages(cmd *cobra.Command, context *upRuntimeContext) []upPi
 					ProjectDir:  context.Cwd,
 					ProjectName: context.Config.ProjectName,
 					ComposeFile: context.Compose,
-					Args:        []string{"pull"},
+					Args:        []string{"pull", "--ignore-buildable"},
 					Stdout:      context.Out,
 					Stderr:      context.Err,
 				})
@@ -298,19 +298,30 @@ func buildUpPipelineStages(cmd *cobra.Command, context *upRuntimeContext) []upPi
 						return fmt.Errorf("docker compose pull failed: %w", err)
 					}
 
+					// A single broken image must not stop the remaining pulls:
+					// retry image by image so only failing ones fall back or fail.
 					pterm.Warning.Printf("docker compose pull failed: %v\n", err)
-					pterm.Info.Println("Attempting local Govard image build fallback...")
+					pterm.Info.Println("Retrieving project images one by one...")
 
-					built, fallbackErr := engine.FallbackBuildMissingGovardImagesFromCompose(context.Compose, context.Out, context.Err)
-					if fallbackErr != nil {
-						return fmt.Errorf("docker compose pull failed: %w (local fallback failed: %v)", err, fallbackErr)
-					}
-					if len(built) == 0 {
-						pterm.Warning.Println("No missing Govard-managed images required local build. Continuing with current local cache.")
-						return nil
+					result, resilientErr := engine.RunResilientImagePullsFromCompose(cmd.Context(), context.Compose, engine.ResilientPullOptions{
+						FallbackLocalBuild: true,
+					}, context.Out, context.Err)
+					if resilientErr != nil {
+						return fmt.Errorf("docker compose pull failed: %w (resilient retry failed: %v)", err, resilientErr)
 					}
 
-					pterm.Success.Printf("Local fallback built %d image(s): %s\n", len(built), strings.Join(built, ", "))
+					if len(result.Pulled) > 0 {
+						pterm.Success.Printf("Pulled %d image(s): %s\n", len(result.Pulled), strings.Join(result.Pulled, ", "))
+					}
+					if len(result.ReusedLocal) > 0 {
+						pterm.Success.Printf("Kept %d existing local image(s): %s\n", len(result.ReusedLocal), strings.Join(result.ReusedLocal, ", "))
+					}
+					if len(result.BuiltLocally) > 0 {
+						pterm.Success.Printf("Local fallback built %d image(s): %s\n", len(result.BuiltLocally), strings.Join(result.BuiltLocally, ", "))
+					}
+					for _, failure := range result.Failed {
+						pterm.Warning.Printf("Could not prepare %s: %v\n", failure.Image, failure.Err)
+					}
 				}
 				return nil
 			},

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -208,6 +208,10 @@ func suppressedComposeFlags(cmd *cobra.Command, govardCmdName, detectedSubcomman
 		}
 	}
 
+	if govardCmdName == "env" && detectedSubcommand == "pull" {
+		flags["no-fallback"] = struct{}{}
+	}
+
 	return flags
 }
 
@@ -360,6 +364,13 @@ func collectGovardSpecificOptions(cmd *cobra.Command, govardCmdName, detectedSub
 				},
 			)
 		}
+	}
+
+	if govardCmdName == "env" && detectedSubcommand == "pull" {
+		specs = append(specs, helpFlagSpec{
+			Display: "--no-fallback",
+			Usage:   "Disable the automatic local image build retry if pulls fail.",
+		})
 	}
 
 	return specs

--- a/internal/engine/local_image_fallback.go
+++ b/internal/engine/local_image_fallback.go
@@ -517,20 +517,79 @@ func resolveVarnishBuildVersions(tag string) (version string, imageTag string) {
 
 func resolveElasticsearchBuildVersion(tag string) string {
 	tag = strings.TrimSpace(tag)
-	switch tag {
-	case "7.9":
-		return "7.9.3"
-	case "7.6":
-		return "7.6.2"
-	case "7.17":
-		return "7.17.10"
-	case "6.8":
-		return "6.8.23"
-	case "8.4":
-		return "8.4.3"
-	default:
+	if tag == "" {
 		return tag
 	}
+	if _, _, _, ok := splitElasticsearchTag(tag); ok {
+		return tag
+	}
+	switch tag {
+	case "5.6":
+		return "5.6.16"
+	case "6.5":
+		return "6.5.4"
+	case "6.8":
+		return "6.8.23"
+	case "7.6":
+		return "7.6.2"
+	case "7.7":
+		return "7.7.1"
+	case "7.9":
+		return "7.9.3"
+	case "7.10":
+		return "7.10.1"
+	case "7.16":
+		return "7.16.3"
+	case "7.17":
+		return "7.17.10"
+	case "8.11":
+		return "8.11.4"
+	default:
+		if majorMinorVersionPattern.MatchString(tag) {
+			// Upstream Elastic does not publish minor-only tags: fall back to
+			// the first patch release of the requested minor so the local
+			// build FROM line always references a real upstream tag.
+			return tag + ".0"
+		}
+		return tag
+	}
+}
+
+// splitElasticsearchTag splits an Elasticsearch image tag into its major,
+// minor, and patch parts. It reports ok only for full X.Y.Z tags (with an
+// optional trailing suffix such as -amd64), because those reference real
+// upstream releases as-is. Minor-only tags (X.Y) are not published upstream.
+func splitElasticsearchTag(tag string) (major string, minor string, rest string, ok bool) {
+	base := strings.TrimSpace(tag)
+	for i := 0; i < len(base); i++ {
+		c := base[i]
+		if (c >= '0' && c <= '9') || c == '.' {
+			continue
+		}
+		base = base[:i]
+		break
+	}
+	parts := strings.Split(base, ".")
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return "", "", "", false
+		}
+		for i := 0; i < len(part); i++ {
+			if part[i] < '0' || part[i] > '9' {
+				return "", "", "", false
+			}
+		}
+	}
+	return parts[0], parts[1], strings.TrimPrefix(strings.TrimSpace(tag), base), true
+}
+
+// ResolveElasticsearchBuildVersionForTest exposes Elasticsearch build version
+// resolution for tests.
+func ResolveElasticsearchBuildVersionForTest(tag string) string {
+	return resolveElasticsearchBuildVersion(tag)
 }
 
 func resolveOpensearchBuildVersion(tag string) string {

--- a/internal/engine/resilient_pull.go
+++ b/internal/engine/resilient_pull.go
@@ -1,0 +1,184 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// ResilientPullFailure records why one image could not be prepared.
+type ResilientPullFailure struct {
+	Image string
+	Err   error
+}
+
+// ResilientPullResult summarizes per-image pull outcomes. Unlike a plain
+// "docker compose pull", one broken image never prevents the remaining
+// images from being pulled.
+type ResilientPullResult struct {
+	Pulled []string
+	// ReusedLocal lists images whose pull failed but for which a
+	// compatible image already exists on this host, so nothing had to be built.
+	ReusedLocal  []string
+	BuiltLocally []string
+	Failed       []ResilientPullFailure
+}
+
+// ResilientPullOptions tunes the resilient pull behavior.
+type ResilientPullOptions struct {
+	// FallbackLocalBuild enables building Govard-managed images locally when
+	// their pull fails. When false, every pull failure is fatal.
+	FallbackLocalBuild bool
+}
+
+// RunResilientImagePullsFromCompose pulls every image referenced by the
+// rendered compose file one by one. A failing image falls back to a local
+// Govard build when allowed, and never blocks the remaining images.
+//
+// Missing third-party images (no Govard local build available) always make
+// the call fail, because there is no way to materialize them locally.
+func RunResilientImagePullsFromCompose(ctx context.Context, composePath string, options ResilientPullOptions, out io.Writer, errOut io.Writer) (ResilientPullResult, error) {
+	serviceImages, err := ReadServiceImagesFromCompose(composePath)
+	if err != nil {
+		return ResilientPullResult{}, fmt.Errorf("read compose service images: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(serviceImages))
+	images := make([]string, 0, len(serviceImages))
+	for _, image := range serviceImages {
+		image = strings.TrimSpace(image)
+		if image == "" {
+			continue
+		}
+		if _, exists := seen[image]; exists {
+			continue
+		}
+		seen[image] = struct{}{}
+		images = append(images, image)
+	}
+	sort.Strings(images)
+
+	var build func(string) error
+	if options.FallbackLocalBuild {
+		build = func(image string) error {
+			dockerRoot, rootErr := ensureDockerAssetsRoot(".")
+			if rootErr != nil {
+				return fmt.Errorf("resolve docker build contexts: %w", rootErr)
+			}
+			return buildGovardImageLocally(image, dockerRoot, out, errOut)
+		}
+	}
+
+	result := runResilientImagePulls(ctx, images, pullSingleImage, build, func(image string) (string, error) {
+		inspection, inspectErr := inspectLocalImage(image)
+		return inspection.Architecture, inspectErr
+	}, out, errOut)
+
+	var unavailable []string
+	for _, failure := range result.Failed {
+		if _, _, _, ok := parseGovardImageReference(failure.Image); !ok {
+			unavailable = append(unavailable, failure.Image)
+		}
+	}
+	if len(unavailable) > 0 {
+		return result, fmt.Errorf("failed to pull images without a Govard local build fallback: %s", strings.Join(unavailable, ", "))
+	}
+	if !options.FallbackLocalBuild && len(result.Failed) > 0 {
+		names := make([]string, 0, len(result.Failed))
+		for _, failure := range result.Failed {
+			names = append(names, failure.Image)
+		}
+		return result, fmt.Errorf("failed to pull images (local fallback disabled): %s", strings.Join(names, ", "))
+	}
+	return result, nil
+}
+
+func pullSingleImage(ctx context.Context, image string) error {
+	command := exec.CommandContext(ctx, "docker", "pull", image)
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	return command.Run()
+}
+
+// runResilientImagePulls is the injectable core used by production and tests.
+func runResilientImagePulls(ctx context.Context, images []string, pull func(context.Context, string) error, build func(string) error, inspect func(string) (string, error), out io.Writer, errOut io.Writer) ResilientPullResult {
+	out = normalizeWriter(out)
+	errOut = normalizeWriter(errOut)
+	result := ResilientPullResult{
+		Pulled:       []string{},
+		ReusedLocal:  []string{},
+		BuiltLocally: []string{},
+		Failed:       []ResilientPullFailure{},
+	}
+
+	for _, image := range images {
+		if ctx != nil && ctx.Err() != nil {
+			break
+		}
+
+		pullErr := pull(ctx, image)
+		if pullErr == nil {
+			result.Pulled = append(result.Pulled, image)
+			continue
+		}
+		fmt.Fprintf(errOut, "WARNING: pull %s failed: %v\n", image, pullErr)
+
+		// A failed pull is harmless when a compatible image is already on
+		// this host: keep it instead of rebuilding from scratch.
+		if arch, inspectErr := inspect(image); inspectErr == nil && canUseExistingLocalImageOnPullFailureWithRuntime(true, arch, runtime.GOOS, runtime.GOARCH) {
+			fmt.Fprintf(out, "Pull %s failed but a compatible local image is already present; keeping it.\n", image)
+			result.ReusedLocal = append(result.ReusedLocal, image)
+			continue
+		}
+
+		if build == nil {
+			result.Failed = append(result.Failed, ResilientPullFailure{Image: image, Err: pullErr})
+			continue
+		}
+		if _, _, _, ok := parseGovardImageReference(image); !ok {
+			fmt.Fprintf(errOut, "WARNING: %s is not a Govard-managed image; no local build fallback available\n", image)
+			result.Failed = append(result.Failed, ResilientPullFailure{Image: image, Err: pullErr})
+			continue
+		}
+
+		fmt.Fprintf(out, "Attempting local Govard build fallback for %s...\n", image)
+		buildErr := build(image)
+		if buildErr == nil {
+			result.BuiltLocally = append(result.BuiltLocally, image)
+			continue
+		}
+		fmt.Fprintf(errOut, "WARNING: local build fallback for %s failed: %v\n", image, buildErr)
+		result.Failed = append(result.Failed, ResilientPullFailure{
+			Image: image,
+			Err:   fmt.Errorf("pull: %v; local build: %w", pullErr, buildErr),
+		})
+	}
+	return result
+}
+
+// RunResilientImagePullsForTest exposes the resilient pull core for tests.
+func RunResilientImagePullsForTest(
+	images []string,
+	pull func(context.Context, string) error,
+	build func(string) error,
+	inspect func(string) (string, error),
+	out io.Writer,
+	errOut io.Writer,
+) ResilientPullResult {
+	return runResilientImagePulls(context.Background(), images, pull, build, inspect, out, errOut)
+}
+
+// canUseExistingLocalImageOnPullFailureWithRuntime reports whether an image
+// that failed to pull can be satisfied by the image already present locally.
+func canUseExistingLocalImageOnPullFailureWithRuntime(exists bool, imageArchitecture string, goos string, goarch string) bool {
+	return exists && !shouldRebuildGovardImageForHostWithRuntime(imageArchitecture, goos, goarch)
+}
+
+// CanUseExistingLocalImageOnPullFailureForTest exposes the local reuse decision for tests.
+func CanUseExistingLocalImageOnPullFailureForTest(exists bool, imageArchitecture string, goos string, goarch string) bool {
+	return canUseExistingLocalImageOnPullFailureWithRuntime(exists, imageArchitecture, goos, goarch)
+}

--- a/tests/resilient_image_pull_test.go
+++ b/tests/resilient_image_pull_test.go
@@ -1,0 +1,183 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"govard/internal/engine"
+)
+
+func TestResolveElasticsearchBuildVersionKnownMinors(t *testing.T) {
+	cases := map[string]string{
+		// Minors published on Docker Hub as Govard images must resolve to a
+		// concrete upstream patch tag, otherwise the local build FROM line
+		// references a non-existent upstream minor-only tag.
+		"5.6":  "5.6.16",
+		"7.7":  "7.7.1",
+		"7.10": "7.10.1",
+		"7.16": "7.16.3",
+		"8.11": "8.11.4",
+		// Pre-existing mappings stay stable.
+		"7.9":  "7.9.3",
+		"7.17": "7.17.10",
+		"6.8":  "6.8.23",
+	}
+	for tag, expected := range cases {
+		if got := engine.ResolveElasticsearchBuildVersionForTest(tag); got != expected {
+			t.Errorf("elasticsearch tag %q: expected %q, got %q", tag, expected, got)
+		}
+	}
+}
+
+func TestResolveElasticsearchBuildVersionGenericMinorFallback(t *testing.T) {
+	// Unknown major.minor tags fall back to X.Y.0 so the local build targets
+	// a real upstream release instead of a non-existent floating minor tag.
+	if got := engine.ResolveElasticsearchBuildVersionForTest("8.19"); got != "8.19.0" {
+		t.Errorf("expected generic minor fallback 8.19.0, got %q", got)
+	}
+	// Full patch tags pass through untouched so projects pinned to a specific
+	// upstream release (e.g. search_version: "7.17.28") keep building exactly
+	// that version.
+	if got := engine.ResolveElasticsearchBuildVersionForTest("7.17.28"); got != "7.17.28" {
+		t.Errorf("expected patch tag passthrough 7.17.28, got %q", got)
+	}
+}
+
+func TestRunResilientImagePullsContinuesAfterFailures(t *testing.T) {
+	images := []string{
+		"ddtcorex/govard-elasticsearch:7.17.28", // pull fails, build fails -> recorded
+		"ddtcorex/govard-mariadb:10.6",          // pull succeeds
+		"ddtcorex/govard-redis:7.0",             // pull fails, local build succeeds
+		"node:24-alpine",                        // third-party: pull fails, no fallback possible
+	}
+
+	pullCalls := make([]string, 0)
+	pullErrs := map[string]error{
+		"ddtcorex/govard-elasticsearch:7.17.28": errors.New("manifest unknown"),
+		"ddtcorex/govard-redis:7.0":             errors.New("not found"),
+		"node:24-alpine":                        errors.New("not found"),
+	}
+	buildCalls := make([]string, 0)
+	buildErrs := map[string]error{
+		"ddtcorex/govard-elasticsearch:7.17.28": errors.New("plugin install failed"),
+	}
+
+	result := engine.RunResilientImagePullsForTest(
+		images,
+		func(_ context.Context, image string) error {
+			pullCalls = append(pullCalls, image)
+			return pullErrs[image]
+		},
+		func(image string) error {
+			buildCalls = append(buildCalls, image)
+			return buildErrs[image]
+		},
+		func(string) (string, error) {
+			return "", errors.New("no local image")
+		},
+		io.Discard,
+		io.Discard,
+	)
+
+	// Every image is attempted even though the first one fails completely.
+	if len(pullCalls) != len(images) {
+		t.Fatalf("expected all %d images to be attempted, pull was called for %v", len(images), pullCalls)
+	}
+
+	if len(result.Pulled) != 1 || result.Pulled[0] != "ddtcorex/govard-mariadb:10.6" {
+		t.Errorf("unexpected pulled set: %v", result.Pulled)
+	}
+	if len(result.BuiltLocally) != 1 || result.BuiltLocally[0] != "ddtcorex/govard-redis:7.0" {
+		t.Errorf("unexpected built-locally set: %v", result.BuiltLocally)
+	}
+	if len(result.Failed) != 2 {
+		t.Fatalf("expected 2 failures (elasticsearch + node), got %v", result.Failed)
+	}
+	failedImages := map[string]bool{}
+	for _, failure := range result.Failed {
+		failedImages[failure.Image] = true
+		if failure.Err == nil {
+			t.Errorf("failure for %s must carry the underlying error", failure.Image)
+		}
+	}
+	if !failedImages["ddtcorex/govard-elasticsearch:7.17.28"] || !failedImages["node:24-alpine"] {
+		t.Errorf("expected elasticsearch and node failures, got %v", failedImages)
+	}
+
+	// Third-party images never reach the local build fallback.
+	for _, image := range buildCalls {
+		if image == "node:24-alpine" {
+			t.Error("third-party image node:24-alpine must not be sent to Govard local build")
+		}
+	}
+}
+
+func TestRunResilientImagePullsNilBuildSkipsFallback(t *testing.T) {
+	images := []string{"ddtcorex/govard-redis:7.4"}
+
+	result := engine.RunResilientImagePullsForTest(
+		images,
+		func(_ context.Context, _ string) error { return errors.New("not found") },
+		nil,
+		func(string) (string, error) {
+			return "", errors.New("no local image")
+		},
+		io.Discard,
+		io.Discard,
+	)
+
+	if len(result.Failed) != 1 {
+		t.Fatalf("expected the image to be recorded as failed without a build fallback, got %+v", result)
+	}
+	if len(result.BuiltLocally) != 0 {
+		t.Errorf("nothing should be built when fallback is disabled: %v", result.BuiltLocally)
+	}
+}
+
+func TestCanUseExistingLocalImageOnPullFailure(t *testing.T) {
+	cases := []struct {
+		name     string
+		exists   bool
+		arch     string
+		goos     string
+		goarch   string
+		expected bool
+	}{
+		{"existing compatible image is used", true, "amd64", "linux", "amd64", true},
+		{"missing image requires build", false, "", "linux", "amd64", false},
+		{"incompatible darwin/arm64 image requires rebuild", true, "amd64", "darwin", "arm64", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := engine.CanUseExistingLocalImageOnPullFailureForTest(tc.exists, tc.arch, tc.goos, tc.goarch); got != tc.expected {
+				t.Errorf("exists=%v arch=%q os=%s arch=%s: expected %v, got %v", tc.exists, tc.arch, tc.goos, tc.goarch, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestRunResilientImagePullsReusesCompatibleLocalImage(t *testing.T) {
+	images := []string{"ddtcorex/govard-elasticsearch:7.17.28"}
+	buildCalled := false
+
+	result := engine.RunResilientImagePullsForTest(
+		images,
+		func(_ context.Context, _ string) error { return errors.New("manifest unknown") },
+		func(string) error { buildCalled = true; return nil },
+		func(string) (string, error) { return "amd64", nil }, // compatible local image exists
+		io.Discard,
+		io.Discard,
+	)
+
+	if len(result.ReusedLocal) != 1 || result.ReusedLocal[0] != "ddtcorex/govard-elasticsearch:7.17.28" {
+		t.Errorf("expected image to be reused from local cache, got %+v", result)
+	}
+	if len(result.Failed) != 0 {
+		t.Errorf("reused image must not be reported as failed: %+v", result.Failed)
+	}
+	if buildCalled {
+		t.Error("local build must not run when a compatible image already exists")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #159

`govard env pull` (and the `Pull` step of `govard env up --pull`) no longer aborts when a single image cannot be pulled. Images are now retried **one by one**: Govard-managed failures fall back to a local build, compatible images already on the host are reused as-is, and only images that are truly impossible to materialize fail the command.

### What changed

**Resilient per-image pull (internal/engine/resilient_pull.go, new)**
- Pulls each compose image individually; one failure never blocks the rest.
- On pull failure: reuse an existing compatible local image (architecture-checked), else build locally (when fallback is enabled), else record a structured failure.
- Missing third-party images (no local build available) still fail the command.
- Honors context cancellation and `--no-fallback`.

**CLI wiring**
- internal/cmd/env.go / internal/cmd/up.go: after a failed batch `docker compose pull`, run the resilient retry; report Pulled / Kept / Built-locally / Failed sets explicitly instead of aborting.
- Both call sites pass `--ignore-buildable` to compose pull so Compose never attempts builds during pull; older Compose versions simply error on the unknown flag and land in the same resilient path, so behavior stays correct.
- internal/cmd/utils.go: `--no-fallback` is registered as a Govard-specific flag for `env pull` help and filtered from compose passthrough args.

**Elasticsearch version resolution (internal/engine/local_image_fallback.go)**
- resolveElasticsearchBuildVersion() now maps every minor tag published on the Govard Docker Hub namespace to a verified real upstream patch release: 5.6 to 5.6.16, 6.5 to 6.5.4, 6.8 to 6.8.23, 7.6 to 7.6.2, 7.7 to 7.7.1, 7.9 to 7.9.3, 7.10 to 7.10.1, 7.16 to 7.16.3, 7.17 to 7.17.10, 8.11 to 8.11.4 (each checked against Docker Hub).
- Unknown minors fall back to X.Y.0 instead of emitting a non-existent upstream minor-only FROM tag.
- Full patch tags (e.g. visiterlyon 7.17.28, which upstream Elastic does publish) pass through untouched so pinned projects keep building exactly that release.
- OpenSearch needed no change: upstream publishes both minor and X.Y.0 tags (verified).

**Docs**: README feature bullet, docs/reference/cli-commands.md + Vietnamese mirror document the new pull behavior and search-version semantics.

## Rationale

The old flow treated "pull everything" as all-or-nothing and used the local-build fallback as a replacement for the failed pull rather than a completion of it. Projects pinning full patch search versions (valid upstream releases like 7.17.28) could never satisfy the Hub minor-only tags, and even the fallback build broke because its resolver emitted upstream-nonexistent minor tags.

## Test plan

- [x] New hermetic tests in tests/resilient_image_pull_test.go: ES version mapping table (verified upstream tags), generic minor fallback, patch passthrough, resilient core continues after failures, third-party images never sent to local build, nil-build skips fallback, local-reuse decision matrix, end-to-end reuse flow test.
- [x] Full make test passes (lint + fmt + vet + unit + integration).
- [x] gofmt -s -l clean on changed files.
- [x] Real-world smoke test on the affected project (visiterlyon): ddtcorex/govard-elasticsearch:7.17.28 fails on the Hub, remaining 5 images pulled successfully, existing local ES image kept, command succeeds.
