### PR TITLE
feat(audit): human-readable default text output

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,12 @@ govard audit toolchain build
 Session manifests live at
 `~/.govard/audit/<project-id>/sessions/<session-id>/manifest.json`; each result
 lives under its `runs/<run-id>/audit-result.json` directory. Reruns always need
-an explicit session ID, never an implicit latest session. Use `--format json`
-for clean machine-readable stdout. Audit evidence includes the immutable image
-digest, the toolchain digest, phase timings, and cache state with its reason.
+an explicit session ID, never an implicit latest session. The default output is
+a readable summary (verdict, per-PHP results with cache state and sample
+findings, plus the exact rerun command); a failed or cancelled run exits
+non-zero after printing it. Use `--format json` for clean machine-readable
+stdout. Audit evidence includes the immutable image digest, the toolchain
+digest, phase timings, and cache state with its reason.
 
 `govard audit` analyzes a whole Magento project, a module inside one, or a
 standalone module (`--mode`). Project and module-in-project targets analyze the

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -68,10 +68,37 @@ govard audit cleanup --older-than 168h
 ```
 
 `run` defaults to `--scope project`, `--checks lint`, `--lint-provider govard`,
-`--mode auto`, and `--lint-jobs 2`. `--format json` writes one undecorated JSON
-object to stdout; diagnostics and backend logs remain out of that stream. Only
-`text` and `json` formats are accepted, and `--lint-jobs` must be between 1 and
+`--mode auto`, and `--lint-jobs 2`. The default `text` format prints a compact
+human-readable summary: the verdict first (PASSED/FAILED/CANCELLED), then scope,
+duration, environment, per-PHP results with cache state and up to ten findings,
+plus next-step hints pointing at the persisted report and the exact rerun
+command. A completed run whose checks did not pass (failed or cancelled) still
+prints its summary and then exits non-zero, so scripts and CI observe the
+outcome. Color is applied only on an interactive terminal (`NO_COLOR` disables
+it), so piped or redirected output stays free of escape codes.
+`--format json` writes one undecorated JSON object to stdout; diagnostics and
+backend logs remain out of that stream. Only `text` and `json` formats are
+accepted, and `--lint-jobs` must be between 1 and
 the number of PHP versions declared by the framework.
+
+Example `govard audit run` summary:
+
+```
+== Audit run run-0001 / session 20260822T005406Z-14bd9570 ==
+  Status:      FAILED
+  Scope:       project
+  Duration:    4.5s
+  Environment: magento2 | nginx | Govard 1.63.0
+
+  Checks
+    - lint - failed - 4.5s - provider govard
+      PHP 8.5 | failed | 3.9s | cache cold | 12 findings
+      - phpcs Squiz.Classes.ClassFileName app/code/Acme/Catalog/Model/Item.php:12: Class name is not camel case
+
+  What next
+  Full findings: ~/.govard/audit/<project-id>/sessions/<session-id>/runs/run-0001/report.json
+  Re-run:        govard audit rerun --session <session-id>
+```
 
 Each run creates `~/.govard/audit/<project-id>/sessions/<session-id>/manifest.json`
 and writes its result atomically to

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -68,10 +68,36 @@ govard audit cleanup --older-than 168h
 ```
 
 `run` mặc định dùng `--scope project`, `--checks lint`,
-`--lint-provider govard`, `--mode auto` và `--lint-jobs 2`. `--format json` chỉ
-ghi một JSON object không có terminal decoration ra stdout; diagnostic và log
-backend nằm ngoài stream đó. Chỉ chấp nhận `text`/`json`; `--lint-jobs` phải từ 1
-đến số PHP version được framework khai báo.
+`--lint-provider govard`, `--mode auto` và `--lint-jobs 2`. Format mặc định
+`text` in một bản tóm tắt dễ đọc: kết luận trước tiên (PASSED/FAILED/CANCELLED),
+tiếp theo là scope, thời gian chạy, môi trường, kết quả từng PHP kèm cache state
+và tối đa mười finding, cùng gợi ý lệnh kế tiếp trỏ tới report đã lưu và đúng
+lệnh rerun. Một run hoàn tất nhưng check không pass (failed hoặc cancelled) vẫn
+in đầy đủ bản tóm tắt rồi mới thoát với exit code khác 0, để script và CI nhận
+biết được kết quả. Màu chỉ được áp dụng trên terminal tương tác (`NO_COLOR` tắt
+hẳn), nên output khi pipe hay redirect không dính escape code.
+`--format json` chỉ ghi một JSON object không có terminal decoration ra stdout;
+diagnostic và log backend nằm ngoài stream đó. Chỉ chấp nhận `text`/`json`;
+`--lint-jobs` phải từ 1 đến số PHP version được framework khai báo.
+
+Ví dụ bản tóm tắt của `govard audit run`:
+
+```
+== Audit run run-0001 / session 20260822T005406Z-14bd9570 ==
+  Status:      FAILED
+  Scope:       project
+  Duration:    4.5s
+  Environment: magento2 | nginx | Govard 1.63.0
+
+  Checks
+    - lint - failed - 4.5s - provider govard
+      PHP 8.5 | failed | 3.9s | cache cold | 12 findings
+      - phpcs Squiz.Classes.ClassFileName app/code/Acme/Catalog/Model/Item.php:12: Class name is not camel case
+
+  What next
+  Full findings: ~/.govard/audit/<project-id>/sessions/<session-id>/runs/run-0001/report.json
+  Re-run:        govard audit rerun --session <session-id>
+```
 
 Mỗi lần chạy tạo
 `~/.govard/audit/<project-id>/sessions/<session-id>/manifest.json` và ghi result

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -237,10 +237,21 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 			MatrixComplete:      resolvedTarget.MatrixComplete,
 			BypassResultCache:   options.NoLintResultCache,
 		})
-		if err != nil {
-			return err
+		// Render the summary before reporting the outcome, so a failed run
+		// still prints everything the operator needs alongside the failure.
+		// A run without a persisted identity produced nothing worth showing;
+		// its error carries the whole story.
+		var renderErr error
+		if result.RunID != "" {
+			renderErr = writeAuditValue(cmd, options.Format, result)
 		}
-		return writeAuditValue(cmd, options.Format, result)
+		if err != nil {
+			return auditRunExitError{cause: err}
+		}
+		if renderErr != nil {
+			return renderErr
+		}
+		return auditRunOutcome(result)
 	}}
 }
 
@@ -260,10 +271,17 @@ func newAuditRerunCommand(options *auditCommandOptions, dependencies auditComman
 			return err
 		}
 		result, err := runner.Rerun(cmd.Context(), options.SessionID, resolvedTarget.ProjectID, options.Checks)
-		if err != nil {
-			return err
+		var renderErr error
+		if result.RunID != "" {
+			renderErr = writeAuditValue(cmd, options.Format, result)
 		}
-		return writeAuditValue(cmd, options.Format, result)
+		if err != nil {
+			return auditRunExitError{cause: err}
+		}
+		if renderErr != nil {
+			return renderErr
+		}
+		return auditRunOutcome(result)
 	}}
 }
 
@@ -487,6 +505,14 @@ func writeAuditValue(cmd *cobra.Command, format string, value any) error {
 	if format == "json" {
 		return writeAuditJSON(cmd.OutOrStdout(), value)
 	}
-	_, err := fmt.Fprintf(cmd.OutOrStdout(), "%+v\n", value)
-	return err
+	return writeAuditText(cmd.OutOrStdout(), value)
 }
+
+// auditRunExitError wraps a completed-but-unsuccessful run so the command can
+// render its full summary first and only then fail the process.
+type auditRunExitError struct {
+	cause error
+}
+
+func (e auditRunExitError) Error() string { return e.cause.Error() }
+func (e auditRunExitError) Unwrap() error { return e.cause }

--- a/internal/cmd/audit_output.go
+++ b/internal/cmd/audit_output.go
@@ -1,0 +1,564 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"govard/internal/audit"
+	"govard/internal/engine"
+
+	"github.com/pterm/pterm"
+	"golang.org/x/term"
+)
+
+// AuditRunOutcomeError reports an audit invocation that completed and persisted
+// its result, but whose analysis did not pass. The command still renders its
+// full human-readable or JSON summary first; this error only turns the outcome
+// into a non-zero exit code so scripts and CI observe failed lint findings and
+// cancelled runs instead of a silent success.
+type AuditRunOutcomeError struct {
+	SessionID string
+	RunID     string
+	Status    audit.Status
+}
+
+func (e *AuditRunOutcomeError) Error() string {
+	subject := fmt.Sprintf("audit run %s/%s", e.SessionID, e.RunID)
+	if e.Status == audit.StatusCancelled {
+		return subject + " was cancelled before completion"
+	}
+	return subject + " reported failed checks"
+}
+
+// auditRunOutcome converts a finished run into the command-level error that
+// fails the process when the outcome is anything but a clean pass.
+func auditRunOutcome(result audit.RunResult) error {
+	switch result.Status {
+	case audit.StatusPassed, audit.StatusPending, audit.StatusRunning, audit.StatusNotComparable:
+		return nil
+	default:
+		return &AuditRunOutcomeError{SessionID: result.SessionID, RunID: result.RunID, Status: result.Status}
+	}
+}
+
+// auditTextRenderer writes the operator-facing text view of audit values. Every
+// line goes straight to the command writer. Color is applied only when the
+// destination is an interactive terminal and NO_COLOR is unset, so piped or
+// redirected output stays free of escape codes.
+type auditTextRenderer struct {
+	writer io.Writer
+	color  bool
+}
+
+const auditFieldWidth = 12
+
+// auditColorEnabled reports whether the writer accepts terminal styling.
+func auditColorEnabled(writer io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	file, ok := writer.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(file.Fd()))
+}
+
+func (r auditTextRenderer) printf(format string, a ...any) {
+	fmt.Fprintf(r.writer, format+"\n", a...)
+}
+
+func (r auditTextRenderer) blank() {
+	fmt.Fprintln(r.writer)
+}
+
+func (r auditTextRenderer) header(text string) {
+	r.blank()
+	if r.color {
+		bar := pterm.NewStyle(pterm.BgLightBlue, pterm.FgBlack, pterm.Bold)
+		fmt.Fprintln(r.writer, bar.Sprint(" "+text+" "))
+		return
+	}
+	fmt.Fprintf(r.writer, "== %s ==\n", text)
+}
+
+func (r auditTextRenderer) section(title string) {
+	r.blank()
+	if r.color {
+		fmt.Fprintln(r.writer, pterm.NewStyle(pterm.Bold).Sprint("  "+title))
+		return
+	}
+	r.printf("  %s", title)
+}
+
+func (r auditTextRenderer) field(label, value string) {
+	if value == "" {
+		return
+	}
+	r.printf("  %-*s %s", auditFieldWidth, label+":", value)
+}
+
+func (r auditTextRenderer) bullet(text string) {
+	r.printf("    - %s", text)
+}
+
+func writeAuditText(writer io.Writer, value any) error {
+	renderer := auditTextRenderer{writer: writer, color: auditColorEnabled(writer)}
+	switch typed := value.(type) {
+	case audit.RunResult:
+		renderer.runResult(typed)
+	case audit.SessionManifest:
+		renderer.sessionManifest(typed)
+	case auditToolchainStatusReport:
+		renderer.toolchainStatus(typed)
+	case auditToolchainIdentity:
+		renderer.toolchainIdentity(typed)
+	case map[string]any:
+		renderer.removedSessions(typed)
+	default:
+		fmt.Fprintf(writer, "%+v\n", value)
+	}
+	return nil
+}
+
+func (r auditTextRenderer) runResult(result audit.RunResult) {
+	r.header(fmt.Sprintf("Audit run %s / session %s", result.RunID, result.SessionID))
+	r.field("Status", auditStatusText(result.Status, r.color))
+	r.field("Scope", string(result.Scope))
+	if duration := auditRunDurationMS(result); duration > 0 {
+		r.field("Duration", auditHumanDuration(duration))
+	}
+	if env := auditEnvironmentSummary(result.Environment); env != "" {
+		r.field("Environment", env)
+	}
+	if source := auditSourceSummary(result.Source); source != "" {
+		r.field("Source", source)
+	}
+	r.checks(result.Jobs)
+	r.errors(result.Errors)
+	r.nextSteps(result)
+}
+
+func (r auditTextRenderer) checks(jobs []audit.JobResult) {
+	if len(jobs) == 0 {
+		return
+	}
+	r.section("Checks")
+	for _, job := range jobs {
+		line := job.ID + " - " + auditPlainStatus(string(job.Status))
+		if job.DurationMS > 0 {
+			line += " - " + auditHumanDuration(job.DurationMS)
+		}
+		if provider := auditEvidenceString(job.Evidence, "provider"); provider != "" {
+			line += " - provider " + provider
+		}
+		if lintStatus := auditEvidenceString(job.Evidence, "lint_status"); lintStatus != "" && lintStatus != string(job.Status) {
+			line += " - lint " + lintStatus
+		}
+		r.bullet(line)
+		for _, php := range auditLintPHPViews(job.Evidence) {
+			r.phpResult(php)
+		}
+	}
+}
+
+func (r auditTextRenderer) phpResult(php auditLintPHPView) {
+	parts := []string{"PHP " + php.Version, auditPlainStatus(php.Outcome)}
+	if php.DurationMS > 0 {
+		parts = append(parts, auditHumanDuration(php.DurationMS))
+	}
+	cache := php.CacheState
+	if cache == "" {
+		cache = "unknown"
+	}
+	parts = append(parts, "cache "+cache, fmt.Sprintf("%d findings", len(php.Findings)))
+	r.printf("      %s", strings.Join(parts, " | "))
+	for index, finding := range php.Findings {
+		if index == auditMaxDisplayedFindings {
+			r.printf("      ... and %d more findings (see the full report under What next)", len(php.Findings)-index)
+			break
+		}
+		r.printf("      - %s", finding.String())
+	}
+}
+
+func (r auditTextRenderer) errors(errors []audit.AuditError) {
+	if len(errors) == 0 {
+		return
+	}
+	r.section("Errors")
+	for _, issue := range errors {
+		code := issue.Code
+		if code == "" {
+			code = "error"
+		}
+		r.bullet("[" + code + "] " + issue.Message)
+	}
+}
+
+func (r auditTextRenderer) nextSteps(result audit.RunResult) {
+	var steps []string
+	report := auditReportPath(result.ProjectID, result.SessionID, result.RunID)
+	switch result.Status {
+	case audit.StatusFailed:
+		steps = append(steps,
+			"Full findings: "+report,
+			"Re-run:        govard audit rerun --session "+result.SessionID)
+	case audit.StatusCancelled:
+		steps = append(steps,
+			"The run stopped before completing.",
+			"Re-run:        govard audit rerun --session "+result.SessionID,
+			"Evidence:      "+report)
+	}
+	if len(steps) == 0 {
+		return
+	}
+	r.section("What next")
+	for _, step := range steps {
+		r.printf("  %s", step)
+	}
+}
+
+func (r auditTextRenderer) sessionManifest(manifest audit.SessionManifest) {
+	r.header("Audit session " + manifest.SessionID)
+	r.field("Project", manifest.ProjectID)
+	if manifest.ProjectRoot != "" {
+		r.field("Root", manifest.ProjectRoot)
+	}
+	scope := string(manifest.Scope)
+	if manifest.BaseRef != "" {
+		scope += " (base " + manifest.BaseRef + ")"
+	}
+	r.field("Scope", scope)
+	if !manifest.CreatedAt.IsZero() {
+		r.field("Created", auditTimestamp(manifest.CreatedAt))
+	}
+	if env := auditEnvironmentSummary(manifest.Environment); env != "" {
+		r.field("Environment", env)
+	}
+	if source := auditSourceSummary(manifest.Source); source != "" {
+		r.field("Source", source)
+	}
+	if len(manifest.Runs) == 0 {
+		return
+	}
+	r.section("Runs")
+	for _, run := range manifest.Runs {
+		line := run.RunID
+		if !run.CreatedAt.IsZero() {
+			line += " - " + auditTimestamp(run.CreatedAt)
+		}
+		r.bullet(line)
+	}
+	r.printf("")
+	r.printf("  Inspect a run:")
+	r.printf("    govard audit result --session %s --run <run-id>", manifest.SessionID)
+}
+
+func (r auditTextRenderer) toolchainStatus(report auditToolchainStatusReport) {
+	r.header("Lint toolchain")
+	r.field("Provider", report.Provider)
+	r.field("Present", auditYesNo(report.Present))
+	if report.ContextDigest != "" {
+		r.field("Context", report.ContextDigest)
+	}
+	if report.OfficialImage != "" {
+		r.field("Official image", fmt.Sprintf("%s (usable: %s)", report.OfficialImage, auditYesNo(report.OfficialUsable)))
+	}
+	if report.LocalBuildImage != "" {
+		r.field("Local image", fmt.Sprintf("%s (present: %s)", report.LocalBuildImage, auditYesNo(report.LocalBuildPresent)))
+	}
+	if report.Toolchain.Image != "" {
+		r.toolchainIdentityLines(report.Toolchain)
+	}
+	if report.Repair != "" {
+		r.blank()
+		r.printf("  Fix: %s", report.Repair)
+	}
+}
+
+func (r auditTextRenderer) toolchainIdentity(identity auditToolchainIdentity) {
+	r.header("Lint toolchain identity")
+	r.toolchainIdentityLines(identity)
+}
+
+func (r auditTextRenderer) toolchainIdentityLines(identity auditToolchainIdentity) {
+	r.field("Image", identity.Image)
+	if identity.ImageDigest != "" {
+		r.field("Image digest", identity.ImageDigest)
+	}
+	if identity.ContextDigest != "" {
+		r.field("Context digest", identity.ContextDigest)
+	}
+	r.field("Local build", auditYesNo(identity.LocalBuild))
+}
+
+func (r auditTextRenderer) removedSessions(payload map[string]any) {
+	raw, _ := payload["removed_sessions"].([]string)
+	ids := make([]string, 0, len(raw))
+	ids = append(ids, raw...)
+	r.header("Audit cleanup")
+	if len(ids) == 0 {
+		r.printf("  No sessions matched the requested age.")
+		return
+	}
+	r.field("Removed", fmt.Sprintf("%d session(s)", len(ids)))
+	for _, id := range ids {
+		r.bullet(id)
+	}
+}
+
+// auditMaxDisplayedFindings caps the per-PHP finding list so a broken module
+// cannot flood the terminal; the provider report keeps the complete list.
+const auditMaxDisplayedFindings = 10
+
+type auditLintPHPView struct {
+	Version     string
+	Outcome     string
+	DurationMS  int64
+	CacheState  string
+	CacheReason string
+	Findings    []auditLintFindingView
+}
+
+type auditLintFindingView struct {
+	Tool    string
+	Rule    string
+	Path    string
+	Line    int
+	Column  int
+	Message string
+}
+
+func (f auditLintFindingView) String() string {
+	location := f.Path
+	if location == "" {
+		location = "(unknown path)"
+	}
+	if f.Line > 0 {
+		location += ":" + fmt.Sprint(f.Line)
+		if f.Column > 0 {
+			location += ":" + fmt.Sprint(f.Column)
+		}
+	}
+	prefix := f.Tool
+	if prefix == "" {
+		prefix = "lint"
+	}
+	if f.Rule != "" {
+		prefix += " " + f.Rule
+	}
+	message := f.Message
+	if len(message) > 160 {
+		message = message[:157] + "..."
+	}
+	if message == "" {
+		return prefix + " " + location
+	}
+	return prefix + " " + location + ": " + message
+}
+
+// auditLintPHPViews normalizes the lint evidence carried by one job. A fresh
+// run holds typed []audit.LintPHPResult values, while a result read back from
+// the store decodes them into []any/map[string]any; both shapes collapse into
+// the same view so run and result render identically.
+func auditLintPHPViews(evidence map[string]any) []auditLintPHPView {
+	if evidence == nil {
+		return nil
+	}
+	if typed, ok := evidence["php_results"].([]audit.LintPHPResult); ok {
+		views := make([]auditLintPHPView, 0, len(typed))
+		for _, result := range typed {
+			findings := make([]auditLintFindingView, 0, len(result.Findings))
+			for _, finding := range result.Findings {
+				findings = append(findings, auditLintFindingView{
+					Tool: finding.Tool, Rule: finding.Rule, Path: finding.Path,
+					Line: finding.Line, Column: finding.Column, Message: finding.Message,
+				})
+			}
+			views = append(views, auditLintPHPView{
+				Version:     result.PHPVersion,
+				Outcome:     result.Outcome,
+				DurationMS:  result.DurationMS,
+				CacheState:  result.Cache.State,
+				CacheReason: result.Cache.Reason,
+				Findings:    findings,
+			})
+		}
+		return views
+	}
+	raw, ok := evidence["php_results"].([]any)
+	if !ok {
+		return nil
+	}
+	views := make([]auditLintPHPView, 0, len(raw))
+	for _, entry := range raw {
+		item, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		view := auditLintPHPView{
+			Version:    auditMapString(item, "php_version"),
+			Outcome:    auditMapString(item, "outcome"),
+			DurationMS: auditMapInt64(item, "duration_ms"),
+		}
+		if cache, ok := item["cache"].(map[string]any); ok {
+			view.CacheState = auditMapString(cache, "state")
+			view.CacheReason = auditMapString(cache, "reason")
+		}
+		if findings, ok := item["findings"].([]any); ok {
+			for _, raw := range findings {
+				finding, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				view.Findings = append(view.Findings, auditLintFindingView{
+					Tool:    auditMapString(finding, "tool"),
+					Rule:    auditMapString(finding, "rule"),
+					Path:    auditMapString(finding, "path"),
+					Line:    int(auditMapInt64(finding, "line")),
+					Column:  int(auditMapInt64(finding, "column")),
+					Message: auditMapString(finding, "message"),
+				})
+			}
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
+func auditMapString(values map[string]any, key string) string {
+	value, _ := values[key].(string)
+	return value
+}
+
+func auditMapInt64(values map[string]any, key string) int64 {
+	switch number := values[key].(type) {
+	case int64:
+		return number
+	case int:
+		return int64(number)
+	case float64:
+		return int64(number)
+	default:
+		return 0
+	}
+}
+
+func auditEvidenceString(evidence map[string]any, key string) string {
+	if evidence == nil {
+		return ""
+	}
+	value, _ := evidence[key].(string)
+	return value
+}
+
+func auditRunDurationMS(result audit.RunResult) int64 {
+	var longest int64
+	for _, job := range result.Jobs {
+		if job.DurationMS > longest {
+			longest = job.DurationMS
+		}
+	}
+	if longest > 0 {
+		return longest
+	}
+	for _, job := range result.Jobs {
+		if duration := auditMapInt64(job.Evidence, "duration_ms"); duration > longest {
+			longest = duration
+		}
+	}
+	return longest
+}
+
+func auditHumanDuration(milliseconds int64) string {
+	if milliseconds < 1000 {
+		return fmt.Sprintf("%dms", milliseconds)
+	}
+	if milliseconds < 60000 {
+		return fmt.Sprintf("%.1fs", float64(milliseconds)/1000)
+	}
+	duration := time.Duration(milliseconds) * time.Millisecond
+	return fmt.Sprintf("%dm%ds", int(duration.Minutes()), int(duration.Seconds())%60)
+}
+
+func auditTimestamp(value time.Time) string {
+	return value.UTC().Format("2006-01-02 15:04 UTC")
+}
+
+func auditYesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+func auditPlainStatus(status string) string {
+	if status == "" {
+		return "unknown"
+	}
+	return status
+}
+
+var auditStatusStyles = map[audit.Status]*pterm.Style{}
+
+func init() {
+	auditStatusStyles[audit.StatusPassed] = pterm.NewStyle(pterm.FgGreen, pterm.Bold)
+	auditStatusStyles[audit.StatusFailed] = pterm.NewStyle(pterm.FgRed, pterm.Bold)
+	auditStatusStyles[audit.StatusCancelled] = pterm.NewStyle(pterm.FgYellow, pterm.Bold)
+	auditStatusStyles[audit.StatusPending] = pterm.NewStyle(pterm.FgGray)
+	auditStatusStyles[audit.StatusRunning] = pterm.NewStyle(pterm.FgGray)
+}
+
+func auditStatusText(status audit.Status, color bool) string {
+	text := strings.ToUpper(auditPlainStatus(string(status)))
+	style, ok := auditStatusStyles[status]
+	if !color || !ok || style == nil {
+		return text
+	}
+	return style.Sprint(text)
+}
+
+func auditEnvironmentSummary(env audit.EnvironmentFingerprint) string {
+	parts := make([]string, 0, 4)
+	if env.Framework != "" {
+		parts = append(parts, env.Framework)
+	}
+	if env.FrameworkVersion != "" {
+		parts = append(parts, env.FrameworkVersion)
+	}
+	if env.WebServer != "" {
+		parts = append(parts, env.WebServer)
+	}
+	if env.GovardVersion != "" {
+		parts = append(parts, "Govard "+env.GovardVersion)
+	}
+	return strings.Join(parts, " | ")
+}
+
+func auditSourceSummary(source audit.SourceFingerprint) string {
+	parts := make([]string, 0, 2)
+	if source.GitCommit != "" {
+		commit := source.GitCommit
+		if source.GitDirty {
+			commit += " (uncommitted changes)"
+		} else {
+			commit += " (clean)"
+		}
+		parts = append(parts, commit)
+	}
+	if source.Digest != "" {
+		parts = append(parts, source.Digest)
+	}
+	return strings.Join(parts, " | ")
+}
+
+// auditReportPath points operators at the persisted provider report without
+// reproducing any of its content in the terminal.
+func auditReportPath(projectID, sessionID, runID string) string {
+	root := audit.DefaultStoreRoot(engine.GovardHomeDir())
+	return fmt.Sprintf("%s/%s/sessions/%s/runs/%s/report.json", root, projectID, sessionID, runID)
+}

--- a/tests/audit_output_test.go
+++ b/tests/audit_output_test.go
@@ -1,0 +1,205 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"govard/internal/audit"
+)
+
+// textLintBackend reports the configured report for every invocation, so
+// command-level text rendering can be exercised without containers.
+type textLintBackend struct {
+	report audit.LintReport
+}
+
+func (backend *textLintBackend) Name() string { return "ci" }
+
+func (backend *textLintBackend) Run(_ context.Context, request audit.LintRequest) (audit.LintReport, error) {
+	return backend.report, nil
+}
+
+func failingLintReportWithFindings(projectID string) audit.LintReport {
+	report := passingLintReport(projectID)
+	report.Status = "failed"
+	php := report.PHPResults[0]
+	php.Outcome = "failed"
+	php.Phases[0].Status = "failed"
+	php.Findings = []audit.LintFinding{
+		{Tool: "phpcs", Rule: "Squiz.Classes.ClassFileName", Path: "app/code/Acme/Catalog/Model/Item.php", Line: 12, Message: "Class name is not camel case"},
+	}
+	report.PHPResults[0] = php
+	return report
+}
+
+func TestAuditRunDefaultTextShowsReadableSummary(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	backend := &textLintBackend{report: passingLintReport("audit-shop")}
+	installAuditCommandDependencies(t, backend)
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "run"})
+	if err != nil {
+		t.Fatalf("default-format run returned error: %v; output=%s", err, output)
+	}
+	rendered := string(output)
+	for _, want := range []string{
+		"Audit run run-0001",
+		"PASSED",
+		"Scope",
+		"Checks",
+		"lint - passed",
+		"PHP 8.4",
+		"provider ci",
+		"0 findings",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("default text output is missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "SchemaVersion:") || strings.Contains(rendered, "{") {
+		t.Fatalf("default text output still dumps the raw struct:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "\x1b[") {
+		t.Fatalf("non-terminal writer received ANSI escape codes:\n%s", rendered)
+	}
+}
+
+func TestAuditRunTextFailsProcessAndExplainsFindings(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	backend := &textLintBackend{report: failingLintReportWithFindings("audit-shop")}
+	installAuditCommandDependencies(t, backend)
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "run"})
+	if err == nil {
+		t.Fatalf("a failed lint must fail the process; output=%s", output)
+	}
+	if !strings.Contains(err.Error(), "failed checks") {
+		t.Fatalf("error = %v, want a failed-checks outcome error", err)
+	}
+	rendered := string(output)
+	for _, want := range []string{
+		"FAILED",
+		"failed",
+		"phpcs Squiz.Classes.ClassFileName app/code/Acme/Catalog/Model/Item.php:12",
+		"govard audit rerun --session",
+		"What next",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("failed-run text output is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestAuditCancelledRunTextExplainsCancellation(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	backend := &textLintBackend{report: func() audit.LintReport {
+		report := passingLintReport("audit-shop")
+		report.Status = "cancelled"
+		php := report.PHPResults[0]
+		php.Outcome = "cancelled"
+		php.Phases[0].Status = "cancelled"
+		report.PHPResults[0] = php
+		return report
+	}()}
+	installAuditCommandDependencies(t, backend)
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "run"})
+	if err == nil || !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("error = %v, want a cancelled outcome error", err)
+	}
+	rendered := string(output)
+	if !strings.Contains(rendered, "CANCELLED") {
+		t.Fatalf("cancelled-run text output is missing CANCELLED:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Re-run:") {
+		t.Fatalf("cancelled-run text output lacks a re-run hint:\n%s", rendered)
+	}
+}
+
+func TestAuditStatusDefaultTextListsRunsAndInspectHint(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	backend := &textLintBackend{report: passingLintReport("audit-shop")}
+	installAuditCommandDependencies(t, backend)
+
+	runOutput, err := executeAuditCommand(t, project, []string{"audit", "run", "--format", "json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result audit.RunResult
+	if err := json.Unmarshal(runOutput, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "status", "--session", result.SessionID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := string(output)
+	for _, want := range []string{
+		"Audit session " + result.SessionID,
+		"Runs",
+		"run-0001",
+		"govard audit result --session " + result.SessionID,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("status text output is missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "SchemaVersion:") {
+		t.Fatalf("status text output still dumps the raw manifest:\n%s", rendered)
+	}
+}
+
+func TestAuditResultDefaultTextRerendersStoredEvidence(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	backend := &textLintBackend{report: failingLintReportWithFindings("audit-shop")}
+	installAuditCommandDependencies(t, backend)
+
+	runOutput, err := executeAuditCommand(t, project, []string{"audit", "run", "--format", "json"})
+	if err == nil || !strings.Contains(err.Error(), "failed checks") {
+		t.Fatalf("error = %v, want a failed-checks outcome error", err)
+	}
+	var result audit.RunResult
+	if err := json.Unmarshal(runOutput, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	// The stored result decodes evidence into generic maps, so rendering a
+	// persisted run exercises the second branch of the evidence normalizer.
+	output, _ := executeAuditCommand(t, project, []string{"audit", "result", "--session", result.SessionID, "--run", result.RunID})
+	rendered := string(output)
+	for _, want := range []string{
+		"Audit run " + result.RunID,
+		"FAILED",
+		"PHP 8.4",
+		"phpcs Squiz.Classes.ClassFileName app/code/Acme/Catalog/Model/Item.php:12",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("result text output is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestAuditCleanupDefaultTextReportsRemovedSessions(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	backend := &textLintBackend{report: passingLintReport("audit-shop")}
+	installAuditCommandDependencies(t, backend)
+
+	if _, err := executeAuditCommand(t, project, []string{"audit", "run", "--format", "json"}); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "cleanup", "--older-than", "1ns"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := string(output)
+	if !strings.Contains(rendered, "Audit cleanup") || !strings.Contains(rendered, "Removed") {
+		t.Fatalf("cleanup text output is missing the removal summary:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "map[removed_sessions:") {
+		t.Fatalf("cleanup text output still dumps the raw map:\n%s", rendered)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #161

`govard audit run` with no flags is the most common invocation, and its default `text` format was a raw `%+v` struct dump on a single line. This PR replaces that path with a compact, verdict-first human renderer shared by every audit subcommand.

### Rationale

- Operators must see the verdict (PASSED / FAILED / CANCELLED) without hunting through fields.
- After a run, the natural next questions are "where is the full report?" and "how do I rerun this session?" — the output now answers both directly ("What next" section).
- A completed-but-failed run used to exit 0; scripts and CI could not observe the outcome. The command now prints the full summary first and then exits non-zero (`AuditRunOutcomeError`). The JSON contract is untouched.
- pterm force-enables color in its `init()`, which would leak ANSI codes into pipes; color is therefore gated on an interactive terminal and honors `NO_COLOR`.

### What changed

- **New** `internal/cmd/audit_output.go`: text renderer for `RunResult`, `SessionManifest`, cleanup payload, and toolchain views; evidence normalizer handles both typed fresh-run evidence and store-decoded generic maps so `run` and `result` render identically.
- `internal/cmd/audit.go`: `writeAuditValue` routes text to the new renderer; `run`/`diff`/`rerun` render the summary before returning the outcome error.
- Findings are capped at ten per PHP version with an overflow note; the persisted provider report keeps the complete list.
- Docs updated: `README.md`, `docs/reference/cli-commands.md` (+ VI), including an example summary block.

### Output before / after

Before: one line — `{SchemaVersion:1 SessionID:... RunID:... Status:failed Jobs:[{ID:lint ... Evidence:map[php_results:[{PHPVersion:8.5 Outcome:failed ...}]]}]}`

After:

```
== Audit run run-0001 / session 20260822T005406Z-14bd9570 ==
  Status:      FAILED
  Scope:       project
  Duration:    4.5s
  Environment: magento2 | nginx | Govard 1.63.0

  Checks
    - lint - failed - 4.5s - provider govard
      PHP 8.5 | failed | 3.9s | cache cold | 12 findings
      - phpcs Squiz.Classes.ClassFileName app/code/Acme/Catalog/Model/Item.php:12: Class name is not camel case

  What next
  Full findings: ~/.govard/audit/<project-id>/sessions/<session-id>/runs/run-0001/report.json
  Re-run:        govard audit rerun --session <session-id>
```

## Test plan

- [x] New `tests/audit_output_test.go` covers: readable pass summary (and no raw struct dump), failed run → non-zero exit + findings + rerun hint rendered, cancelled run → CANCELLED + re-run hint, status lists runs + inspect hint, result re-renders persisted evidence through the generic-map branch, cleanup prints a removal summary instead of a raw map
- [x] All pre-existing audit tests pass unchanged (JSON machine contract intact)
- [x] Manual end-to-end check against the real magelint backend: pass/fail runs, status, piped `cat -v` shows zero escape codes
- [x] `gofmt -s -l .` clean on changed files
- [x] Full `make test` (lint + fmt-check + vet + unit + integration) passes