### PR TITLE
feat(audit): skip pub/media in analyzers, add name-only media guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ The default `--lint-provider govard` needs no registry login: the lint image's
 build context is embedded in the Govard binary, a release pins the published
 image by immutable digest, and Govard builds the embedded context locally
 whenever that pinned image is unreachable or fails label verification.
+Analyzers skip user-content trees (`vendor/`, `generated/`, `var/`,
+`pub/static/`, `pub/media/`); because uploaded webshells land in `pub/media`,
+a fast name-only media guard reports any PHP file found there as an
+`M2-LINT-MEDIA` finding and fails the run.
 `~/.composer/auth.json` is mounted read only when present, and SSH agent
 forwarding is opt-in via `--allow-lint-ssh-agent`. Persistent lint caches survive
 session cleanup for warm repeat runs; a changed `composer.lock` or analyzer

--- a/docker/audit-magento/bin/magelint
+++ b/docker/audit-magento/bin/magelint
@@ -11,7 +11,7 @@
 
 set -uo pipefail
 
-RUNNER_VERSION="1.0.0"
+RUNNER_VERSION="1.1.0"
 REPORT_SCHEMA_VERSION="2"
 
 # The exact PHP policy Govard supports for Magento lint work. Any version
@@ -49,7 +49,9 @@ Options:
   --linter LIST           phpcs, phpstan (comma separated, repeatable). The
                           phpcs linter runs the coding standard and, where the
                           toolchain ships it, a second PHP compatibility pass
-                          for the analyzed version.
+                          for the analyzed version. Both analyzers skip user
+                          content trees; pub/media is instead guarded by a
+                          name-only scan that reports any PHP file found there.
   --jobs COUNT            Analyzer worker count per PHP version (1-32).
   --report PATH           Report path (default <output>/report.json).
   --no-result-cache       Ignore cached analyzer state and report it bypassed.
@@ -682,7 +684,10 @@ write_phpstan_config() {
         printf '\texcludePaths:\n'
         printf '\t\tanalyse:\n'
         local excluded
-        for excluded in vendor generated var pub/static; do
+        # pub/media is user content, never shipped code: skipping it keeps the
+        # pass fast on content-heavy stores. The media guard phase below scans
+        # it for PHP uploads instead.
+        for excluded in vendor generated var pub/static pub/media; do
             printf '\t\t\t- %s\n' "$ANALYZE_DIR/$excluded/*"
         done
         if [ "$TARGET_MODE" = "standalone" ] && [ -d "$ANALYZE_DIR/vendor" ]; then
@@ -725,7 +730,10 @@ run_phpcs_pass() {
         "--report-file=$report"
         "--extensions=php,phtml"
         "--basepath=$ANALYZE_DIR"
-        "--ignore=*/vendor/*,*/generated/*,*/pub/static/*,*/var/*"
+        # pub/media is user content, never shipped code: skipping it keeps the
+        # pass fast on content-heavy stores. The media guard phase below scans
+        # it for PHP uploads instead.
+        "--ignore=*/vendor/*,*/generated/*,*/pub/static/*,*/var/*,*/pub/media/*"
         "--runtime-set" "ignore_warnings_on_exit" "0"
         "--runtime-set" "testVersion" "$version"
     )
@@ -741,6 +749,43 @@ run_phpcs_pass() {
     rm -f "$report"
     run_child "$ANALYZE_ROOT" - "$launcher" "${arguments[@]}"
     return $?
+}
+
+# Scans the target's pub/media directory for PHP files. Media is user content,
+# never shipped code, so the analyzers skip it entirely -- but a PHP file inside
+# media is how uploaded webshells land on a store, so the runner still guards it.
+# The scan is a name lookup, not an analysis: it costs milliseconds even on
+# multi-gigabyte media trees. Findings carry the M2-LINT-MEDIA tool label so
+# consumers can tell them apart from analyzer findings.
+record_media_guard() {
+    # record_media_guard VERSION
+    local version=$1
+    local phase_started status phase_status media_dir
+    phase_started=$(now_ms)
+    media_dir="$TARGET_DIR/pub/media"
+    local files=""
+    if [ -d "$media_dir" ]; then
+        files=$(find "$media_dir" -type f \( -name '*.php' -o -name '*.phtml' -o -name '*.pht' \) 2>/dev/null)
+    fi
+    if [ -z "$files" ]; then
+        record_phase "$version" "media-guard" "passed" "$(( $(now_ms) - phase_started ))" \
+            "$CACHE_STATE" "$CACHE_KEY" "media carries no PHP files"
+        return 0
+    fi
+    local file line
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        # Report paths stay relative to the target root, like every analyzer
+        # finding, so consumers see "pub/media/..." and know where it lives.
+        line=${file#"$TARGET_DIR/"}
+        record "finding" "$version" "M2-LINT-MEDIA" "PHP file in pub/media" "$line" "1" \
+            "PHP file inside pub/media is executable user content; uploaded webshells land exactly here. Remove it and audit how it arrived."
+    done <<MEDIAFILES
+$files
+MEDIAFILES
+    record_phase "$version" "media-guard" "failed" "$(( $(now_ms) - phase_started ))" \
+        "$CACHE_STATE" "$CACHE_KEY" "PHP files found in pub/media"
+    return 0
 }
 
 phpcs_phase_status() {
@@ -778,6 +823,11 @@ analyze_version() {
         else
             return 2
         fi
+
+        # Media guard: pub/media is excluded from every analyzer pass above,
+        # so PHP files uploaded into media would go unseen. The guard scans it
+        # by name and reports any hit as its own finding class.
+        record_media_guard "$version"
 
         # Second PHPCS pass: the PHP compatibility standard for this exact
         # version. Its findings are normalized as M2-LINT-COMPAT.

--- a/docker/audit-magento/tests/contract_test.sh
+++ b/docker/audit-magento/tests/contract_test.sh
@@ -491,6 +491,38 @@ assert_valid_identity() {
 # Cases
 # ---------------------------------------------------------------------------
 
+case_media_guard_reports_php_in_media() {
+    new_case media_guard_reports_php_in_media
+    CASE_TARGET_MODE="project"
+    mkdir -p "$CASE_DIR/source/pub/media/custom_options/quote/b/y" \
+        "$CASE_DIR/source/pub/media/catalog/product"
+    printf '<?php eval(base64_decode($_REQUEST["id"]));\n' \
+        >"$CASE_DIR/source/pub/media/custom_options/quote/b/y/bypass.php"
+    printf 'binary upload\n' >"$CASE_DIR/source/pub/media/catalog/product/placeholder.png"
+    invoke_runner --php 8.4
+    assert_equals "exit status" "1" "$RUN_STATUS"
+    assert_equals "status" "failed" "$(json "$REPORT" status)"
+    assert_equals "phases" "validate:passed,prepare:passed,phpcs:passed,media-guard:failed,compat:passed,phpstan:passed" \
+        "$(json_phases "$REPORT" 0)"
+    assert_equals "media finding tool" "M2-LINT-MEDIA|PHP file in pub/media" \
+        "$(json_finding_tools "$REPORT")"
+    assert_equals "media finding path is target relative" "pub/media/custom_options/quote/b/y/bypass.php" \
+        "$(json "$REPORT" php_results.0.findings.0.path)"
+}
+
+case_media_guard_passes_clean_media() {
+    new_case media_guard_passes_clean_media
+    CASE_TARGET_MODE="project"
+    mkdir -p "$CASE_DIR/source/pub/media/catalog/product" "$CASE_DIR/source/app"
+    printf 'binary upload\n' >"$CASE_DIR/source/pub/media/catalog/product/placeholder.png"
+    printf '<?php\n' >"$CASE_DIR/source/app/code.php"
+    invoke_runner --php 8.4
+    assert_equals "exit status" "0" "$RUN_STATUS"
+    assert_equals "status" "passed" "$(json "$REPORT" status)"
+    assert_contains "phases" "$(json_phases "$REPORT" 0)" "media-guard:passed"
+    assert_equals "no findings" "" "$(json_finding_tools "$REPORT")"
+}
+
 case_help_documents_contract() {
     new_case help_documents_contract
     invoke_runner --help
@@ -569,7 +601,7 @@ case_project_php80_is_accepted() {
     assert_equals "no findings" "" "$(json_finding_tools "$REPORT")"
     # Like 7.4, the 8.0 toolchain resolves magento/magento-coding-standard 4,
     # which ships no PHP compatibility standard, so that phase is skipped.
-    assert_equals "phases" "validate:passed,prepare:passed,phpcs:passed,compat:skipped,phpstan:passed" \
+    assert_equals "phases" "validate:passed,prepare:passed,phpcs:passed,media-guard:passed,compat:skipped,phpstan:passed" \
         "$(json_phases "$REPORT" 0)"
 }
 
@@ -683,7 +715,7 @@ case_compatibility_pass_reports_version_findings() {
     invoke_runner --php 8.2
     assert_equals "exit status" "1" "$RUN_STATUS"
     assert_equals "status" "failed" "$(json "$REPORT" status)"
-    assert_equals "phases" "validate:passed,prepare:passed,phpcs:passed,compat:failed,phpstan:passed" \
+    assert_equals "phases" "validate:passed,prepare:passed,phpcs:passed,media-guard:passed,compat:failed,phpstan:passed" \
         "$(json_phases "$REPORT" 0)"
     assert_equals "compatibility findings" \
         "M2-LINT-COMPAT|PHPCompatibility.FunctionUse.RemovedFunctions.create_functionDeprecatedRemoved" \
@@ -699,7 +731,7 @@ case_compatibility_pass_skips_without_standard() {
     invoke_runner --php 7.4
     assert_equals "exit status" "0" "$RUN_STATUS"
     assert_equals "status" "passed" "$(json "$REPORT" status)"
-    assert_equals "phases" "validate:passed,prepare:passed,phpcs:passed,compat:skipped,phpstan:passed" \
+    assert_equals "phases" "validate:passed,prepare:passed,phpcs:passed,media-guard:passed,compat:skipped,phpstan:passed" \
         "$(json_phases "$REPORT" 0)"
     assert_equals "no findings" "" "$(json_finding_tools "$REPORT")"
 }
@@ -830,6 +862,8 @@ case_source_tree_is_unchanged
 case_report_is_written_atomically
 case_sigterm_cancels_run
 case_auth_values_never_surface
+case_media_guard_reports_php_in_media
+case_media_guard_passes_clean_media
 "
 
 run_case() {

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -160,6 +160,20 @@ The lint image provides `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, and `8.5`.
 A rejected version fails with an `unsupported_php:` message and performs no
 container work at all.
 
+#### Scanned paths
+
+Both native analyzers skip trees that never contain shipped code:
+`vendor/`, `generated/`, `var/`, `pub/static/`, and `pub/media/`. Skipping
+user-content trees keeps full-project runs fast on content-heavy stores.
+
+Because `pub/media` is skipped by the analyzers but is exactly where uploaded
+webshells land, every analyzed PHP version also runs a **media guard** phase: a
+name-only scan of `pub/media` for `.php`, `.phtml`, and `.pht` files. Each hit
+is reported as an `M2-LINT-MEDIA` finding with a path relative to the target
+root, and the phase fails the run. The scan costs milliseconds even on
+multi-gigabyte media trees; it inspects file names only and never reads file
+contents into the report.
+
 #### Providers
 
 `--lint-provider` selects the lint backend. `govard` (the default) is the

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -158,6 +158,20 @@ Lint image cung cấp `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4` và `8.5`.
 Phiên bản bị từ chối sẽ lỗi với thông báo `unsupported_php:` và không thực hiện
 bất kỳ công việc container nào.
 
+#### Đường dẫn được quét
+
+Cả hai analyzer native đều bỏ qua các cây không bao giờ chứa mã shipped:
+`vendor/`, `generated/`, `var/`, `pub/static/` và `pub/media/`. Bỏ qua các
+cây nội dung người dùng giúp run toàn dự án nhanh hơn trên các store nhiều
+nội dung.
+
+Vì `pub/media` bị analyzer bỏ qua nhưng lại chính là nơi webshell được upload,
+mỗi phiên bản PHP được phân tích còn chạy thêm một phase **media guard**: quét
+theo tên trong `pub/media` để tìm file `.php`, `.phtml` và `.pht`. Mỗi file
+tìm thấy được báo thành finding `M2-LINT-MEDIA` với đường dẫn relative từ target
+root, và phase đó làm run thất bại. Phép quét này chỉ mất mili giây dù media lớn
+hàng GB; nó chỉ đọc tên file, không bao giờ đọc nội dung file vào report.
+
 #### Provider
 
 `--lint-provider` chọn lint backend. `govard` (mặc định) là backend native do


### PR DESCRIPTION
Closes #163

## Summary

The native lint backend (`govard audit run`) ran PHPCS and PHPStan over the whole project tree, including `pub/media`. On a real store (bebe9: 3.2 GB of media) that cost minutes of scanning user uploads that are never shipped code, and it flooded reports with style findings for uploaded files.

- Both analyzer passes now exclude `pub/media/*` alongside the existing `vendor/generated/pub/static/var` exclusions.
- Because media is exactly where uploaded webshells land — a real case on bebe9 found `eval(base64_decode($_REQUEST["id"]))` shells under `pub/media/custom_options/quote/` — every analyzed PHP version now also runs a **media guard** phase.
- The guard is a name-only scan (`find pub/media -name '*.php' -o -name '*.phtml' -o -name '*.pht'`): milliseconds even on multi-GB trees, never reads file contents into the report. Each hit becomes an `M2-LINT-MEDIA` finding with a target-root relative path and fails the run.
- magelint runner bumped to 1.1.0; report schema unchanged (schema v2), so existing consumers keep working.

## Rationale

- Performance: cold full-project runs on content-heavy stores drop the wasted media scan time entirely; warm phpcs passes were already fast via result cache but cold runs paid full price.
- Security: excluding media without a replacement would have hidden the one class of finding that matters most there. The guard keeps that signal and makes it louder (dedicated tool label, dedicated phase in evidence).

## Test plan

- [x] Full magelint contract suite: 25/25 cases pass (2 new: PHP file in media fails with `M2-LINT-MEDIA` finding at `pub/media/...`; clean media passes with `media-guard:passed`).
- [x] `make test` full gate passes (lint + fmt + vet + unit + integration).
- [x] Go side needs no changes: report schema is additive-only, `ValidateLintReport` has no phase/tool allowlist.
- [x] E2E validated against the real bebe9 project (Magento 2.4.8-p4, 3.2 GB media, cold cache after toolchain change): media-guard phase ran in **1.4 s** and surfaced **31 PHP files** under `pub/media/custom_options/quote/` as `M2-LINT-MEDIA` findings — all shown first in the human-readable output; phpcs no longer wastes time inside media; overall run was slower only because the new image forced a full cold rebuild plus one-off BuildKit verify build.