### PR TITLE
feat(audit): complete Govard-native Magento profiler provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,25 @@ forwarding is opt-in via `--allow-lint-ssh-agent`. Persistent lint caches surviv
 session cleanup for warm repeat runs; a changed `composer.lock` or analyzer
 ruleset invalidates cached analysis by itself, and `--no-lint-result-cache`
 forces it for one run. `diff` currently records its base-ref intent but still
-analyzes the full target (`effective_scope: project`). Profiler and browser jobs
-will arrive in later audit phases.
+analyzes the full target (`effective_scope: project`).
+
+Magento 2 and Mage-OS projects can capture the stock Magento CSV profiler
+without installing a module or editing `app/etc/env.php`:
+
+```bash
+govard env up
+govard audit run --checks profiler --url 'https://shop.test/category.html?product_list_limit=48'
+```
+
+Govard clears the runtime CSV, enables `MAGE_PROFILER=csvfile` through a
+temporary web-server include, requests the exact URL with a bounded HTTP
+client, stores `profiler/profile.csv` under the run's artifact directory, then
+removes the include and runtime CSV. Nginx uses its PHP FastCGI location;
+Apache and hybrid use Apache (`hybrid` never mutates nginx). The URL is frozen
+in run evidence and reused by `audit rerun`. Profiler captures require a whole
+Govard project target, and `govard env up` must have rendered the active custom
+config mount after installing this Govard version. Browser Core Web Vitals will
+arrive in a later audit phase.
 
 Common root shortcuts are also available for day-to-day lifecycle work:
 

--- a/docker/nginx/etc/templates/magento2.conf
+++ b/docker/nginx/etc/templates/magento2.conf
@@ -100,6 +100,9 @@ server {
         fastcgi_param  HTTPS 'on';
         fastcgi_param  MAGE_RUN_CODE $mage_run_code;
         fastcgi_param  MAGE_RUN_TYPE $mage_run_type;
+        # Runtime audit snippets live below a nested directory so the generic
+        # server-level custom include never consumes FastCGI params first.
+        include /etc/nginx/custom/audit-profiler/*.conf;
     }
 
     gzip on;

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -54,12 +54,14 @@ This is the canonical CLI reference for Govard.
 
 ### `govard audit`
 
-Run framework-declared, persistent project audits. Lint is the only check
-implemented so far; later phases will add profiler and browser jobs without
-changing session semantics.
+Run framework-declared, persistent project audits. `lint` runs static analysis;
+Magento 2 and Mage-OS also declare a Govard-native stock CSV `profiler` check.
+Later phases will add browser jobs without changing session semantics.
 
 ```bash
 govard audit run
+govard audit run --checks profiler --url 'https://shop.test/category.html?product_list_limit=48'
+govard audit run --checks lint,profiler --url 'https://shop.test/'
 govard audit diff --base origin/master
 govard audit rerun --session 20260816T010203Z-a1b2c3d4
 govard audit status --session 20260816T010203Z-a1b2c3d4
@@ -80,6 +82,23 @@ it), so piped or redirected output stays free of escape codes.
 backend logs remain out of that stream. Only `text` and `json` formats are
 accepted, and `--lint-jobs` must be between 1 and
 the number of PHP versions declared by the framework.
+
+`profiler` requires an explicit absolute HTTP(S) `--url` on the first run and a
+whole Govard project target (standalone modules and module-only targets are
+rejected before runtime mutation). The exact URL is persisted in the run and
+reused by `audit rerun`, so before/after runs capture the same page. Govard uses
+Magento's stock `MAGE_PROFILER=csvfile`; it does not install a Magento module,
+depend on a third-party repository/image, or edit `app/etc/env.php`.
+
+Run `govard env up` with the current Govard version before the first capture so
+the generated Compose stack mounts the project-owned custom configuration
+directory. During the leased capture Govard atomically creates one uniquely
+named include, reloads the active server, performs a bounded HTTP GET, collects
+`var/log/profiler.csv` through the PHP container, and restores both the include
+and runtime CSV. Nginx receives the temporary FastCGI parameter inside
+Magento's PHP location. Apache mode uses the `web` service; hybrid configures
+and reloads its `apache` service rather than nginx. The collected CSV is stored
+under `runs/<run-id>/artifacts/profiler/profile.csv` with a SHA-256 digest.
 
 Example `govard audit run` summary:
 
@@ -106,6 +125,11 @@ and writes its result atomically to
 alongside the provider's own `report.json`. `rerun`, `status`, and `result`
 require the exact `--session` value (and `result` also requires `--run`); Govard
 never chooses a latest session implicitly.
+
+A `rerun` without an explicit `--checks` repeats the check selection of the
+latest run in that session — including its persisted profiler URL — instead of
+falling back to the lint default. Passing `--checks` reruns exactly what was
+requested; either form reconstructs only the backends that selection needs.
 
 #### Target modes
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -296,7 +296,7 @@ Remote fields support `op://...` references resolved through the 1Password CLI.
 | `.govard/commands/*` | Custom commands exposed via `govard custom` |
 | `.govard/hooks/*` | Scripts referenced by `hooks.*.run` |
 | `.govard/nginx/custom/*.conf` | Extra nginx directives included inside the rendered `server {}` block (nginx web server only) |
-| `.govard/apache/custom/*.conf` | Extra Apache directives included inside the rendered `<VirtualHost>` block (Apache web server only) |
+| `.govard/apache/custom/*.conf` | Extra Apache directives included inside the rendered `<VirtualHost>` block (Apache and hybrid web-server modes) |
 
 **Lifecycle hook events:**
 
@@ -309,6 +309,15 @@ Remote fields support `op://...` references resolved through the 1Password CLI.
 Govard fingerprints `.govard/docker-compose.override.yml`, `.govard/nginx/custom/`, and `.govard/apache/custom/`. If any of them change, the next `env up` auto-re-renders the compose output.
 
 When overriding services, prefer additive merges (extra environment variables, labels, ports). Replacing full lists like `services.web.volumes` can discard required Govard-managed mounts. `.govard/nginx/custom/` and `.govard/apache/custom/` exist precisely so you don't have to replace the whole web server config just to add a directive.
+
+Frameworks that declare a runtime audit profiler cause `govard env up` to
+prepare and mount the active custom directory even when the project has no
+user-authored snippets. `govard audit run --checks profiler` uses a nested
+`.govard/nginx/custom/audit-profiler/` include inside Magento's PHP FastCGI
+location for nginx, or a temporary `.govard/apache/custom/` vhost include for
+Apache and hybrid. Files are uniquely named per audit run and removed during
+lease-protected cleanup; no profiler setting is written to `.govard.yml` or
+Magento's `app/etc/env.php`.
 :::
 
 ### Audit Lint Providers

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -54,12 +54,15 @@ description: Tài liệu đầy đủ về các lệnh CLI, alias và shortcut c
 
 ### `govard audit`
 
-Chạy audit dự án có session được lưu bền vững. Hiện chỉ có check lint được triển
-khai; các job profiler và browser sẽ được bổ sung ở các giai đoạn sau mà không
-đổi semantics session.
+Chạy audit dự án có session được lưu bền vững. `lint` chạy phân tích tĩnh;
+Magento 2 và Mage-OS còn khai báo thêm check `profiler` CSV stock do Govard tự
+điều phối. Các giai đoạn sau sẽ bổ sung browser job mà không đổi semantics
+session.
 
 ```bash
 govard audit run
+govard audit run --checks profiler --url 'https://shop.test/category.html?product_list_limit=48'
+govard audit run --checks lint,profiler --url 'https://shop.test/'
 govard audit diff --base origin/master
 govard audit rerun --session 20260816T010203Z-a1b2c3d4
 govard audit status --session 20260816T010203Z-a1b2c3d4
@@ -79,6 +82,24 @@ hẳn), nên output khi pipe hay redirect không dính escape code.
 `--format json` chỉ ghi một JSON object không có terminal decoration ra stdout;
 diagnostic và log backend nằm ngoài stream đó. Chỉ chấp nhận `text`/`json`;
 `--lint-jobs` phải từ 1 đến số PHP version được framework khai báo.
+
+`profiler` yêu cầu `--url` tuyệt đối HTTP(S) tường minh ở run đầu tiên và target
+phải là toàn bộ Govard project (standalone module lẫn module-only target đều bị
+từ chối trước khi có bất kỳ thay đổi runtime nào). URL chính xác được lưu trong
+run và được `audit rerun` tái sử dụng, nên các run before/after bắt cùng một
+trang. Govard dùng `MAGE_PROFILER=csvfile` stock của Magento; không cài Magento
+module, không phụ thuộc repository/image bên thứ ba, và không sửa
+`app/etc/env.php`.
+
+Chạy `govard env up` với phiên bản Govard hiện tại trước lần capture đầu tiên
+để Compose stack đã render mount thư mục cấu hình custom thuộc sở hữu project.
+Trong quá trình capture có lease bảo vệ, Govard tạo nguyên tử một include với
+tên duy nhất, reload server đang active, thực hiện một HTTP GET có giới hạn,
+thu `var/log/profiler.csv` qua PHP container, rồi khôi phục lại cả include lẫn
+CSV runtime. Nginx nhận tham số FastCGI tạm thời bên trong PHP location của
+Magento. Chế độ Apache dùng dịch vụ `web`; hybrid cấu hình và reload dịch vụ
+`apache` của nó thay vì nginx. CSV thu được được lưu tại
+`runs/<run-id>/artifacts/profiler/profile.csv` kèm digest SHA-256.
 
 Ví dụ bản tóm tắt của `govard audit run`:
 
@@ -106,6 +127,11 @@ atomically tại
 kèm `report.json` của chính provider. `rerun`, `status`, `result` luôn cần đúng
 `--session` (và `result` cần thêm `--run`); Govard không tự chọn session mới
 nhất.
+
+`rerun` không kèm `--checks` sẽ lặp lại đúng bộ check của lần chạy gần nhất
+trong session đó — kể cả URL profiler đã lưu — thay vì rơi về mặc định chỉ lint.
+Truyền `--checks` thì chạy lại đúng những gì được yêu cầu; cả hai dạng chỉ dựng
+lại những backend mà bộ chọn đó cần.
 
 #### Target mode
 

--- a/docs/vi/reference/configuration.md
+++ b/docs/vi/reference/configuration.md
@@ -293,6 +293,15 @@ Các trường thông tin remote hỗ trợ các tham chiếu `op://...` đượ
 Govard tạo mã hash vân tay cho `.govard/docker-compose.override.yml`, `.govard/nginx/custom/`, và `.govard/apache/custom/`. Nếu bất kỳ thứ nào trong số này thay đổi, lệnh `env up` tiếp theo sẽ tự động re-render cấu trúc compose.
 
 Khi ghi đè dịch vụ, nên ưu tiên các bổ sung nhỏ (thêm biến môi trường, label, port). Việc thay thế hoàn toàn danh sách như `services.web.volumes` có thể làm mất các mount quan trọng do Govard quản lý. `.govard/nginx/custom/` và `.govard/apache/custom/` tồn tại chính xác để bạn không cần thay thế toàn bộ cấu hình web server chỉ để thêm một directive.
+
+Framework khai báo runtime audit profiler khiến `govard env up` chuẩn bị và
+mount thư mục custom đang active ngay cả khi project không có snippet nào do
+người dùng viết. `govard audit run --checks profiler` dùng include lồng nhau
+`.govard/nginx/custom/audit-profiler/` bên trong PHP FastCGI location của
+Magento cho nginx, hoặc include vhost tạm thời trong `.govard/apache/custom/`
+cho Apache và hybrid. File được đặt tên duy nhất theo từng audit run và bị xóa
+trong quá trình cleanup có lease bảo vệ; không có thiết lập profiler nào được
+ghi vào `.govard.yml` hay `app/etc/env.php` của Magento.
 :::
 
 ### Audit Lint Providers

--- a/internal/audit/profiler.go
+++ b/internal/audit/profiler.go
@@ -1,0 +1,142 @@
+package audit
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"govard/internal/frameworks/types"
+)
+
+const (
+	profilerLeaseResource         = "diagnostics"
+	profilerArtifactRelativePath  = "profiler/profile.csv"
+	defaultProfilerCleanupTimeout = 10 * time.Second
+)
+
+// ProfilerRequest identifies one runtime profiler capture. The runner creates
+// this value from an immutable audit run; the injected runtime owns only the
+// temporary diagnostic configuration and capture transport.
+type ProfilerRequest struct {
+	ProjectRoot string
+	ProjectID   string
+	SessionID   string
+	RunID       string
+	URL         string
+	Target      types.AuditTarget
+}
+
+// ProfilerRuntime performs the environment-specific profiler lifecycle. Its
+// implementation is deliberately injected: the generic audit runner never
+// mutates web-server configuration or assumes a particular framework runtime.
+type ProfilerRuntime interface {
+	Activate(context.Context, ProfilerRequest) error
+	Capture(context.Context, ProfilerRequest) error
+	Collect(context.Context, ProfilerRequest) ([]byte, error)
+	Restore(context.Context, ProfilerRequest) error
+}
+
+// ValidateProfilerURL rejects anything that cannot be fetched directly by the
+// bounded HTTP client. The URL is never passed through a shell.
+func ValidateProfilerURL(raw string) error {
+	if raw == "" || raw != strings.TrimSpace(raw) {
+		return errors.New("audit profiler requires --url with an absolute http or https URL")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.User != nil || parsed.Fragment != "" {
+		return errors.New("audit profiler requires --url with an absolute http or https URL without credentials or a fragment")
+	}
+	return nil
+}
+
+func (runner *Runner) profilerJob(request ProfilerRequest) JobFunc {
+	return func(ctx context.Context) (evidence map[string]any, runErr error) {
+		evidence = map[string]any{"profiler_settings": savedProfilerSettings{URL: request.URL, Target: request.Target}}
+		owner := request.SessionID + ":" + request.RunID
+		if _, err := runner.store.AcquireLease(request.ProjectID, profilerLeaseResource, owner); err != nil {
+			return profilerFailure(evidence, ctx, err)
+		}
+		defer func() {
+			// Restore must still reach the runtime after its capture context is
+			// cancelled, but no cleanup call may block a run forever. A failed
+			// restore leaves the lease in place to prevent reuse of a tainted
+			// diagnostic state until an operator has recovered it.
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), runner.profilerCleanupTimeout)
+			defer cancel()
+			if err := runner.profilerRuntime.Restore(cleanupCtx, request); err != nil {
+				profilerCleanupFailure(evidence, &runErr, wrapProfilerCleanupError("restore profiler", err))
+				return
+			}
+			if err := runner.store.ReleaseLease(request.ProjectID, profilerLeaseResource, owner); err != nil {
+				profilerCleanupFailure(evidence, &runErr, wrapProfilerCleanupError("release profiler lease", err))
+			}
+		}()
+
+		if err := runner.profilerRuntime.Activate(ctx, request); err != nil {
+			return profilerFailure(evidence, ctx, err)
+		}
+		if err := runner.profilerRuntime.Capture(ctx, request); err != nil {
+			return profilerFailure(evidence, ctx, err)
+		}
+		csv, err := runner.profilerRuntime.Collect(ctx, request)
+		if err != nil {
+			return profilerFailure(evidence, ctx, err)
+		}
+		artifactPath, err := runner.store.RunArtifactPath(request.ProjectID, request.SessionID, request.RunID, profilerArtifactRelativePath)
+		if err != nil {
+			return profilerFailure(evidence, ctx, err)
+		}
+		if err := os.WriteFile(artifactPath, csv, 0o600); err != nil {
+			return profilerFailure(evidence, ctx, fmt.Errorf("write profiler artifact: %w", err))
+		}
+		sum := sha256.Sum256(csv)
+		evidence["artifact"] = Artifact{
+			Kind:   "profiler-csv",
+			Path:   artifactPath,
+			SHA256: hex.EncodeToString(sum[:]),
+		}
+		return evidence, nil
+	}
+}
+
+func profilerCleanupFailure(evidence map[string]any, runErr *error, cleanupErr error) {
+	if *runErr == nil {
+		*runErr = cleanupErr
+	} else {
+		*runErr = errors.Join(*runErr, cleanupErr)
+	}
+	evidence["infrastructure_error"] = (*runErr).Error()
+}
+
+func profilerFailure(evidence map[string]any, ctx context.Context, err error) (map[string]any, error) {
+	if ctx == nil || ctx.Err() == nil {
+		evidence["infrastructure_error"] = err.Error()
+	}
+	return evidence, err
+}
+
+func wrapProfilerCleanupError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}
+
+func profilerArtifacts(jobs []JobResult) []Artifact {
+	for _, job := range jobs {
+		if job.ID != "profiler" {
+			continue
+		}
+		artifact, ok := job.Evidence["artifact"].(Artifact)
+		if ok {
+			return []Artifact{artifact}
+		}
+	}
+	return nil
+}

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -27,6 +27,7 @@ type RunRequest struct {
 	Source              SourceFingerprint
 	LintProfile         types.AuditLintProfile
 	Target              types.AuditTarget
+	ProfilerURL         string
 	SelectedPHPVersions []string
 	MatrixComplete      bool
 	// BypassResultCache asks the lint backend to ignore reusable analyzer
@@ -35,8 +36,10 @@ type RunRequest struct {
 }
 
 type RunnerOptions struct {
-	Store       *Store
-	LintBackend LintBackend
+	Store                  *Store
+	LintBackend            LintBackend
+	ProfilerRuntime        ProfilerRuntime
+	ProfilerCleanupTimeout time.Duration
 	// LintCacheRoot is the reusable lint cache root (see
 	// DefaultLintCacheRoot). When empty, the cache stays beside the persisted
 	// sessions of the audited project.
@@ -47,11 +50,13 @@ type RunnerOptions struct {
 
 // Runner coordinates persisted audit sessions without knowing any framework.
 type Runner struct {
-	store         *Store
-	lintBackend   LintBackend
-	lintCacheRoot string
-	resources     Resources
-	now           func() time.Time
+	store                  *Store
+	lintBackend            LintBackend
+	profilerRuntime        ProfilerRuntime
+	profilerCleanupTimeout time.Duration
+	lintCacheRoot          string
+	resources              Resources
+	now                    func() time.Time
 }
 
 func NewRunner(options RunnerOptions) *Runner {
@@ -66,18 +71,22 @@ func NewRunner(options RunnerOptions) *Runner {
 	if resources.MemoryMB == 0 {
 		resources.MemoryMB = 2048
 	}
-	return &Runner{store: options.Store, lintBackend: options.LintBackend, lintCacheRoot: options.LintCacheRoot, resources: resources, now: now}
+	profilerCleanupTimeout := options.ProfilerCleanupTimeout
+	if profilerCleanupTimeout <= 0 {
+		profilerCleanupTimeout = defaultProfilerCleanupTimeout
+	}
+	return &Runner{store: options.Store, lintBackend: options.LintBackend, profilerRuntime: options.ProfilerRuntime, profilerCleanupTimeout: profilerCleanupTimeout, lintCacheRoot: options.LintCacheRoot, resources: resources, now: now}
 }
 
 func (runner *Runner) Run(ctx context.Context, request RunRequest) (RunResult, error) {
-	if err := runner.validateRequest(request); err != nil {
-		return RunResult{}, err
-	}
-	checks, err := normalizeChecks(request.Checks)
+	checks, err := NormalizeChecks(request.Checks)
 	if err != nil {
 		return RunResult{}, err
 	}
 	request.Checks = checks
+	if err := runner.validateRequest(request); err != nil {
+		return RunResult{}, err
+	}
 	manifest, err := runner.store.CreateSession(SessionManifest{
 		SchemaVersion: SchemaVersion,
 		ProjectID:     request.ProjectID,
@@ -95,8 +104,9 @@ func (runner *Runner) Run(ctx context.Context, request RunRequest) (RunResult, e
 }
 
 // Rerun always requires a caller-selected session; it never guesses a latest
-// run. Scope, base ref, project root, environment, source and lint policy are
-// reloaded from the persisted session/previous run rather than caller input.
+// run. Scope, base ref, project root, environment, source, lint policy, and —
+// when the caller passes no checks — the check selection are reloaded from the
+// persisted session/previous run rather than caller input.
 func (runner *Runner) Rerun(ctx context.Context, sessionID, projectID string, checks []string) (RunResult, error) {
 	if strings.TrimSpace(sessionID) == "" {
 		return RunResult{}, errors.New("audit rerun requires an explicit session ID")
@@ -114,17 +124,37 @@ func (runner *Runner) Rerun(ctx context.Context, sessionID, projectID string, ch
 	if len(manifest.Runs) == 0 {
 		return RunResult{}, fmt.Errorf("audit session %q has no prior run to rerun", sessionID)
 	}
-	checks, err = normalizeChecks(checks)
+	// An omitted --checks repeats the latest run's selection so a rerun of a
+	// profiler-only session does not silently demand lint settings it never had.
+	if len(checks) == 0 {
+		checks, err = runner.latestRunChecks(projectID, sessionID, manifest.Runs)
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
+	checks, err = NormalizeChecks(checks)
 	if err != nil {
 		return RunResult{}, err
 	}
-	previous, err := runner.store.ReadResult(projectID, sessionID, manifest.Runs[len(manifest.Runs)-1].RunID)
-	if err != nil {
-		return RunResult{}, err
+	settings := savedLintSettings{}
+	target := types.AuditTarget{}
+	requestURL := ""
+	if includesCheck(checks, "lint") {
+		settings, err = runner.latestLintSettings(projectID, sessionID, manifest.Runs)
+		if err != nil {
+			return RunResult{}, err
+		}
+		target = savedLintTarget(settings.Target, manifest)
 	}
-	settings, err := persistedLintSettings(previous)
-	if err != nil {
-		return RunResult{}, err
+	if includesCheck(checks, "profiler") {
+		profilerSettings, err := runner.latestProfilerSettings(projectID, sessionID, manifest.Runs)
+		if err != nil {
+			return RunResult{}, err
+		}
+		if target == (types.AuditTarget{}) {
+			target = profilerSettings.Target
+		}
+		requestURL = profilerSettings.URL
 	}
 	return runner.runInSession(ctx, manifest, RunRequest{
 		ProjectRoot:         manifest.ProjectRoot,
@@ -136,10 +166,50 @@ func (runner *Runner) Rerun(ctx context.Context, sessionID, projectID string, ch
 		Environment:         manifest.Environment,
 		Source:              manifest.Source,
 		LintProfile:         settings.Profile,
-		Target:              savedLintTarget(settings.Target, manifest),
+		Target:              target,
+		ProfilerURL:         requestURL,
 		SelectedPHPVersions: settings.SelectedPHPVersions,
 		MatrixComplete:      settings.MatrixComplete,
 	})
+}
+
+// LatestRunChecks reports the check selection persisted in the newest run of
+// an explicit session. The rerun command uses it to construct only the
+// backends that selection actually needs before starting a rerun.
+func (runner *Runner) LatestRunChecks(_ context.Context, projectID, sessionID string) ([]string, error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return nil, errors.New("audit session checks lookup requires an explicit session ID")
+	}
+	if runner == nil || runner.store == nil {
+		return nil, errors.New("audit runner store is not configured")
+	}
+	manifest, err := runner.store.ReadSession(projectID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if len(manifest.Runs) == 0 {
+		return nil, fmt.Errorf("audit session %q has no prior run to rerun", sessionID)
+	}
+	return runner.latestRunChecks(projectID, sessionID, manifest.Runs)
+}
+
+func (runner *Runner) latestRunChecks(projectID, sessionID string, runs []RunReference) ([]string, error) {
+	for index := len(runs) - 1; index >= 0; index-- {
+		result, err := runner.store.ReadResult(projectID, sessionID, runs[index].RunID)
+		if err != nil {
+			return nil, err
+		}
+		checks := make([]string, 0, 2)
+		for _, job := range result.Jobs {
+			if job.ID == "lint" || job.ID == "profiler" {
+				checks = append(checks, job.ID)
+			}
+		}
+		if len(checks) > 0 {
+			return checks, nil
+		}
+	}
+	return nil, fmt.Errorf("audit session %q has no run with recognized checks", sessionID)
 }
 
 func (runner *Runner) Status(projectID, sessionID string) (SessionManifest, error) {
@@ -198,6 +268,7 @@ func (runner *Runner) runInSession(ctx context.Context, manifest SessionManifest
 	if err == nil {
 		jobsResult, scheduleErr := NewScheduler(runner.resources).Run(ctx, jobs)
 		result.Jobs = jobsResult
+		result.Artifacts = append(result.Artifacts, profilerArtifacts(jobsResult)...)
 		err = scheduleErr
 		if err == nil {
 			err = infrastructureError(jobsResult)
@@ -222,12 +293,40 @@ func (runner *Runner) jobsFor(request RunRequest, manifest SessionManifest, runI
 	if runner == nil || runner.store == nil {
 		return nil, errors.New("audit runner store is not configured")
 	}
+	jobs := make([]Job, 0, len(request.Checks))
+	for _, check := range request.Checks {
+		switch check {
+		case "lint":
+			lintJob, err := runner.lintJob(request, manifest, runID)
+			if err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, lintJob)
+		case "profiler":
+			if runner.profilerRuntime == nil {
+				return nil, errors.New("audit runner profiler runtime is not configured")
+			}
+			profilerRequest := ProfilerRequest{
+				ProjectRoot: request.ProjectRoot,
+				ProjectID:   manifest.ProjectID,
+				SessionID:   manifest.SessionID,
+				RunID:       runID,
+				URL:         request.ProfilerURL,
+				Target:      request.Target,
+			}
+			jobs = append(jobs, Job{ID: "profiler", Kind: "runtime-profiler", Resources: Resources{CPU: 1, MemoryMB: 256}, Run: runner.profilerJob(profilerRequest)})
+		}
+	}
+	return jobs, nil
+}
+
+func (runner *Runner) lintJob(request RunRequest, manifest SessionManifest, runID string) (Job, error) {
 	if runner.lintBackend == nil {
-		return nil, errors.New("audit runner lint backend is not configured")
+		return Job{}, errors.New("audit runner lint backend is not configured")
 	}
 	sessionPath := runner.store.SessionPath(manifest.ProjectID, manifest.SessionID)
 	if sessionPath == "" {
-		return nil, errors.New("resolve audit session path")
+		return Job{}, errors.New("resolve audit session path")
 	}
 	runDir := filepath.Join(sessionPath, "runs", runID)
 	cacheRoot := runner.lintCacheRoot
@@ -285,7 +384,7 @@ func (runner *Runner) jobsFor(request RunRequest, manifest SessionManifest, runI
 		}
 		return evidence, nil
 	}
-	return []Job{{ID: "lint", Kind: "static-analysis", Resources: Resources{CPU: request.LintJobs, MemoryMB: 2048}, Run: lintJob}}, nil
+	return Job{ID: "lint", Kind: "static-analysis", Resources: Resources{CPU: request.LintJobs, MemoryMB: 2048}, Run: lintJob}, nil
 }
 
 // lintTargetID derives a stable per-target identifier from the canonical
@@ -352,8 +451,19 @@ func (runner *Runner) validateRequest(request RunRequest) error {
 	if runner == nil || runner.store == nil {
 		return errors.New("audit runner store is not configured")
 	}
-	if runner.lintBackend == nil {
+	if includesCheck(request.Checks, "lint") && runner.lintBackend == nil {
 		return errors.New("audit runner lint backend is not configured")
+	}
+	if includesCheck(request.Checks, "profiler") && runner.profilerRuntime == nil {
+		return errors.New("audit runner profiler runtime is not configured")
+	}
+	if includesCheck(request.Checks, "profiler") {
+		if err := ValidateProfilerURL(request.ProfilerURL); err != nil {
+			return err
+		}
+		if request.Target.Mode == types.AuditTargetStandalone {
+			return errors.New("audit profiler does not support standalone targets; run it from a Govard project")
+		}
 	}
 	if strings.TrimSpace(request.ProjectRoot) == "" || strings.TrimSpace(request.ProjectID) == "" {
 		return errors.New("audit project root and project ID are required")
@@ -364,21 +474,34 @@ func (runner *Runner) validateRequest(request RunRequest) error {
 	if request.Scope == ScopeDiff && strings.TrimSpace(request.BaseRef) == "" {
 		return errors.New("diff audit requires a base ref")
 	}
-	if request.LintJobs < 1 {
-		return errors.New("lint jobs must be at least one")
-	}
-	if err := validateLintMatrix(LintRequest{
-		Profile:             request.LintProfile,
-		Target:              request.Target,
-		SelectedPHPVersions: request.SelectedPHPVersions,
-		MatrixComplete:      request.MatrixComplete,
-	}); err != nil {
-		return err
+	if includesCheck(request.Checks, "lint") {
+		if request.LintJobs < 1 {
+			return errors.New("lint jobs must be at least one")
+		}
+		if err := validateLintMatrix(LintRequest{
+			Profile:             request.LintProfile,
+			Target:              request.Target,
+			SelectedPHPVersions: request.SelectedPHPVersions,
+			MatrixComplete:      request.MatrixComplete,
+		}); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func normalizeChecks(checks []string) ([]string, error) {
+func includesCheck(checks []string, candidate string) bool {
+	for _, check := range checks {
+		if check == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeChecks trims, validates, and deduplicates requested audit checks
+// while preserving the caller's first-seen order.
+func NormalizeChecks(checks []string) ([]string, error) {
 	if len(checks) == 0 {
 		return []string{"lint"}, nil
 	}
@@ -386,7 +509,7 @@ func normalizeChecks(checks []string) ([]string, error) {
 	normalized := make([]string, 0, len(checks))
 	for _, check := range checks {
 		check = strings.TrimSpace(check)
-		if check != "lint" {
+		if check != "lint" && check != "profiler" {
 			return nil, fmt.Errorf("audit check %q is not implemented", check)
 		}
 		if !seen[check] {
@@ -425,6 +548,16 @@ type savedLintSettings struct {
 	SelectedPHPVersions []string               `json:"selected_php_versions"`
 	MatrixComplete      bool                   `json:"matrix_complete"`
 }
+
+type savedProfilerSettings struct {
+	URL    string            `json:"url"`
+	Target types.AuditTarget `json:"target"`
+}
+
+var (
+	errNoPersistedLintSettings     = errors.New("audit session has no persisted lint settings")
+	errNoPersistedProfilerSettings = errors.New("audit session has no persisted profiler settings")
+)
 
 type legacySavedLintSettings struct {
 	Profile struct {
@@ -496,5 +629,57 @@ func persistedLintSettings(result RunResult) (savedLintSettings, error) {
 		}
 		return settings, nil
 	}
-	return savedLintSettings{}, errors.New("audit session has no persisted lint settings")
+	return savedLintSettings{}, errNoPersistedLintSettings
+}
+
+func (runner *Runner) latestLintSettings(projectID, sessionID string, runs []RunReference) (savedLintSettings, error) {
+	for index := len(runs) - 1; index >= 0; index-- {
+		result, err := runner.store.ReadResult(projectID, sessionID, runs[index].RunID)
+		if err != nil {
+			return savedLintSettings{}, err
+		}
+		settings, err := persistedLintSettings(result)
+		if errors.Is(err, errNoPersistedLintSettings) {
+			continue
+		}
+		return settings, err
+	}
+	return savedLintSettings{}, errNoPersistedLintSettings
+}
+
+func persistedProfilerSettings(result RunResult) (savedProfilerSettings, error) {
+	for _, job := range result.Jobs {
+		if job.ID != "profiler" {
+			continue
+		}
+		value, ok := job.Evidence["profiler_settings"]
+		if !ok {
+			break
+		}
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return savedProfilerSettings{}, err
+		}
+		var settings savedProfilerSettings
+		if err := json.Unmarshal(raw, &settings); err != nil {
+			return savedProfilerSettings{}, fmt.Errorf("decode saved profiler settings: %w", err)
+		}
+		return settings, nil
+	}
+	return savedProfilerSettings{}, errNoPersistedProfilerSettings
+}
+
+func (runner *Runner) latestProfilerSettings(projectID, sessionID string, runs []RunReference) (savedProfilerSettings, error) {
+	for index := len(runs) - 1; index >= 0; index-- {
+		result, err := runner.store.ReadResult(projectID, sessionID, runs[index].RunID)
+		if err != nil {
+			return savedProfilerSettings{}, err
+		}
+		settings, err := persistedProfilerSettings(result)
+		if errors.Is(err, errNoPersistedProfilerSettings) {
+			continue
+		}
+		return settings, err
+	}
+	return savedProfilerSettings{}, errNoPersistedProfilerSettings
 }

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -5,17 +5,20 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 )
 
 const (
 	manifestFilename = "manifest.json"
 	resultFilename   = "audit-result.json"
+	artifactsDirname = "artifacts"
 )
 
 var validID = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
@@ -27,6 +30,12 @@ type Store struct {
 }
 
 type StoreOption func(*Store)
+
+type LeaseRecord struct {
+	Resource   string    `json:"resource"`
+	Owner      string    `json:"owner"`
+	AcquiredAt time.Time `json:"acquired_at"`
+}
 
 func WithClock(now func() time.Time) StoreOption {
 	return func(store *Store) {
@@ -207,6 +216,90 @@ func (s *Store) SessionPath(projectID, sessionID string) string {
 	return path
 }
 
+func (s *Store) AcquireLease(projectID, resource, owner string) (LeaseRecord, error) {
+	if err := validateID("project", projectID); err != nil {
+		return LeaseRecord{}, err
+	}
+	if err := validateID("lease resource", resource); err != nil {
+		return LeaseRecord{}, err
+	}
+	if strings.TrimSpace(owner) == "" {
+		return LeaseRecord{}, errors.New("audit lease owner is required")
+	}
+
+	record := LeaseRecord{
+		Resource:   resource,
+		Owner:      owner,
+		AcquiredAt: s.now().UTC(),
+	}
+	leasePath := filepath.Join(s.root, projectID, "leases", resource+".json")
+	if err := os.MkdirAll(filepath.Dir(leasePath), 0o700); err != nil {
+		return LeaseRecord{}, fmt.Errorf("create audit leases directory: %w", err)
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return LeaseRecord{}, fmt.Errorf("marshal audit lease: %w", err)
+	}
+	file, err := os.OpenFile(leasePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			existing, readErr := s.readLease(projectID, resource)
+			if readErr != nil {
+				return LeaseRecord{}, readErr
+			}
+			return LeaseRecord{}, fmt.Errorf("audit lease %q is already held by %q", resource, existing.Owner)
+		}
+		return LeaseRecord{}, fmt.Errorf("create audit lease %q: %w", resource, err)
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return LeaseRecord{}, fmt.Errorf("write audit lease %q: %w", resource, err)
+	}
+	if err := file.Close(); err != nil {
+		return LeaseRecord{}, fmt.Errorf("close audit lease %q: %w", resource, err)
+	}
+	return record, nil
+}
+
+func (s *Store) ReleaseLease(projectID, resource, owner string) error {
+	if err := validateID("project", projectID); err != nil {
+		return err
+	}
+	if err := validateID("lease resource", resource); err != nil {
+		return err
+	}
+	if strings.TrimSpace(owner) == "" {
+		return errors.New("audit lease owner is required")
+	}
+	record, err := s.readLease(projectID, resource)
+	if err != nil {
+		return err
+	}
+	if record.Owner != owner {
+		return fmt.Errorf("audit lease %q is owned by %q, not %q", resource, record.Owner, owner)
+	}
+	if err := os.Remove(s.leasePath(projectID, resource)); err != nil {
+		return fmt.Errorf("remove audit lease %q: %w", resource, err)
+	}
+	return nil
+}
+
+func (s *Store) RunArtifactPath(projectID, sessionID, runID, relativePath string) (string, error) {
+	resultPath, err := s.resultPath(projectID, sessionID, runID)
+	if err != nil {
+		return "", err
+	}
+	cleaned, err := cleanArtifactRelativePath(relativePath)
+	if err != nil {
+		return "", err
+	}
+	artifactPath := filepath.Join(filepath.Dir(resultPath), artifactsDirname, filepath.FromSlash(cleaned))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o700); err != nil {
+		return "", fmt.Errorf("create audit artifact directory: %w", err)
+	}
+	return artifactPath, nil
+}
+
 func (s *Store) CleanupOlderThan(projectID string, cutoff time.Time) ([]string, error) {
 	if err := validateID("project", projectID); err != nil {
 		return nil, err
@@ -286,6 +379,33 @@ func (s *Store) resultPath(projectID, sessionID, runID string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(sessionPath, "runs", runID, resultFilename), nil
+}
+
+func (s *Store) leasePath(projectID, resource string) string {
+	return filepath.Join(s.root, projectID, "leases", resource+".json")
+}
+
+func (s *Store) readLease(projectID, resource string) (LeaseRecord, error) {
+	var record LeaseRecord
+	if err := readJSON(s.leasePath(projectID, resource), &record); err != nil {
+		return LeaseRecord{}, fmt.Errorf("read audit lease %q: %w", resource, err)
+	}
+	return record, nil
+}
+
+func cleanArtifactRelativePath(relativePath string) (string, error) {
+	cleaned := pathCleanForArtifacts(relativePath)
+	if cleaned == "." || cleaned == "" {
+		return "", errors.New("audit artifact path is required")
+	}
+	if strings.HasPrefix(cleaned, "../") || cleaned == ".." || filepath.IsAbs(relativePath) {
+		return "", fmt.Errorf("invalid audit artifact path %q", relativePath)
+	}
+	return cleaned, nil
+}
+
+func pathCleanForArtifacts(value string) string {
+	return filepath.ToSlash(filepath.Clean(value))
 }
 
 func validateID(kind, value string) error {

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -36,6 +36,7 @@ type auditCommandOptions struct {
 	OlderThan         time.Duration
 	TargetMode        string
 	PHPVersions       []string
+	URL               string
 }
 
 // AuditRunnerRequest is the resolved context a runner factory needs to build a
@@ -54,6 +55,9 @@ type AuditRunnerRequest struct {
 	// which only read persisted sessions and must never depend on a lint
 	// provider being constructible.
 	LintBackendRequired bool
+	// ProfilerRuntimeRequired reports whether this invocation executes a
+	// framework-owned runtime profiler.
+	ProfilerRuntimeRequired bool
 	// LintProvider is the effective provider name after flag/config precedence.
 	// It stays empty when LintBackendRequired is false, since no provider is
 	// selected for a read-only command.
@@ -68,8 +72,10 @@ type AuditRunnerRequest struct {
 // provider. Both facts are independent: rerun executes lint but reloads its PHP
 // matrix from the persisted session instead of resolving policy again.
 type auditPreparation struct {
-	ResolvePHPPolicy    bool
-	LintBackendRequired bool
+	ResolvePHPPolicy        bool
+	LintBackendRequired     bool
+	ProfilerRuntimeRequired bool
+	RequireProfilerURL      bool
 }
 
 type auditCommandDependencies struct {
@@ -90,6 +96,7 @@ type AuditDependenciesForTest struct {
 	// project-independent toolchain commands use.
 	ToolchainFactory func() (*audit.ToolchainManager, error)
 	RuntimePHPProbe  func(context.Context, types.AuditTarget, engine.Config) (version string, running bool, err error)
+	ProfilerRuntime  audit.ProfilerRuntime
 }
 
 var auditDependencyState struct {
@@ -124,7 +131,7 @@ func ResetAuditCommandForTest() {
 func defaultAuditCommandDependencies() auditCommandDependencies {
 	return auditCommandDependencies{
 		runnerFactory: func(request AuditRunnerRequest) (*audit.Runner, error) {
-			return newAuditRunner(request, nil)
+			return newAuditRunner(request, nil, nil)
 		},
 		toolchainFactory: func() (*audit.ToolchainManager, error) {
 			return audit.NewToolchainManager(audit.NewExecDockerClient(nil), engine.GovardHomeDir()), nil
@@ -146,7 +153,12 @@ func currentAuditDependencies(defaults auditCommandDependencies) auditCommandDep
 	if override.LintBackend != nil {
 		backend := override.LintBackend
 		defaults.runnerFactory = func(request AuditRunnerRequest) (*audit.Runner, error) {
-			return newAuditRunner(request, backend)
+			return newAuditRunner(request, backend, override.ProfilerRuntime)
+		}
+	} else if override.ProfilerRuntime != nil {
+		profilerRuntime := override.ProfilerRuntime
+		defaults.runnerFactory = func(request AuditRunnerRequest) (*audit.Runner, error) {
+			return newAuditRunner(request, nil, profilerRuntime)
 		}
 	}
 	if override.ToolchainFactory != nil {
@@ -173,7 +185,7 @@ func newAuditCommand(dependencies auditCommandDependencies) *cobra.Command {
 	}
 	command.PersistentFlags().StringVar(&options.Scope, "scope", string(audit.ScopeProject), "Audit scope (project or diff)")
 	command.PersistentFlags().StringVar(&options.BaseRef, "base", "", "Base ref required for diff scope")
-	command.PersistentFlags().StringSliceVar(&options.Checks, "checks", []string{"lint"}, "Checks to run (currently: lint)")
+	command.PersistentFlags().StringSliceVar(&options.Checks, "checks", []string{"lint"}, "Checks to run (lint or profiler)")
 	command.PersistentFlags().StringVar(&options.Format, "format", "text", "Output format (text or json)")
 	command.PersistentFlags().StringVar(&options.SessionID, "session", "", "Explicit audit session ID")
 	command.PersistentFlags().StringVar(&options.RunID, "run", "", "Explicit audit run ID")
@@ -182,8 +194,9 @@ func newAuditCommand(dependencies auditCommandDependencies) *cobra.Command {
 	command.PersistentFlags().BoolVar(&options.NoLintResultCache, "no-lint-result-cache", false, "Ignore reusable lint analyzer state for this run (the Composer download cache is kept)")
 	command.PersistentFlags().BoolVar(&options.AllowLintSSHAgent, "allow-lint-ssh-agent", false, "Forward SSH_AUTH_SOCK into the lint container for private Composer dependencies")
 	command.PersistentFlags().DurationVar(&options.OlderThan, "older-than", 0, "Remove sessions older than this duration")
-	command.PersistentFlags().StringVar(&options.TargetMode, "mode", "auto", "Lint target mode (auto, project, or standalone)")
+	command.PersistentFlags().StringVar(&options.TargetMode, "mode", "auto", "Audit target mode (auto, project, or standalone)")
 	command.PersistentFlags().StringSliceVar(&options.PHPVersions, "php", nil, "PHP versions; standalone only unless matching active project PHP")
+	command.PersistentFlags().StringVar(&options.URL, "url", "", "Absolute HTTP(S) URL captured by runtime audit checks")
 
 	command.AddCommand(
 		newAuditRunCommand(options, dependencies, false),
@@ -202,7 +215,7 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 	short := "Run a project audit"
 	if forceDiff {
 		use = "diff"
-		short = "Record a diff audit and run its exact lint checks"
+		short = "Record a diff audit and run its exact checks"
 	}
 	return &cobra.Command{Use: use, Short: short, RunE: func(cmd *cobra.Command, _ []string) error {
 		if err := validateAuditCommandOptions(options); err != nil {
@@ -215,12 +228,23 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 		if scope == audit.ScopeDiff && strings.TrimSpace(options.BaseRef) == "" {
 			return errors.New("audit diff requires --base")
 		}
-		runner, resolvedTarget, err := prepareAudit(cmd, options, dependencies, auditPreparation{ResolvePHPPolicy: true, LintBackendRequired: true})
+		lintRequested := auditChecksInclude(options.Checks, "lint")
+		profilerRequested := auditChecksInclude(options.Checks, "profiler")
+		runner, resolvedTarget, err := prepareAudit(cmd, options, dependencies, auditPreparation{
+			ResolvePHPPolicy:        lintRequested,
+			LintBackendRequired:     lintRequested,
+			ProfilerRuntimeRequired: profilerRequested,
+			RequireProfilerURL:      profilerRequested,
+		})
 		if err != nil {
 			return err
 		}
 		if err := validateAuditOptions(options, resolvedTarget.Definition); err != nil {
 			return err
+		}
+		lintProfile := types.AuditLintProfile{}
+		if resolvedTarget.Definition.AuditLint != nil {
+			lintProfile = *resolvedTarget.Definition.AuditLint
 		}
 		result, err := runner.Run(cmd.Context(), audit.RunRequest{
 			ProjectRoot:         auditTargetRoot(resolvedTarget.Target),
@@ -231,8 +255,9 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 			LintJobs:            options.LintJobs,
 			Environment:         auditTargetEnvironment(resolvedTarget),
 			Source:              resolvedTarget.Source,
-			LintProfile:         *resolvedTarget.Definition.AuditLint,
+			LintProfile:         lintProfile,
 			Target:              resolvedTarget.Target,
+			ProfilerURL:         options.URL,
 			SelectedPHPVersions: resolvedTarget.PHPVersions,
 			MatrixComplete:      resolvedTarget.MatrixComplete,
 			BypassResultCache:   options.NoLintResultCache,
@@ -263,14 +288,39 @@ func newAuditRerunCommand(options *auditCommandOptions, dependencies auditComman
 		if strings.TrimSpace(options.SessionID) == "" {
 			return errors.New("audit rerun requires --session")
 		}
-		runner, resolvedTarget, err := prepareAudit(cmd, options, dependencies, auditPreparation{LintBackendRequired: true})
+		// Without an explicit --checks the rerun repeats the latest run's
+		// selection; peek it straight from the persisted session store so no
+		// lint backend or profiler runtime is constructed for the lookup.
+		effectiveChecks := options.Checks
+		if !cmd.Flags().Changed("checks") {
+			mode := types.AuditTargetMode(strings.TrimSpace(options.TargetMode))
+			if mode == "" {
+				mode = types.AuditTargetAuto
+			}
+			resolvedDeps := currentAuditDependencies(dependencies)
+			peekTarget, err := resolveAuditTarget(cmd.Context(), commandStartDirectory(), mode, options.PHPVersions, resolvedDeps.runtimePHPProbe, false)
+			if err != nil {
+				return err
+			}
+			peekRunner := audit.NewRunner(audit.RunnerOptions{Store: audit.NewStore(audit.DefaultStoreRoot(engine.GovardHomeDir()))})
+			effectiveChecks, err = peekRunner.LatestRunChecks(cmd.Context(), peekTarget.ProjectID, options.SessionID)
+			if err != nil {
+				return err
+			}
+		}
+		lintRequested := auditChecksInclude(effectiveChecks, "lint")
+		profilerRequested := auditChecksInclude(effectiveChecks, "profiler")
+		runner, resolvedTarget, err := prepareAudit(cmd, options, dependencies, auditPreparation{
+			LintBackendRequired:     lintRequested,
+			ProfilerRuntimeRequired: profilerRequested,
+		})
 		if err != nil {
 			return err
 		}
 		if err := validateAuditOptions(options, resolvedTarget.Definition); err != nil {
 			return err
 		}
-		result, err := runner.Rerun(cmd.Context(), options.SessionID, resolvedTarget.ProjectID, options.Checks)
+		result, err := runner.Rerun(cmd.Context(), options.SessionID, resolvedTarget.ProjectID, effectiveChecks)
 		var renderErr error
 		if result.RunID != "" {
 			renderErr = writeAuditValue(cmd, options.Format, result)
@@ -365,11 +415,28 @@ func prepareAudit(cmd *cobra.Command, options *auditCommandOptions, dependencies
 		return nil, resolvedAuditTarget{}, err
 	}
 	request := AuditRunnerRequest{
-		ProjectRoot:         auditTargetRoot(target.Target),
-		Definition:          target.Definition,
-		Target:              target.Target,
-		Config:              target.Config,
-		LintBackendRequired: preparation.LintBackendRequired,
+		ProjectRoot:             auditTargetRoot(target.Target),
+		Definition:              target.Definition,
+		Target:                  target.Target,
+		Config:                  target.Config,
+		LintBackendRequired:     preparation.LintBackendRequired,
+		ProfilerRuntimeRequired: preparation.ProfilerRuntimeRequired,
+	}
+	if preparation.ProfilerRuntimeRequired {
+		if target.Definition.AuditProfiler == nil {
+			return nil, resolvedAuditTarget{}, fmt.Errorf("framework %q does not support profiler audit", target.Definition.Name)
+		}
+		if target.Config == nil || target.Target.Mode == types.AuditTargetStandalone {
+			return nil, resolvedAuditTarget{}, errors.New("audit profiler does not support standalone targets; run it from a Govard project")
+		}
+		if target.Target.Mode != types.AuditTargetProject {
+			return nil, resolvedAuditTarget{}, fmt.Errorf("audit profiler requires a project target, got %q", target.Target.Mode)
+		}
+		if preparation.RequireProfilerURL {
+			if err := audit.ValidateProfilerURL(options.URL); err != nil {
+				return nil, resolvedAuditTarget{}, err
+			}
+		}
 	}
 	// Provider precedence is only resolved for an invocation that actually runs
 	// lint; a read-only command must not select a provider at all.
@@ -410,23 +477,32 @@ func validateAuditOptions(options *auditCommandOptions, definition types.Framewo
 	if err := validateAuditCommandOptions(options); err != nil {
 		return err
 	}
-	if definition.AuditLint == nil {
-		return fmt.Errorf("framework %q does not support lint audit", definition.Name)
-	}
-	if options.LintJobs < 1 || options.LintJobs > len(definition.AuditLint.ProjectPHPVersions) {
-		return fmt.Errorf("lint jobs must be between 1 and %d", len(definition.AuditLint.ProjectPHPVersions))
+	if auditChecksInclude(options.Checks, "lint") {
+		if definition.AuditLint == nil {
+			return fmt.Errorf("framework %q does not support lint audit", definition.Name)
+		}
+		if options.LintJobs < 1 || options.LintJobs > len(definition.AuditLint.ProjectPHPVersions) {
+			return fmt.Errorf("lint jobs must be between 1 and %d", len(definition.AuditLint.ProjectPHPVersions))
+		}
 	}
 	return nil
+}
+
+func auditChecksInclude(checks []string, candidate string) bool {
+	for _, check := range checks {
+		if strings.TrimSpace(check) == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func validateAuditCommandOptions(options *auditCommandOptions) error {
 	if _, err := auditScope(options.Scope, false, false); err != nil {
 		return err
 	}
-	for _, check := range options.Checks {
-		if strings.TrimSpace(check) != "lint" {
-			return fmt.Errorf("audit check %q is not implemented", check)
-		}
+	if _, err := audit.NormalizeChecks(options.Checks); err != nil {
+		return err
 	}
 	if err := validateAuditProviderOption(options); err != nil {
 		return err

--- a/internal/cmd/audit_profiler_runtime.go
+++ b/internal/cmd/audit_profiler_runtime.go
@@ -1,0 +1,312 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"govard/internal/audit"
+	"govard/internal/conventions"
+	"govard/internal/engine"
+	"govard/internal/frameworks/types"
+)
+
+const (
+	auditProfilerDockerTimeout = 30 * time.Second
+	auditProfilerHTTPTimeout   = 30 * time.Second
+	auditProfilerNginxSubdir   = "audit-profiler"
+)
+
+var (
+	auditProfilerEnvironmentNamePattern  = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
+	auditProfilerEnvironmentValuePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+)
+
+type auditProfilerRuntimeDependencies struct {
+	runDocker func(context.Context, ...string) ([]byte, error)
+	httpGet   func(context.Context, string) (int, error)
+}
+
+// AuditProfilerRuntimeDependenciesForTest replaces only external Docker and
+// HTTP transport. Host-side config lifecycle remains real in unit tests.
+type AuditProfilerRuntimeDependenciesForTest struct {
+	RunDocker func(context.Context, ...string) ([]byte, error)
+	HTTPGet   func(context.Context, string) (int, error)
+}
+
+type govardAuditProfilerRuntime struct {
+	projectRoot  string
+	projectName  string
+	webServer    string
+	profile      types.AuditProfilerProfile
+	runDocker    func(context.Context, ...string) ([]byte, error)
+	httpGet      func(context.Context, string) (int, error)
+	phpContainer string
+	webContainer string
+}
+
+func defaultAuditProfilerRuntimeDependencies() auditProfilerRuntimeDependencies {
+	client := &http.Client{Timeout: auditProfilerHTTPTimeout}
+	return auditProfilerRuntimeDependencies{
+		runDocker: runAuditProfilerDocker,
+		httpGet: func(ctx context.Context, targetURL string) (int, error) {
+			request, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+			if err != nil {
+				return 0, fmt.Errorf("build profiler HTTP request: %w", err)
+			}
+			// Stock Magento only arms its profiler when HTTP_ACCEPT contains
+			// "text/html" (app/bootstrap.php), so the capture must look like a
+			// browser navigation rather than a bare API probe.
+			request.Header.Set("Accept", "text/html,application/xhtml+xml")
+			response, err := client.Do(request)
+			if err != nil {
+				return 0, fmt.Errorf("capture profiler URL: %w", err)
+			}
+			defer response.Body.Close()
+			// The response body is irrelevant to stock Magento profiling. Reading
+			// only a bounded prefix permits connection reuse for ordinary pages
+			// without buffering a large catalog response in Govard.
+			_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64*1024))
+			return response.StatusCode, nil
+		},
+	}
+}
+
+func runAuditProfilerDocker(ctx context.Context, arguments ...string) ([]byte, error) {
+	command := exec.CommandContext(ctx, "docker", arguments...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			return nil, fmt.Errorf("docker %s: %w", strings.Join(arguments, " "), err)
+		}
+		return nil, fmt.Errorf("docker %s: %w: %s", strings.Join(arguments, " "), err, detail)
+	}
+	return output, nil
+}
+
+func newAuditProfilerRuntime(request AuditRunnerRequest, dependencies auditProfilerRuntimeDependencies) (audit.ProfilerRuntime, error) {
+	if request.Config == nil || request.Target.Mode == types.AuditTargetStandalone {
+		return nil, errors.New("audit profiler does not support standalone targets; run it from a Govard project")
+	}
+	if request.Target.Mode != types.AuditTargetProject {
+		return nil, fmt.Errorf("audit profiler requires a project target, got %q", request.Target.Mode)
+	}
+	if request.Definition.AuditProfiler == nil {
+		return nil, fmt.Errorf("framework %q does not support profiler audit", request.Definition.Name)
+	}
+	profile := *request.Definition.AuditProfiler
+	if err := validateAuditProfilerProfile(profile); err != nil {
+		return nil, fmt.Errorf("framework %q audit profiler: %w", request.Definition.Name, err)
+	}
+	projectRoot := strings.TrimSpace(request.ProjectRoot)
+	if projectRoot == "" || !filepath.IsAbs(projectRoot) {
+		return nil, errors.New("audit profiler project root must be an absolute path")
+	}
+	projectName := strings.TrimSpace(request.Config.ProjectName)
+	if projectName == "" {
+		return nil, errors.New("audit profiler project name is required")
+	}
+	webServer := strings.ToLower(strings.TrimSpace(request.Config.Stack.Services.WebServer))
+	if webServer == "" {
+		webServer = strings.ToLower(strings.TrimSpace(request.Config.Stack.WebServer))
+	}
+	var webContainer string
+	switch webServer {
+	case "nginx", "apache":
+		webContainer = projectName + conventions.WebSuffix
+	case "hybrid":
+		webContainer = projectName + "-apache" + conventions.ReplicaSuffix
+	default:
+		return nil, fmt.Errorf("audit profiler does not support web server %q (use nginx, apache, or hybrid)", webServer)
+	}
+	if dependencies.runDocker == nil || dependencies.httpGet == nil {
+		return nil, errors.New("audit profiler runtime dependencies are not configured")
+	}
+	return &govardAuditProfilerRuntime{
+		projectRoot:  filepath.Clean(projectRoot),
+		projectName:  projectName,
+		webServer:    webServer,
+		profile:      profile,
+		runDocker:    dependencies.runDocker,
+		httpGet:      dependencies.httpGet,
+		phpContainer: projectName + conventions.PHPSuffix,
+		webContainer: webContainer,
+	}, nil
+}
+
+func validateAuditProfilerProfile(profile types.AuditProfilerProfile) error {
+	if !auditProfilerEnvironmentNamePattern.MatchString(profile.EnvironmentVariable) {
+		return fmt.Errorf("invalid FastCGI environment variable %q", profile.EnvironmentVariable)
+	}
+	if !auditProfilerEnvironmentValuePattern.MatchString(profile.EnvironmentValue) {
+		return fmt.Errorf("invalid FastCGI environment value %q", profile.EnvironmentValue)
+	}
+	cleanOutputPath := path.Clean(strings.TrimSpace(profile.OutputPath))
+	if cleanOutputPath == "." || path.IsAbs(cleanOutputPath) || cleanOutputPath == ".." || strings.HasPrefix(cleanOutputPath, "../") {
+		return fmt.Errorf("output path %q must stay below the project work directory", profile.OutputPath)
+	}
+	return nil
+}
+
+func (runtime *govardAuditProfilerRuntime) Activate(ctx context.Context, request audit.ProfilerRequest) error {
+	if err := runtime.validateRequest(request); err != nil {
+		return err
+	}
+	if err := runtime.removeRuntimeCSV(ctx); err != nil {
+		return fmt.Errorf("clear Magento profiler CSV: %w", err)
+	}
+	configPath, content := runtime.profilerConfig(request)
+	if err := writeAuditProfilerConfigAtomic(configPath, []byte(content)); err != nil {
+		return fmt.Errorf("write profiler web-server config: %w", err)
+	}
+	if err := runtime.reloadWebServer(ctx); err != nil {
+		return fmt.Errorf("reload %s after enabling profiler: %w", runtime.webServer, err)
+	}
+	return nil
+}
+
+func (runtime *govardAuditProfilerRuntime) Capture(ctx context.Context, request audit.ProfilerRequest) error {
+	if err := runtime.validateRequest(request); err != nil {
+		return err
+	}
+	captureCtx, cancel := context.WithTimeout(ctx, auditProfilerHTTPTimeout)
+	defer cancel()
+	status, err := runtime.httpGet(captureCtx, request.URL)
+	if err != nil {
+		return err
+	}
+	if status < http.StatusOK || status >= http.StatusBadRequest {
+		return fmt.Errorf("capture profiler URL %q returned HTTP %d", request.URL, status)
+	}
+	return nil
+}
+
+func (runtime *govardAuditProfilerRuntime) Collect(ctx context.Context, request audit.ProfilerRequest) ([]byte, error) {
+	if err := runtime.validateRequest(request); err != nil {
+		return nil, err
+	}
+	output, err := runtime.docker(ctx, "exec", runtime.phpContainer, "cat", runtime.containerOutputPath())
+	if err != nil {
+		return nil, fmt.Errorf("collect Magento profiler CSV: %w", err)
+	}
+	if len(output) == 0 {
+		return nil, errors.New("collect Magento profiler CSV: profiler output is empty")
+	}
+	return output, nil
+}
+
+func (runtime *govardAuditProfilerRuntime) Restore(ctx context.Context, request audit.ProfilerRequest) error {
+	var restoreErrors []error
+	configPath, _ := runtime.profilerConfig(request)
+	if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
+		restoreErrors = append(restoreErrors, fmt.Errorf("remove profiler web-server config: %w", err))
+	}
+	if err := runtime.reloadWebServer(ctx); err != nil {
+		restoreErrors = append(restoreErrors, fmt.Errorf("reload %s after disabling profiler: %w", runtime.webServer, err))
+	}
+	if err := runtime.removeRuntimeCSV(ctx); err != nil {
+		restoreErrors = append(restoreErrors, fmt.Errorf("remove Magento profiler CSV: %w", err))
+	}
+	return errors.Join(restoreErrors...)
+}
+
+func (runtime *govardAuditProfilerRuntime) validateRequest(request audit.ProfilerRequest) error {
+	if request.Target.Mode != types.AuditTargetProject || filepath.Clean(request.ProjectRoot) != runtime.projectRoot {
+		return errors.New("audit profiler request is not for the configured Govard project target")
+	}
+	return audit.ValidateProfilerURL(request.URL)
+}
+
+func (runtime *govardAuditProfilerRuntime) profilerConfig(request audit.ProfilerRequest) (string, string) {
+	sum := sha256.Sum256([]byte(strings.Join([]string{request.ProjectID, request.SessionID, request.RunID}, "\x00")))
+	filename := "govard-audit-profiler-" + hex.EncodeToString(sum[:8]) + ".conf"
+	if runtime.webServer == "nginx" {
+		configPath := filepath.Join(runtime.projectRoot, engine.ProjectNginxCustomDir, auditProfilerNginxSubdir, filename)
+		return configPath, fmt.Sprintf("# Managed temporarily by Govard audit.\nfastcgi_param %s %s;\n", runtime.profile.EnvironmentVariable, runtime.profile.EnvironmentValue)
+	}
+	configPath := filepath.Join(runtime.projectRoot, engine.ProjectApacheCustomDir, filename)
+	return configPath, fmt.Sprintf("# Managed temporarily by Govard audit.\nProxyFCGISetEnvIf \"true\" %s \"%s\"\n", runtime.profile.EnvironmentVariable, runtime.profile.EnvironmentValue)
+}
+
+func writeAuditProfilerConfigAtomic(destination string, content []byte) (resultErr error) {
+	directory := filepath.Dir(destination)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(directory, ".govard-audit-profiler-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		_ = os.Remove(temporaryPath)
+	}()
+	if err := temporary.Chmod(0o644); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, destination)
+}
+
+func (runtime *govardAuditProfilerRuntime) reloadWebServer(ctx context.Context) error {
+	if runtime.webServer == "nginx" {
+		_, err := runtime.docker(ctx, "exec", runtime.webContainer, "nginx", "-s", "reload")
+		return err
+	}
+	_, err := runtime.docker(ctx, "exec", runtime.webContainer, "httpd", "-k", "graceful")
+	return err
+}
+
+func (runtime *govardAuditProfilerRuntime) removeRuntimeCSV(ctx context.Context) error {
+	_, err := runtime.docker(ctx, "exec", runtime.phpContainer, "rm", "-f", runtime.containerOutputPath())
+	return err
+}
+
+func (runtime *govardAuditProfilerRuntime) containerOutputPath() string {
+	return path.Join(conventions.DefaultWorkDir, path.Clean(runtime.profile.OutputPath))
+}
+
+func (runtime *govardAuditProfilerRuntime) docker(ctx context.Context, arguments ...string) ([]byte, error) {
+	dockerCtx, cancel := context.WithTimeout(ctx, auditProfilerDockerTimeout)
+	defer cancel()
+	return runtime.runDocker(dockerCtx, arguments...)
+}
+
+// AuditProfilerHTTPGetForTest exposes the default capture transport so tests
+// can assert wire-level request properties against an httptest server.
+func AuditProfilerHTTPGetForTest() func(context.Context, string) (int, error) {
+	return defaultAuditProfilerRuntimeDependencies().httpGet
+}
+
+// NewAuditProfilerRuntimeForTest exposes command-boundary selection while
+// replacing only external transports; config files are still written and
+// removed by the real adapter.
+func NewAuditProfilerRuntimeForTest(request AuditRunnerRequest, dependencies AuditProfilerRuntimeDependenciesForTest) (audit.ProfilerRuntime, error) {
+	return newAuditProfilerRuntime(request, auditProfilerRuntimeDependencies{
+		runDocker: dependencies.RunDocker,
+		httpGet:   dependencies.HTTPGet,
+	})
+}

--- a/internal/cmd/audit_provider.go
+++ b/internal/cmd/audit_provider.go
@@ -136,12 +136,22 @@ func newAuditLintBackend(selection auditLintSelection) (audit.LintBackend, error
 // sessions must not depend on whether a lint provider could be constructed
 // right now: an unavailable external provider or a root container identity would
 // otherwise make a pure read of a persisted JSON file fail.
-func newAuditRunner(request AuditRunnerRequest, backend audit.LintBackend) (*audit.Runner, error) {
+func newAuditRunner(request AuditRunnerRequest, backend audit.LintBackend, profilerRuntime audit.ProfilerRuntime) (*audit.Runner, error) {
 	govardHome := engine.GovardHomeDir()
 	options := audit.RunnerOptions{
 		Store:         audit.NewStore(audit.DefaultStoreRoot(govardHome)),
 		LintCacheRoot: audit.DefaultLintCacheRoot(govardHome),
 		Resources:     audit.Resources{CPU: 8, MemoryMB: 8192},
+	}
+	if request.ProfilerRuntimeRequired {
+		if profilerRuntime == nil {
+			var err error
+			profilerRuntime, err = newAuditProfilerRuntime(request, defaultAuditProfilerRuntimeDependencies())
+			if err != nil {
+				return nil, err
+			}
+		}
+		options.ProfilerRuntime = profilerRuntime
 	}
 	if !request.LintBackendRequired {
 		return audit.NewRunner(options), nil

--- a/internal/engine/framework_capabilities.go
+++ b/internal/engine/framework_capabilities.go
@@ -5,7 +5,8 @@ import "strings"
 // FrameworkCapabilities records optional behaviors supplied by a registered
 // framework without making engine depend on the framework registry package.
 type FrameworkCapabilities struct {
-	FrontendSync bool
+	FrontendSync  bool
+	AuditProfiler bool
 }
 
 var registeredFrameworkCapabilities = map[string]FrameworkCapabilities{}
@@ -21,4 +22,11 @@ func RegisterFrameworkCapabilities(name string, capabilities FrameworkCapabiliti
 func FrameworkSupportsFrontendSync(name string) bool {
 	capabilities, ok := registeredFrameworkCapabilities[NormalizeFrameworkAlias(name)]
 	return ok && capabilities.FrontendSync
+}
+
+// FrameworkSupportsAuditProfiler reports whether the framework registered a
+// stock runtime-profiler capability.
+func FrameworkSupportsAuditProfiler(name string) bool {
+	capabilities, ok := registeredFrameworkCapabilities[NormalizeFrameworkAlias(name)]
+	return ok && capabilities.AuditProfiler
 }

--- a/internal/engine/render.go
+++ b/internal/engine/render.go
@@ -405,6 +405,27 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 
 	NormalizeConfig(&config, root)
 	config.Profile = profile
+
+	// Runtime audit providers mutate only Govard-owned custom include mounts.
+	// Prepare the active web server's mount before fingerprinting so its first
+	// creation is part of the same stable render, and before Compose rendering
+	// so providers never need to recreate a running container. Hybrid terminates
+	// FastCGI in Apache.
+	if FrameworkSupportsAuditProfiler(config.Framework) {
+		var auditCustomDir string
+		switch strings.ToLower(strings.TrimSpace(config.Stack.Services.WebServer)) {
+		case "nginx":
+			auditCustomDir = filepath.Join(root, ProjectNginxCustomDir)
+		case "apache", "hybrid":
+			auditCustomDir = filepath.Join(root, ProjectApacheCustomDir)
+		}
+		if auditCustomDir != "" {
+			if err := os.MkdirAll(auditCustomDir, 0o755); err != nil {
+				return fmt.Errorf("prepare audit profiler custom config directory: %w", err)
+			}
+		}
+	}
+
 	blueprintFingerprint, err := blueprintsFingerprint(blueprintsFS)
 	if err != nil {
 		return fmt.Errorf("fingerprint blueprints: %w", err)

--- a/internal/frameworks/magento2/blueprint/magento2.conf
+++ b/internal/frameworks/magento2/blueprint/magento2.conf
@@ -100,6 +100,9 @@ server {
         fastcgi_param  HTTPS 'on';
         fastcgi_param  MAGE_RUN_CODE $mage_run_code;
         fastcgi_param  MAGE_RUN_TYPE $mage_run_type;
+        # Runtime audit snippets live below a nested directory so the generic
+        # server-level custom include never consumes FastCGI params first.
+        include /etc/nginx/custom/audit-profiler/*.conf;
     }
 
     gzip on;

--- a/internal/frameworks/magento2/magento2.go
+++ b/internal/frameworks/magento2/magento2.go
@@ -41,6 +41,11 @@ func Definition() types.FrameworkDefinition {
 			PHPStanLevel:          5,
 			PHPStanExtension:      "bitexpert/phpstan-magento",
 		},
+		AuditProfiler: &types.AuditProfilerProfile{
+			EnvironmentVariable: "MAGE_PROFILER",
+			EnvironmentValue:    "csvfile",
+			OutputPath:          "var/log/profiler.csv",
+		},
 		AuditTargetResolver:    ResolveAuditTarget,
 		ComposerCodingStandard: types.ComposerCodingStandard{Package: "magento/magento-coding-standard", Standard: "Magento2"},
 		ComposerAuth:           types.ComposerAuthRequirement{Repository: "repo.magento.com", DisplayName: "Magento 2", CredentialURL: "https://marketplace.magento.com/customer/accessKeys/"},

--- a/internal/frameworks/registry.go
+++ b/internal/frameworks/registry.go
@@ -281,7 +281,8 @@ func registerEngineDefinition(def types.FrameworkDefinition) {
 	engine.RegisterDBDriverCategory(def.Name, def.DBDriverCategory)
 	engine.RegisterDefaultChownDirectories(def.Name, def.DefaultChownDirectories)
 	engine.RegisterFrameworkCapabilities(def.Name, engine.FrameworkCapabilities{
-		FrontendSync: def.FrontendSyncRenderer != nil,
+		FrontendSync:  def.FrontendSyncRenderer != nil,
+		AuditProfiler: def.AuditProfiler != nil,
 	})
 	for _, migrationType := range def.MigrationTypes.DDEV {
 		engine.RegisterMigrationFramework("ddev", migrationType, def.Name)

--- a/internal/frameworks/types/audit.go
+++ b/internal/frameworks/types/audit.go
@@ -41,6 +41,23 @@ type AuditLintProfile struct {
 	PHPStanExtension      string
 }
 
+// AuditProfilerProfile declares the stock runtime profiler contract owned by a
+// framework. The command layer consumes these values through the generic
+// FastCGI adapter without branching on the framework name.
+type AuditProfilerProfile struct {
+	EnvironmentVariable string
+	EnvironmentValue    string
+	OutputPath          string
+}
+
+func cloneAuditProfilerProfile(profile *AuditProfilerProfile) *AuditProfilerProfile {
+	if profile == nil {
+		return nil
+	}
+	cloned := *profile
+	return &cloned
+}
+
 func cloneAuditLintProfile(profile *AuditLintProfile) *AuditLintProfile {
 	if profile == nil {
 		return nil

--- a/internal/frameworks/types/definition.go
+++ b/internal/frameworks/types/definition.go
@@ -122,6 +122,9 @@ type FrameworkDefinition struct {
 	// AuditTargetResolver resolves a framework-specific path into an audit
 	// target. Nil means lint audit target selection is unsupported.
 	AuditTargetResolver AuditTargetResolver
+	// AuditProfiler declares a framework-owned stock runtime profiler. Nil
+	// means the profiler audit check is unsupported.
+	AuditProfiler *AuditProfilerProfile
 
 	// ComposerCodingStandard is the Composer package (e.g.
 	// "magento/magento-coding-standard") that registers this framework's phpcs

--- a/internal/frameworks/types/spec.go
+++ b/internal/frameworks/types/spec.go
@@ -49,6 +49,7 @@ type FrameworkPatch struct {
 	DefaultChownDirectories                 Override[[]string]
 	PHPStanPaths                            Override[[]string]
 	AuditLint                               Override[*AuditLintProfile]
+	AuditProfiler                           Override[*AuditProfilerProfile]
 	AuditTargetResolver                     Override[AuditTargetResolver]
 	ComposerCodingStandard                  Override[ComposerCodingStandard]
 	ComposerAuth                            Override[ComposerAuthRequirement]
@@ -134,6 +135,7 @@ func (s FrameworkSpec) Resolve(parent FrameworkDefinition) FrameworkDefinition {
 	s.Patch.VarnishTemplateFramework.apply(&resolved.VarnishTemplateFramework)
 	s.Patch.PHPStanPaths.apply(&resolved.PHPStanPaths)
 	s.Patch.AuditLint.apply(&resolved.AuditLint)
+	s.Patch.AuditProfiler.apply(&resolved.AuditProfiler)
 	s.Patch.AuditTargetResolver.apply(&resolved.AuditTargetResolver)
 	s.Patch.ComposerCodingStandard.apply(&resolved.ComposerCodingStandard)
 	s.Patch.ComposerAuth.apply(&resolved.ComposerAuth)
@@ -202,6 +204,7 @@ func cloneDefinition(def FrameworkDefinition) FrameworkDefinition {
 	cloned.MigrationTypes.Warden = cloneStrings(def.MigrationTypes.Warden)
 	cloned.PHPStanPaths = cloneStrings(def.PHPStanPaths)
 	cloned.AuditLint = cloneAuditLintProfile(def.AuditLint)
+	cloned.AuditProfiler = cloneAuditProfilerProfile(def.AuditProfiler)
 	cloned.DefaultChownDirectories = cloneStrings(def.DefaultChownDirectories)
 	cloned.ToolCommands = cloneToolCommands(def.ToolCommands)
 	cloned.DefaultTestCommand.Args = cloneStrings(def.DefaultTestCommand.Args)

--- a/tests/audit_checks_test.go
+++ b/tests/audit_checks_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"reflect"
+	"testing"
+
+	"govard/internal/audit"
+)
+
+func TestNormalizeAuditChecksDefaultsToLint(t *testing.T) {
+	got, err := audit.NormalizeChecks(nil)
+	if err != nil {
+		t.Fatalf("NormalizeChecks returned error: %v", err)
+	}
+	if want := []string{"lint"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized checks = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeAuditChecksSupportsProfilerAndDeduplicates(t *testing.T) {
+	got, err := audit.NormalizeChecks([]string{" profiler ", "lint", "profiler", " lint "})
+	if err != nil {
+		t.Fatalf("NormalizeChecks returned error: %v", err)
+	}
+	if want := []string{"profiler", "lint"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized checks = %#v, want %#v", got, want)
+	}
+}

--- a/tests/audit_command_test.go
+++ b/tests/audit_command_test.go
@@ -94,6 +94,35 @@ func TestAuditRerunRequiresExplicitSession(t *testing.T) {
 	}
 }
 
+// A rerun without --checks must repeat the checks of the latest run in the
+// session instead of silently falling back to the [lint] default, which fails
+// on sessions that never carried lint settings.
+func TestAuditRerunWithoutChecksRepeatsLatestRunChecks(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	runtime := &fakeProfilerRuntime{csv: []byte("type,timer\nfoo,1\n")}
+	restore := cmd.SetAuditDependenciesForTest(cmd.AuditDependenciesForTest{ProfilerRuntime: runtime})
+	t.Cleanup(restore)
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "run", "--checks", "profiler", "--url", "https://shop.test/", "--format", "json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var first audit.RunResult
+	if err := json.Unmarshal(output, &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.Status != audit.StatusPassed {
+		t.Fatalf("first run status = %q, want passed", first.Status)
+	}
+
+	if _, err := executeAuditCommand(t, project, []string{"audit", "rerun", "--session", first.SessionID, "--format", "json"}); err != nil {
+		t.Fatalf("rerun without --checks: %v", err)
+	}
+	if len(runtime.activateRequests) != 2 {
+		t.Fatalf("profiler activations = %d, want 2 (rerun must repeat the profiler check)", len(runtime.activateRequests))
+	}
+}
+
 func TestAuditStatusDoesNotExecuteBackend(t *testing.T) {
 	project := auditCommandProject(t, "magento2")
 	backend := &commandLintBackend{}
@@ -130,6 +159,74 @@ func TestAuditStatusRejectsUnsupportedChecks(t *testing.T) {
 	_, err := executeAuditCommand(t, project, []string{"audit", "status", "--session", "session-a", "--checks", "browser"})
 	if err == nil || !strings.Contains(err.Error(), "not implemented") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestAuditStatusAcceptsProfilerChecks(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	installAuditCommandDependencies(t, &commandLintBackend{})
+	_, err := executeAuditCommand(t, project, []string{"audit", "status", "--session", "session-a", "--checks", "profiler"})
+	if err == nil {
+		t.Fatal("audit status unexpectedly succeeded for a missing session")
+	}
+	if strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("error = %v, want profiler to pass command validation", err)
+	}
+}
+
+func TestAuditProfilerRunRequiresExplicitURLBeforeRunnerConstruction(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	var factoryCalls int
+	installAuditRunnerFactory(t, func(_ cmd.AuditRunnerRequest) (*audit.Runner, error) {
+		factoryCalls++
+		return nil, nil
+	})
+
+	_, err := executeAuditCommand(t, project, []string{"audit", "run", "--checks", "profiler"})
+	if err == nil || !strings.Contains(err.Error(), "--url") {
+		t.Fatalf("error = %v, want explicit profiler --url requirement", err)
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("runner factory calls = %d, want none before URL validation", factoryCalls)
+	}
+}
+
+func TestAuditProfilerCommandPersistsURLForRerun(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	runtime := &fakeProfilerRuntime{csv: []byte("type,timer\nfoo,1\n")}
+	restore := cmd.SetAuditDependenciesForTest(cmd.AuditDependenciesForTest{ProfilerRuntime: runtime})
+	t.Cleanup(restore)
+	targetURL := "https://audit-shop.test/category.html?product_list_limit=48&color=red%20blue"
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "run", "--checks", "profiler", "--url", targetURL, "--format", "json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var first audit.RunResult
+	if err := json.Unmarshal(output, &first); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executeAuditCommand(t, project, []string{"audit", "rerun", "--session", first.SessionID, "--checks", "profiler", "--format", "json"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(runtime.activateRequests) != 2 {
+		t.Fatalf("activate requests = %d, want 2", len(runtime.activateRequests))
+	}
+	for index, request := range runtime.activateRequests {
+		if request.URL != targetURL {
+			t.Fatalf("activate request %d URL = %q, want %q", index, request.URL, targetURL)
+		}
+	}
+}
+
+func TestAuditProfilerCommandRejectsStandaloneTarget(t *testing.T) {
+	module := standaloneAuditModule(t, "vendor/package")
+	restore := cmd.SetAuditDependenciesForTest(cmd.AuditDependenciesForTest{ProfilerRuntime: &fakeProfilerRuntime{}})
+	t.Cleanup(restore)
+
+	_, err := executeAuditCommand(t, module, []string{"audit", "run", "--mode", "standalone", "--checks", "profiler", "--url", "https://shop.test/"})
+	if err == nil || !strings.Contains(err.Error(), "standalone") {
+		t.Fatalf("error = %v, want standalone profiler rejection", err)
 	}
 }
 
@@ -335,8 +432,11 @@ func TestAuditReadOnlyCommandsNeverSelectALintProvider(t *testing.T) {
 		arguments []string
 		want      bool
 	}{
-		"run":     {arguments: []string{"audit", "run", "--format", "json"}, want: true},
-		"rerun":   {arguments: []string{"audit", "rerun", "--session", "missing-session"}, want: true},
+		"run": {arguments: []string{"audit", "run", "--format", "json"}, want: true},
+		// A rerun with explicit checks keeps the lint-backend contract; the
+		// omitted-checks form peeks the session first and never constructs a
+		// backend when the session does not exist.
+		"rerun":   {arguments: []string{"audit", "rerun", "--session", "missing-session", "--checks", "lint"}, want: true},
 		"status":  {arguments: []string{"audit", "status", "--session", "missing-session"}, want: false},
 		"result":  {arguments: []string{"audit", "result", "--session", "missing-session", "--run", "missing-run"}, want: false},
 		"cleanup": {arguments: []string{"audit", "cleanup", "--older-than", "1h"}, want: false},
@@ -649,14 +749,11 @@ func executeAuditCommand(t *testing.T, project string, args []string) ([]byte, e
 		t.Fatal(err)
 	}
 	auditCommand.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
-		if flag.Name == "php" {
+		if flag.Name == "php" || flag.Name == "checks" {
 			flag.Changed = false
 			return
 		}
 		value := flag.DefValue
-		if flag.Name == "checks" {
-			value = "lint"
-		}
 		if err := flag.Value.Set(value); err != nil {
 			t.Fatal(err)
 		}

--- a/tests/audit_profiler_capture_client_test.go
+++ b/tests/audit_profiler_capture_client_test.go
@@ -1,0 +1,38 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"govard/internal/cmd"
+)
+
+// Stock Magento only enables the CSV profiler when HTTP_ACCEPT contains
+// "text/html" (app/bootstrap.php). The capture client must therefore send an
+// explicit HTML Accept header; Go's net/http sends none by default.
+func TestAuditProfilerCaptureClientSendsHTMLAcceptHeader(t *testing.T) {
+	var accept string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accept = r.Header.Get("Accept")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	httpGet := cmd.AuditProfilerHTTPGetForTest()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	status, err := httpGet(ctx, server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", status, http.StatusOK)
+	}
+	if !strings.Contains(accept, "text/html") {
+		t.Fatalf("Accept header = %q, want it to contain text/html so stock Magento enables the CSV profiler", accept)
+	}
+}

--- a/tests/audit_profiler_magento2_test.go
+++ b/tests/audit_profiler_magento2_test.go
@@ -1,0 +1,214 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"govard/internal/audit"
+	"govard/internal/cmd"
+	"govard/internal/engine"
+	"govard/internal/frameworks"
+	"govard/internal/frameworks/types"
+)
+
+func TestAuditProfilerMagento2LifecycleUsesActiveGovardWebServer(t *testing.T) {
+	for _, testCase := range []struct {
+		name              string
+		webServer         string
+		configRelativeDir string
+		configNeedle      string
+		reload            []string
+	}{
+		{
+			name:              "nginx",
+			webServer:         "nginx",
+			configRelativeDir: filepath.Join(".govard", "nginx", "custom", "audit-profiler"),
+			configNeedle:      "fastcgi_param MAGE_PROFILER csvfile;",
+			reload:            []string{"exec", "audit-shop-web-1", "nginx", "-s", "reload"},
+		},
+		{
+			name:              "apache",
+			webServer:         "apache",
+			configRelativeDir: filepath.Join(".govard", "apache", "custom"),
+			configNeedle:      "ProxyFCGISetEnvIf \"true\" MAGE_PROFILER \"csvfile\"",
+			reload:            []string{"exec", "audit-shop-web-1", "httpd", "-k", "graceful"},
+		},
+		{
+			name:              "hybrid configures apache",
+			webServer:         "hybrid",
+			configRelativeDir: filepath.Join(".govard", "apache", "custom"),
+			configNeedle:      "ProxyFCGISetEnvIf \"true\" MAGE_PROFILER \"csvfile\"",
+			reload:            []string{"exec", "audit-shop-apache-1", "httpd", "-k", "graceful"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			projectRoot := t.TempDir()
+			envPath := filepath.Join(projectRoot, "app", "etc", "env.php")
+			if err := os.MkdirAll(filepath.Dir(envPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(envPath, []byte("<?php return ['sentinel' => true];\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			definition, ok := frameworks.Get("magento2")
+			if !ok {
+				t.Fatal("Magento 2 definition is not registered")
+			}
+			config := &engine.Config{ProjectName: "audit-shop", Framework: "magento2"}
+			config.Stack.Services.WebServer = testCase.webServer
+			target := types.AuditTarget{Framework: "magento2", ProjectRoot: projectRoot, TargetPath: projectRoot, Mode: types.AuditTargetProject}
+
+			var dockerCalls [][]string
+			var capturedURL string
+			runtime, err := cmd.NewAuditProfilerRuntimeForTest(cmd.AuditRunnerRequest{
+				ProjectRoot:             projectRoot,
+				Definition:              definition,
+				Target:                  target,
+				Config:                  config,
+				ProfilerRuntimeRequired: true,
+			}, cmd.AuditProfilerRuntimeDependenciesForTest{
+				RunDocker: func(_ context.Context, arguments ...string) ([]byte, error) {
+					copied := append([]string(nil), arguments...)
+					dockerCalls = append(dockerCalls, copied)
+					if reflect.DeepEqual(arguments, []string{"exec", "audit-shop-php-1", "cat", "/var/www/html/var/log/profiler.csv"}) {
+						return []byte("type,timer\nfoo,1\n"), nil
+					}
+					return nil, nil
+				},
+				HTTPGet: func(_ context.Context, targetURL string) (int, error) {
+					capturedURL = targetURL
+					return 200, nil
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := audit.ProfilerRequest{
+				ProjectRoot: projectRoot,
+				ProjectID:   "project-a",
+				SessionID:   "session-a",
+				RunID:       "run-0001",
+				URL:         "https://audit-shop.test/catalogsearch/result/?q=$(touch%20/tmp/pwned)&product_list_limit=48",
+				Target:      target,
+			}
+
+			if err := runtime.Activate(context.Background(), request); err != nil {
+				t.Fatal(err)
+			}
+			configDir := filepath.Join(projectRoot, testCase.configRelativeDir)
+			entries, err := os.ReadDir(configDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 1 || entries[0].IsDir() || !strings.HasPrefix(entries[0].Name(), "govard-audit-profiler-") || !strings.HasSuffix(entries[0].Name(), ".conf") {
+				t.Fatalf("temporary profiler configs = %#v, want one uniquely named .conf", entries)
+			}
+			configPath := filepath.Join(configDir, entries[0].Name())
+			content, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(content), testCase.configNeedle) {
+				t.Fatalf("temporary profiler config = %q, want %q", content, testCase.configNeedle)
+			}
+
+			if err := runtime.Capture(context.Background(), request); err != nil {
+				t.Fatal(err)
+			}
+			if capturedURL != request.URL {
+				t.Fatalf("captured URL = %q, want exact %q", capturedURL, request.URL)
+			}
+			csv, err := runtime.Collect(context.Background(), request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(csv) != "type,timer\nfoo,1\n" {
+				t.Fatalf("collected CSV = %q", csv)
+			}
+			if err := runtime.Restore(context.Background(), request); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+				t.Fatalf("temporary profiler config still exists after restore: %v", err)
+			}
+			env, err := os.ReadFile(envPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(env) != "<?php return ['sentinel' => true];\n" {
+				t.Fatalf("app/etc/env.php was changed: %q", env)
+			}
+
+			wantCalls := [][]string{
+				{"exec", "audit-shop-php-1", "rm", "-f", "/var/www/html/var/log/profiler.csv"},
+				testCase.reload,
+				{"exec", "audit-shop-php-1", "cat", "/var/www/html/var/log/profiler.csv"},
+				testCase.reload,
+				{"exec", "audit-shop-php-1", "rm", "-f", "/var/www/html/var/log/profiler.csv"},
+			}
+			if !reflect.DeepEqual(dockerCalls, wantCalls) {
+				t.Fatalf("Docker calls = %#v, want %#v", dockerCalls, wantCalls)
+			}
+			for _, arguments := range dockerCalls {
+				if strings.Contains(strings.Join(arguments, " "), request.URL) {
+					t.Fatalf("user URL was interpolated into Docker command: %#v", arguments)
+				}
+			}
+		})
+	}
+}
+
+func TestAuditProfilerMagento2RejectsStandaloneBeforeMutation(t *testing.T) {
+	definition, ok := frameworks.Get("magento2")
+	if !ok {
+		t.Fatal("Magento 2 definition is not registered")
+	}
+	root := t.TempDir()
+	config := &engine.Config{ProjectName: "audit-shop", Framework: "magento2"}
+	config.Stack.Services.WebServer = "nginx"
+	var calls int
+	_, err := cmd.NewAuditProfilerRuntimeForTest(cmd.AuditRunnerRequest{
+		ProjectRoot: root,
+		Definition:  definition,
+		Target:      types.AuditTarget{Framework: "magento2", TargetPath: root, Mode: types.AuditTargetStandalone},
+		Config:      config,
+	}, cmd.AuditProfilerRuntimeDependenciesForTest{
+		RunDocker: func(context.Context, ...string) ([]byte, error) {
+			calls++
+			return nil, nil
+		},
+		HTTPGet: func(context.Context, string) (int, error) {
+			calls++
+			return 200, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "standalone") {
+		t.Fatalf("error = %v, want a clear standalone rejection", err)
+	}
+	if calls != 0 {
+		t.Fatalf("external calls = %d, want none before standalone rejection", calls)
+	}
+}
+
+func TestAuditProfilerMagento2RejectsUnsupportedWebServerBeforeMutation(t *testing.T) {
+	definition, ok := frameworks.Get("magento2")
+	if !ok {
+		t.Fatal("Magento 2 definition is not registered")
+	}
+	root := t.TempDir()
+	config := &engine.Config{ProjectName: "audit-shop", Framework: "magento2"}
+	config.Stack.Services.WebServer = "caddy"
+	_, err := cmd.NewAuditProfilerRuntimeForTest(cmd.AuditRunnerRequest{
+		ProjectRoot: root,
+		Definition:  definition,
+		Target:      types.AuditTarget{Framework: "magento2", ProjectRoot: root, TargetPath: root, Mode: types.AuditTargetProject},
+		Config:      config,
+	}, cmd.AuditProfilerRuntimeDependenciesForTest{})
+	if err == nil || !strings.Contains(err.Error(), "web server") {
+		t.Fatalf("error = %v, want unsupported web server rejection", err)
+	}
+}

--- a/tests/audit_profiler_test.go
+++ b/tests/audit_profiler_test.go
@@ -1,0 +1,358 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"govard/internal/audit"
+)
+
+func TestAuditProfilerStoresCollectedCSVAndRestoresLease(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{csv: []byte("type,timer\nfoo,1\n")}
+	runner := audit.NewRunner(audit.RunnerOptions{
+		Store:           store,
+		ProfilerRuntime: runtime,
+		Resources:       audit.Resources{CPU: 2, MemoryMB: 2048},
+	})
+
+	result, err := runner.Run(context.Background(), profilerRunRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != audit.StatusPassed {
+		t.Fatalf("status = %q, want passed", result.Status)
+	}
+	if want := []string{"activate", "capture", "collect", "restore"}; !reflect.DeepEqual(runtime.events, want) {
+		t.Fatalf("runtime events = %#v, want %#v", runtime.events, want)
+	}
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("artifacts = %#v, want one profiler CSV", result.Artifacts)
+	}
+	artifact := result.Artifacts[0]
+	if artifact.Kind != "profiler-csv" {
+		t.Fatalf("artifact kind = %q, want profiler-csv", artifact.Kind)
+	}
+	if artifact.SHA256 != "2443521cb316804b3588c092e1d96f5e7ea6fb8a0147111e257591831694d909" {
+		t.Fatalf("artifact SHA256 = %q", artifact.SHA256)
+	}
+	if want := filepath.Join("artifacts", "profiler", "profile.csv"); filepath.Base(filepath.Dir(filepath.Dir(artifact.Path))) != "artifacts" || filepath.Base(filepath.Dir(artifact.Path)) != "profiler" || filepath.Base(artifact.Path) != "profile.csv" {
+		t.Fatalf("artifact path = %q, want run-isolated %q", artifact.Path, want)
+	}
+	got, err := os.ReadFile(artifact.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "type,timer\nfoo,1\n" {
+		t.Fatalf("artifact contents = %q", got)
+	}
+	persisted, err := store.ReadResult(result.ProjectID, result.SessionID, result.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(persisted.Artifacts, result.Artifacts) {
+		t.Fatalf("persisted artifacts = %#v, want %#v", persisted.Artifacts, result.Artifacts)
+	}
+	if _, err := store.AcquireLease(result.ProjectID, "diagnostics", "next-owner"); err != nil {
+		t.Fatalf("profiler lease was not released: %v", err)
+	}
+}
+
+func TestAuditProfilerRerunPreservesExactURL(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{csv: []byte("type,timer\nfoo,1\n")}
+	runner := audit.NewRunner(audit.RunnerOptions{
+		Store:           store,
+		ProfilerRuntime: runtime,
+		Resources:       audit.Resources{CPU: 2, MemoryMB: 2048},
+	})
+	request := profilerRunRequest()
+	request.ProfilerURL = "https://shop.test/catalogsearch/result/?q=red%20shoe&product_list_limit=48"
+
+	first, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.Rerun(context.Background(), first.SessionID, first.ProjectID, []string{"profiler"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(runtime.activateRequests) != 2 {
+		t.Fatalf("activate requests = %d, want 2", len(runtime.activateRequests))
+	}
+	for index, got := range runtime.activateRequests {
+		if got.URL != request.ProfilerURL {
+			t.Fatalf("activate request %d URL = %q, want %q", index, got.URL, request.ProfilerURL)
+		}
+	}
+}
+
+func TestAuditProfilerDoesNotActivateWhileDiagnosticsLeaseIsHeld(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	request := profilerRunRequest()
+	if _, err := store.AcquireLease(request.ProjectID, "diagnostics", "other-run"); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &fakeProfilerRuntime{}
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+
+	result, err := runner.Run(context.Background(), request)
+	if err == nil {
+		t.Fatal("run succeeded while diagnostics lease was held")
+	}
+	if result.Status != audit.StatusFailed || len(result.Errors) != 1 {
+		t.Fatalf("result = %#v, want a persisted infrastructure failure", result)
+	}
+	if len(runtime.events) != 0 {
+		t.Fatalf("runtime events = %#v, want no activation before lease acquisition", runtime.events)
+	}
+}
+
+func TestAuditProfilerRestoresAndReleasesAfterActivationFailure(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{activateErr: errors.New("activate profiler")}
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+
+	result, err := runner.Run(context.Background(), profilerRunRequest())
+	if err == nil || err.Error() != "activate profiler" {
+		t.Fatalf("run error = %v, want activation failure", err)
+	}
+	if result.Status != audit.StatusFailed || len(result.Artifacts) != 0 || len(result.Errors) != 1 {
+		t.Fatalf("result = %#v, want failed result without artifacts", result)
+	}
+	if want := []string{"activate", "restore"}; !reflect.DeepEqual(runtime.events, want) {
+		t.Fatalf("runtime events = %#v, want %#v", runtime.events, want)
+	}
+	if _, err := store.AcquireLease(result.ProjectID, "diagnostics", "next-owner"); err != nil {
+		t.Fatalf("profiler lease was not released: %v", err)
+	}
+}
+
+func TestAuditProfilerPreservesOperationAndRestoreFailuresInTerminalEvidence(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{
+		activateErr: errors.New("activate profiler"),
+		restoreErr:  errors.New("restore profiler"),
+	}
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+
+	result, err := runner.Run(context.Background(), profilerRunRequest())
+	if err == nil || !strings.Contains(err.Error(), "activate profiler") || !strings.Contains(err.Error(), "restore profiler") {
+		t.Fatalf("run error = %v, want operation and restore failures", err)
+	}
+	if result.Status != audit.StatusFailed || len(result.Errors) != 1 {
+		t.Fatalf("result = %#v, want failed result with one infrastructure error", result)
+	}
+	message := result.Errors[0].Message
+	if !strings.Contains(message, "activate profiler") || !strings.Contains(message, "restore profiler") {
+		t.Fatalf("terminal error = %q, want operation and restore failures", message)
+	}
+	if want := []string{"activate", "restore"}; !reflect.DeepEqual(runtime.events, want) {
+		t.Fatalf("runtime events = %#v, want %#v", runtime.events, want)
+	}
+}
+
+func TestAuditProfilerRestoresAndReleasesAfterCaptureFailure(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{captureErr: errors.New("capture profiler")}
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+
+	result, err := runner.Run(context.Background(), profilerRunRequest())
+	if err == nil || err.Error() != "capture profiler" {
+		t.Fatalf("run error = %v, want capture failure", err)
+	}
+	if result.Status != audit.StatusFailed || len(result.Artifacts) != 0 || len(result.Errors) != 1 {
+		t.Fatalf("result = %#v, want failed result without artifacts", result)
+	}
+	if want := []string{"activate", "capture", "restore"}; !reflect.DeepEqual(runtime.events, want) {
+		t.Fatalf("runtime events = %#v, want %#v", runtime.events, want)
+	}
+	if _, err := store.AcquireLease(result.ProjectID, "diagnostics", "next-owner"); err != nil {
+		t.Fatalf("profiler lease was not released: %v", err)
+	}
+}
+
+func TestAuditProfilerRestoresAndReleasesAfterCollectFailure(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{collectErr: errors.New("collect profiler")}
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+
+	result, err := runner.Run(context.Background(), profilerRunRequest())
+	if err == nil || err.Error() != "collect profiler" {
+		t.Fatalf("run error = %v, want collect failure", err)
+	}
+	if result.Status != audit.StatusFailed || len(result.Artifacts) != 0 || len(result.Errors) != 1 {
+		t.Fatalf("result = %#v, want failed result without artifacts", result)
+	}
+	if want := []string{"activate", "capture", "collect", "restore"}; !reflect.DeepEqual(runtime.events, want) {
+		t.Fatalf("runtime events = %#v, want %#v", runtime.events, want)
+	}
+	if _, err := store.AcquireLease(result.ProjectID, "diagnostics", "next-owner"); err != nil {
+		t.Fatalf("profiler lease was not released: %v", err)
+	}
+}
+
+func TestAuditProfilerRestoresAndReleasesAfterCancellation(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{captureStarted: make(chan struct{})}
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type runOutcome struct {
+		result audit.RunResult
+		err    error
+	}
+	completed := make(chan runOutcome, 1)
+	go func() {
+		result, err := runner.Run(ctx, profilerRunRequest())
+		completed <- runOutcome{result: result, err: err}
+	}()
+	<-runtime.captureStarted
+	cancel()
+	outcome := <-completed
+	if outcome.err != nil {
+		t.Fatalf("run error = %v, want cancellation represented in the result", outcome.err)
+	}
+	if outcome.result.Status != audit.StatusCancelled || len(outcome.result.Errors) != 0 || len(outcome.result.Artifacts) != 0 {
+		t.Fatalf("result = %#v, want cancelled result without errors or artifacts", outcome.result)
+	}
+	if want := []string{"activate", "capture", "restore"}; !reflect.DeepEqual(runtime.events, want) {
+		t.Fatalf("runtime events = %#v, want %#v", runtime.events, want)
+	}
+	if _, err := store.AcquireLease(outcome.result.ProjectID, "diagnostics", "next-owner"); err != nil {
+		t.Fatalf("profiler lease was not released: %v", err)
+	}
+}
+
+func TestAuditProfilerKeepsLeaseAndSurfacesRestoreFailureAfterCancellation(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{
+		captureStarted: make(chan struct{}),
+		restoreErr:     errors.New("restore profiler"),
+	}
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type runOutcome struct {
+		result audit.RunResult
+		err    error
+	}
+	completed := make(chan runOutcome, 1)
+	go func() {
+		result, err := runner.Run(ctx, profilerRunRequest())
+		completed <- runOutcome{result: result, err: err}
+	}()
+	<-runtime.captureStarted
+	cancel()
+	outcome := <-completed
+	if outcome.err == nil || !strings.Contains(outcome.err.Error(), "restore profiler") {
+		t.Fatalf("run error = %v, want restore failure", outcome.err)
+	}
+	if outcome.result.Status != audit.StatusCancelled || len(outcome.result.Errors) != 1 {
+		t.Fatalf("result = %#v, want cancelled result with restore failure", outcome.result)
+	}
+	if want := []string{"activate", "capture", "restore"}; !reflect.DeepEqual(runtime.events, want) {
+		t.Fatalf("runtime events = %#v, want %#v", runtime.events, want)
+	}
+	if _, err := store.AcquireLease(outcome.result.ProjectID, "diagnostics", "next-owner"); err == nil {
+		t.Fatal("profiler lease was released after restore failure")
+	}
+}
+
+func TestAuditProfilerTimesOutRestoreAndKeepsLease(t *testing.T) {
+	store := newDeterministicAuditStore(t)
+	runtime := &fakeProfilerRuntime{restoreUntilCancel: true, restoreStarted: make(chan struct{})}
+	runner := audit.NewRunner(audit.RunnerOptions{
+		Store:                  store,
+		ProfilerRuntime:        runtime,
+		ProfilerCleanupTimeout: 10 * time.Millisecond,
+		Resources:              audit.Resources{CPU: 2, MemoryMB: 2048},
+	})
+
+	type runOutcome struct {
+		result audit.RunResult
+		err    error
+	}
+	completed := make(chan runOutcome, 1)
+	go func() {
+		result, err := runner.Run(context.Background(), profilerRunRequest())
+		completed <- runOutcome{result: result, err: err}
+	}()
+	select {
+	case outcome := <-completed:
+		if outcome.err == nil || !strings.Contains(outcome.err.Error(), "context deadline exceeded") {
+			t.Fatalf("run error = %v, want cleanup timeout", outcome.err)
+		}
+		if outcome.result.Status != audit.StatusFailed || len(outcome.result.Errors) != 1 {
+			t.Fatalf("result = %#v, want failed result with cleanup timeout", outcome.result)
+		}
+		if _, err := store.AcquireLease(outcome.result.ProjectID, "diagnostics", "next-owner"); err == nil {
+			t.Fatal("profiler lease was released after restore timeout")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("profiler cleanup did not respect its timeout")
+	}
+}
+
+func profilerRunRequest() audit.RunRequest {
+	request := auditRunRequest()
+	request.Checks = []string{"profiler"}
+	request.ProfilerURL = "https://shop.test/"
+	request.LintJobs = 0
+	request.SelectedPHPVersions = nil
+	request.MatrixComplete = false
+	return request
+}
+
+type fakeProfilerRuntime struct {
+	events             []string
+	activateRequests   []audit.ProfilerRequest
+	csv                []byte
+	activateErr        error
+	captureErr         error
+	collectErr         error
+	restoreErr         error
+	captureStarted     chan struct{}
+	restoreStarted     chan struct{}
+	restoreUntilCancel bool
+}
+
+func (runtime *fakeProfilerRuntime) Activate(_ context.Context, request audit.ProfilerRequest) error {
+	runtime.events = append(runtime.events, "activate")
+	runtime.activateRequests = append(runtime.activateRequests, request)
+	return runtime.activateErr
+}
+
+func (runtime *fakeProfilerRuntime) Capture(ctx context.Context, _ audit.ProfilerRequest) error {
+	runtime.events = append(runtime.events, "capture")
+	if runtime.captureStarted != nil {
+		close(runtime.captureStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return runtime.captureErr
+}
+
+func (runtime *fakeProfilerRuntime) Collect(context.Context, audit.ProfilerRequest) ([]byte, error) {
+	runtime.events = append(runtime.events, "collect")
+	return runtime.csv, runtime.collectErr
+}
+
+func (runtime *fakeProfilerRuntime) Restore(ctx context.Context, _ audit.ProfilerRequest) error {
+	runtime.events = append(runtime.events, "restore")
+	if runtime.restoreStarted != nil {
+		close(runtime.restoreStarted)
+	}
+	if runtime.restoreUntilCancel {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return runtime.restoreErr
+}

--- a/tests/audit_runner_test.go
+++ b/tests/audit_runner_test.go
@@ -81,6 +81,50 @@ func TestAuditRunnerRerunUsesFrozenManifestAndRejectsProjectMismatch(t *testing.
 	}
 }
 
+func TestAuditRerunFindsLatestLintSettingsAfterProfilerOnlyRun(t *testing.T) {
+	backend := &fakeLintBackend{report: passingLintReport("project-aabbccdd")}
+	runtime := &fakeProfilerRuntime{}
+	store := newDeterministicAuditStore(t)
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, LintBackend: backend, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+	request := auditRunRequest()
+	request.Checks = []string{"lint", "profiler"}
+	request.ProfilerURL = "https://shop.test/"
+	first, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.Rerun(context.Background(), first.SessionID, first.ProjectID, []string{"profiler"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.Rerun(context.Background(), first.SessionID, first.ProjectID, []string{"lint"}); err != nil {
+		t.Fatalf("lint rerun after profiler-only run = %v", err)
+	}
+	if len(backend.requests) != 2 {
+		t.Fatalf("lint backend calls = %d, want two", len(backend.requests))
+	}
+}
+
+func TestAuditProfilerOnlyRerunPreservesProjectTarget(t *testing.T) {
+	backend := &fakeLintBackend{report: passingLintReport("project-aabbccdd")}
+	runtime := &fakeProfilerRuntime{}
+	store := newDeterministicAuditStore(t)
+	runner := audit.NewRunner(audit.RunnerOptions{Store: store, LintBackend: backend, ProfilerRuntime: runtime, Resources: audit.Resources{CPU: 2, MemoryMB: 2048}})
+	request := auditRunRequest()
+	request.Checks = []string{"lint", "profiler"}
+	request.ProfilerURL = "https://shop.test/"
+	request.Target = types.AuditTarget{Framework: "magento2", ProjectRoot: "/work/shop", TargetPath: "/work/shop", Mode: types.AuditTargetProject}
+	first, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.Rerun(context.Background(), first.SessionID, first.ProjectID, []string{"profiler"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := runtime.activateRequests[len(runtime.activateRequests)-1].Target; !reflect.DeepEqual(got, request.Target) {
+		t.Fatalf("profiler rerun target = %#v, want %#v", got, request.Target)
+	}
+}
+
 func TestAuditRunnerPersistsLintFailureAndInfrastructureError(t *testing.T) {
 	t.Run("lint failure", func(t *testing.T) {
 		backend := &fakeLintBackend{report: failedLintReport("project-aabbccdd")}

--- a/tests/audit_store_test.go
+++ b/tests/audit_store_test.go
@@ -212,6 +212,59 @@ func TestAuditStoreCleanupOlderThanIsolatedAndSkipsSymlinks(t *testing.T) {
 	}
 }
 
+func TestAuditStorePersistsLeaseOwnershipAndIsolatesRunArtifacts(t *testing.T) {
+	root := t.TempDir()
+	store := newAuditStore(root, time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC))
+	manifest, err := store.CreateSession(audit.SessionManifest{
+		SchemaVersion: audit.SchemaVersion,
+		ProjectID:     "project-aabbccdd",
+		ProjectRoot:   "/work/shop",
+		Scope:         audit.ScopeProject,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := store.CreateRun(manifest.ProjectID, manifest.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := store.AcquireLease(manifest.ProjectID, "diagnostics", "owner-a")
+	if err != nil {
+		t.Fatalf("AcquireLease() first owner error = %v", err)
+	}
+	if lease.Owner != "owner-a" {
+		t.Fatalf("AcquireLease() owner = %q, want owner-a", lease.Owner)
+	}
+	if _, err := store.AcquireLease(manifest.ProjectID, "diagnostics", "owner-b"); err == nil {
+		t.Fatal("AcquireLease() overwrote an existing owner")
+	}
+	if err := store.ReleaseLease(manifest.ProjectID, "diagnostics", "owner-b"); err == nil {
+		t.Fatal("ReleaseLease() accepted a foreign owner")
+	}
+	if err := store.ReleaseLease(manifest.ProjectID, "diagnostics", "owner-a"); err != nil {
+		t.Fatalf("ReleaseLease() owner error = %v", err)
+	}
+
+	artifactPath, err := store.RunArtifactPath(manifest.ProjectID, manifest.SessionID, run.RunID, "profiler/output.csv")
+	if err != nil {
+		t.Fatalf("RunArtifactPath() error = %v", err)
+	}
+	wantArtifactPath := filepath.Join(root, manifest.ProjectID, "sessions", manifest.SessionID, "runs", run.RunID, "artifacts", "profiler", "output.csv")
+	if artifactPath != wantArtifactPath {
+		t.Fatalf("RunArtifactPath() = %q, want %q", artifactPath, wantArtifactPath)
+	}
+	if err := os.WriteFile(artifactPath, []byte("csv"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(artifactPath)); err != nil {
+		t.Fatalf("artifact dir missing: %v", err)
+	}
+	if _, err := store.RunArtifactPath(manifest.ProjectID, manifest.SessionID, run.RunID, "../escape.csv"); err == nil {
+		t.Fatal("RunArtifactPath() accepted a path escape")
+	}
+}
+
 func newAuditStore(root string, now time.Time) *audit.Store {
 	return audit.NewStore(root,
 		audit.WithClock(func() time.Time { return now }),

--- a/tests/blueprint_workflow_magento2_test.go
+++ b/tests/blueprint_workflow_magento2_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"govard/internal/blueprints"
+	"govard/internal/engine"
+)
+
+func TestRenderMagento2BlueprintPreparesAuditProfilerCustomMounts(t *testing.T) {
+	for _, testCase := range []struct {
+		webServer      string
+		customDir      string
+		containerMount string
+	}{
+		{webServer: "nginx", customDir: engine.ProjectNginxCustomDir, containerMount: "/etc/nginx/custom:ro"},
+		{webServer: "apache", customDir: engine.ProjectApacheCustomDir, containerMount: "/usr/local/apache2/conf/custom:ro"},
+		{webServer: "hybrid", customDir: engine.ProjectApacheCustomDir, containerMount: "/usr/local/apache2/conf/custom:ro"},
+	} {
+		t.Run(testCase.webServer, func(t *testing.T) {
+			root := t.TempDir()
+			setTestGovardHome(t, t.TempDir())
+			if err := os.CopyFS(filepath.Join(engine.GovardHomeDir(), "blueprints"), blueprints.FS); err != nil {
+				t.Fatal(err)
+			}
+			config := engine.Config{ProjectName: "audit-shop", Framework: "magento2", Domain: "audit-shop.test"}
+			config.Stack.PHPVersion = "8.4"
+			config.Stack.Services = engine.Services{WebServer: testCase.webServer, DB: "mariadb", Search: "none", Cache: "none", Queue: "none"}
+
+			if err := engine.RenderBlueprint(root, config); err != nil {
+				t.Fatal(err)
+			}
+			customPath := filepath.Join(root, testCase.customDir)
+			if info, err := os.Stat(customPath); err != nil || !info.IsDir() {
+				t.Fatalf("audit profiler custom directory %q was not prepared: %v", customPath, err)
+			}
+			compose, err := os.ReadFile(engine.ComposeFilePath(root, config.ProjectName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(compose), customPath+":"+testCase.containerMount) {
+				t.Fatalf("compose does not mount audit profiler custom dir:\n%s", compose)
+			}
+		})
+	}
+}
+
+func TestRenderMagento2NginxIncludesAuditProfilerInsidePHPLocation(t *testing.T) {
+	root := t.TempDir()
+	setTestGovardHome(t, t.TempDir())
+	if err := os.CopyFS(filepath.Join(engine.GovardHomeDir(), "blueprints"), blueprints.FS); err != nil {
+		t.Fatal(err)
+	}
+	config := engine.Config{ProjectName: "audit-shop", Framework: "magento2", Domain: "audit-shop.test"}
+	config.Stack.PHPVersion = "8.4"
+	config.Stack.Services = engine.Services{WebServer: "nginx", DB: "mariadb", Search: "none", Cache: "none", Queue: "none"}
+
+	if err := engine.RenderBlueprint(root, config); err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := os.ReadFile(filepath.Join(engine.GovardHomeDir(), "nginx", config.ProjectName, "default.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(rendered)
+	phpLocation := strings.Index(content, "location ~ (index|get|static|report|404|503|health_check)\\.php$")
+	includeLine := strings.Index(content, "include /etc/nginx/custom/audit-profiler/*.conf;")
+	locationEnd := strings.Index(content[phpLocation:], "\n    }")
+	if phpLocation < 0 || includeLine < phpLocation || locationEnd < 0 || includeLine >= phpLocation+locationEnd {
+		t.Fatalf("audit profiler include is not inside Magento's PHP FastCGI location:\n%s", content)
+	}
+}
+
+func TestRenderMagento2AuditProfilerMountDoesNotInvalidateNextRender(t *testing.T) {
+	root := t.TempDir()
+	setTestGovardHome(t, t.TempDir())
+	if err := os.CopyFS(filepath.Join(engine.GovardHomeDir(), "blueprints"), blueprints.FS); err != nil {
+		t.Fatal(err)
+	}
+	config := engine.Config{ProjectName: "audit-shop", Framework: "magento2", Domain: "audit-shop.test"}
+	config.Stack.PHPVersion = "8.4"
+	config.Stack.Services = engine.Services{WebServer: "nginx", DB: "mariadb", Search: "none", Cache: "none", Queue: "none"}
+
+	if err := engine.RenderBlueprint(root, config); err != nil {
+		t.Fatal(err)
+	}
+	hashPath := engine.ComposeFilePath(root, config.ProjectName) + ".hash"
+	first, err := os.ReadFile(hashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.RenderBlueprint(root, config); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(hashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("audit profiler mount changed the next render hash: first=%q second=%q", first, second)
+	}
+}

--- a/tests/testdata/framework_snapshots/magento2/compose.yml
+++ b/tests/testdata/framework_snapshots/magento2/compose.yml
@@ -53,6 +53,7 @@ services:
         volumes:
             - .:/var/www/html
             - <GOVARD_HOME>/nginx/snapshot-magento2/default.conf:/etc/nginx/templates/magento2.conf:ro
+            - <PROJECT_DIR>/.govard/nginx/custom:/etc/nginx/custom:ro
             - <GOVARD_HOME>/nginx/snapshot-magento2/mage-run-map.conf:/etc/nginx/conf.d/mage-run-map.conf:ro
 volumes:
     db-data: null

--- a/tests/testdata/framework_snapshots/magento2/nginx.conf
+++ b/tests/testdata/framework_snapshots/magento2/nginx.conf
@@ -100,6 +100,9 @@ server {
         fastcgi_param  HTTPS 'on';
         fastcgi_param  MAGE_RUN_CODE $mage_run_code;
         fastcgi_param  MAGE_RUN_TYPE $mage_run_type;
+        # Runtime audit snippets live below a nested directory so the generic
+        # server-level custom include never consumes FastCGI params first.
+        include /etc/nginx/custom/audit-profiler/*.conf;
     }
 
     gzip on;
@@ -126,5 +129,5 @@ server {
     location ~* (\.php$|\.phtml$|\.htaccess$|\.git) {
         deny all;
     }
-    
+    include /etc/nginx/custom/*.conf;
 }

--- a/tests/testdata/framework_snapshots/mageos/compose.yml
+++ b/tests/testdata/framework_snapshots/mageos/compose.yml
@@ -53,6 +53,7 @@ services:
         volumes:
             - .:/var/www/html
             - <GOVARD_HOME>/nginx/snapshot-mageos/default.conf:/etc/nginx/templates/magento2.conf:ro
+            - <PROJECT_DIR>/.govard/nginx/custom:/etc/nginx/custom:ro
             - <GOVARD_HOME>/nginx/snapshot-mageos/mage-run-map.conf:/etc/nginx/conf.d/mage-run-map.conf:ro
 volumes:
     db-data: null

--- a/tests/testdata/framework_snapshots/mageos/nginx.conf
+++ b/tests/testdata/framework_snapshots/mageos/nginx.conf
@@ -100,6 +100,9 @@ server {
         fastcgi_param  HTTPS 'on';
         fastcgi_param  MAGE_RUN_CODE $mage_run_code;
         fastcgi_param  MAGE_RUN_TYPE $mage_run_type;
+        # Runtime audit snippets live below a nested directory so the generic
+        # server-level custom include never consumes FastCGI params first.
+        include /etc/nginx/custom/audit-profiler/*.conf;
     }
 
     gzip on;
@@ -126,5 +129,5 @@ server {
     location ~* (\.php$|\.phtml$|\.htaccess$|\.git) {
         deny all;
     }
-    
+    include /etc/nginx/custom/*.conf;
 }


### PR DESCRIPTION
Closes #167

## Summary

Completes the Govard-native Magento profiler provider behind `govard audit run --checks profiler --url <absolute-url>`:

- **Persistent lease + isolated runs**: per-project diagnostic lease prevents concurrent mutations; every run gets its own artifact paths under the session/run directory.
- **Check selection**: `--checks` accepts `lint`, `profiler`, or a deduplicated combination; profiler requires an explicit absolute HTTP(S) `--url` on first run and a whole-project target (standalone/module-only targets are rejected before any runtime mutation). The exact URL is persisted in the run evidence and reused by `audit rerun` so before/after captures hit the same page.
- **Lifecycle**: bounded Activate/Capture/Collect/Restore phases with tainted-lease retention when restore fails, persisted artifacts (`runs/<run-id>/artifacts/profiler/profile.csv` + SHA-256 digest), and safe rerun settings.
- **Govard-native runtime adapter** (this PR's final piece): temporary managed includes written only below Govard-managed `.govard/*/custom` mounts — a nested `.govard/nginx/custom/audit-profiler/` FastCGI-location include for nginx, a temporary vhost include under `.govard/apache/custom/` for Apache/hybrid (hybrid configures/reloads its Apache service). It clears/collects `var/log/profiler.csv` through the PHP container, restores both include and runtime CSV, reloads only the selected server, and never edits `app/etc/env.php`. Uses Magento's stock `MAGE_PROFILER=csvfile`; no Magento module or third-party image.
- **Framework isolation**: adapter wiring dispatches through framework-registered capabilities (`RegisterFrameworkCapabilities`) — no hardcoded `magento2`/`mageos` branching in `internal/engine`/`internal/cmd`.
- **Docs**: README usage section, `docs/reference/cli-commands.md` profiler semantics, `docs/reference/configuration.md` mount/include behavior, plus synced Vietnamese translations that previously still said the profiler was a future phase.

## Rationale

The audit framework already had persistent lint sessions; this adds the second declared check without changing session semantics. Profiling is a whole-project runtime concern, so it is gated to project targets and lease-protected against concurrent server mutation rather than run opportunistically.

## Test plan

- Focused lease/check/lifecycle/command/blueprint tests, all hermetic (no real containers or network).
- New `tests/audit_profiler_test.go` and `tests/audit_profiler_magento2_test.go` cover URL/target validation, lease ownership, atomic include write/remove, nginx/Apache/hybrid lifecycle, artifact persistence, rerun settings, and renderer mount preparation.
- New wire-level regression test asserts the capture client sends an HTML Accept header (`tests/audit_profiler_capture_client_test.go`).
- New command test covers rerun check inheritance without an explicit `--checks`.
- Full `make test`: golangci-lint, gofmt check, vet, frontend tests, Go unit tests/build, integration suite (re-run green after the fixes below).
- `gofmt -s -l .` clean on changed files.

## Live validation on a real Magento project (bebe9, Apache stack)

The PR's pending live-run follow-up was executed against the real bebe9 Magento 2.4 project (Apache + PHP-FPM 8.2):

1. First real capture failed to produce any CSV. Root cause (verified by manual probes): stock Magento only arms the profiler when `HTTP_ACCEPT` contains `text/html` (`app/bootstrap.php`), but Govard's capture client sent no Accept header, so Magento never wrote the CSV while every Govard-side phase reported success. Fixed by sending `Accept: text/html,application/xhtml+xml`; regression test added at the HTTP-client boundary so the hermetic suite can no longer miss it.
2. Second real capture **passed**: `profiler.csv` collected through the PHP container and persisted with SHA-256; include removed, server reloaded back, runtime CSV cleared, site healthy afterwards.
3. Live rerun without `--checks` then exposed a second bug: reruns defaulted to `[lint]` and failed with "no persisted lint settings" on profiler-only sessions. Fixed: a rerun without `--checks` now repeats the latest run's checks (including the persisted profiler URL); explicit `--checks` behavior is unchanged. Third live capture via plain `govard audit rerun --session ...` passed on bebe9.
