### PR TITLE
fix(audit): document every --mode value and reject typos with the accepted list

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -142,8 +142,8 @@ directory:
 | `module_in_project` | The directory is a module — either `etc/module.xml` (how `app/code` modules are declared) or a Composer package of type `magento2-module` — inside a Magento project | Only the module, with the whole project mounted read only so its autoloader resolves |
 | `standalone` | The directory is a module with no Magento project anywhere above it | Only the module; its dependencies are installed into a scratch worktree and scanned for symbols |
 
-`--mode project` and `--mode standalone` force a classification and fail when the
-directory does not support it.
+`--mode project`, `--mode module_in_project`, and `--mode standalone` force a
+classification and fail when the directory does not support it.
 
 ```bash
 # project: run from the Magento project root

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -144,8 +144,8 @@ mục hiện tại:
 | `module_in_project` | Thư mục là một module — qua `etc/module.xml` (cách khai báo module `app/code`) hoặc Composer package type `magento2-module` — nằm bên trong một Magento project | Chỉ module đó, toàn bộ project được mount read-only để autoloader phân giải được |
 | `standalone` | Thư mục là một module và không có Magento project nào ở cấp trên | Chỉ module đó; dependency được cài vào worktree tạm và chỉ được scan lấy symbol |
 
-`--mode project` và `--mode standalone` buộc một phân loại cụ thể và sẽ lỗi khi
-thư mục không thỏa điều kiện.
+`--mode project`, `--mode module_in_project` và `--mode standalone` buộc một
+phân loại cụ thể và sẽ lỗi khi thư mục không thỏa điều kiện.
 
 ```bash
 # project: chạy từ project root của Magento

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -194,7 +194,7 @@ func newAuditCommand(dependencies auditCommandDependencies) *cobra.Command {
 	command.PersistentFlags().BoolVar(&options.NoLintResultCache, "no-lint-result-cache", false, "Ignore reusable lint analyzer state for this run (the Composer download cache is kept)")
 	command.PersistentFlags().BoolVar(&options.AllowLintSSHAgent, "allow-lint-ssh-agent", false, "Forward SSH_AUTH_SOCK into the lint container for private Composer dependencies")
 	command.PersistentFlags().DurationVar(&options.OlderThan, "older-than", 0, "Remove sessions older than this duration")
-	command.PersistentFlags().StringVar(&options.TargetMode, "mode", "auto", "Audit target mode (auto, project, or standalone)")
+	command.PersistentFlags().StringVar(&options.TargetMode, "mode", "auto", auditTargetModeUsage())
 	command.PersistentFlags().StringSliceVar(&options.PHPVersions, "php", nil, "PHP versions; standalone only unless matching active project PHP")
 	command.PersistentFlags().StringVar(&options.URL, "url", "", "Absolute HTTP(S) URL captured by runtime audit checks")
 
@@ -501,6 +501,9 @@ func validateAuditCommandOptions(options *auditCommandOptions) error {
 	if _, err := auditScope(options.Scope, false, false); err != nil {
 		return err
 	}
+	if err := validateAuditTargetMode(options.TargetMode); err != nil {
+		return err
+	}
 	if _, err := audit.NormalizeChecks(options.Checks); err != nil {
 		return err
 	}
@@ -508,6 +511,43 @@ func validateAuditCommandOptions(options *auditCommandOptions) error {
 		return err
 	}
 	return validateAuditOutputOptions(options)
+}
+
+// auditTargetModeUsage renders the --mode help text from the framework-owned
+// mode vocabulary so a new mode cannot be added without the flag documenting it.
+func auditTargetModeUsage() string {
+	names := auditTargetModeNames()
+	if len(names) == 0 {
+		return "Audit target mode"
+	}
+	if len(names) == 1 {
+		return "Audit target mode (" + names[0] + ")"
+	}
+	return "Audit target mode (" + strings.Join(names[:len(names)-1], ", ") + ", or " + names[len(names)-1] + ")"
+}
+
+// auditTargetModeNames lists the accepted --mode values in vocabulary order.
+func auditTargetModeNames() []string {
+	modes := types.AuditTargetModes()
+	names := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		names = append(names, string(mode))
+	}
+	return names
+}
+
+// validateAuditTargetMode rejects an unknown --mode value before any target
+// resolution runs. Left unchecked, a typo like `--mode module` would fall
+// through to the generic "no framework can resolve audit target" failure and
+// never tell the operator which values exist.
+func validateAuditTargetMode(mode string) error {
+	trimmed := strings.TrimSpace(mode)
+	for _, candidate := range types.AuditTargetModes() {
+		if trimmed == string(candidate) {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown audit target mode %q (valid modes: %s)", mode, strings.Join(auditTargetModeNames(), ", "))
 }
 
 // validateAuditProviderOption only rejects a syntactically unusable provider

--- a/internal/frameworks/types/audit.go
+++ b/internal/frameworks/types/audit.go
@@ -11,6 +11,13 @@ const (
 	AuditTargetStandalone AuditTargetMode = "standalone"
 )
 
+// AuditTargetModes lists every --mode value in vocabulary order. The audit
+// command's help text and its unknown-mode error both render this list, so the
+// accepted values stay documented in exactly one place.
+func AuditTargetModes() []AuditTargetMode {
+	return []AuditTargetMode{AuditTargetAuto, AuditTargetProject, AuditTargetModule, AuditTargetStandalone}
+}
+
 // AuditTargetResolveRequest supplies the user-selected starting point and an
 // optional mode override to a framework-owned target resolver.
 type AuditTargetResolveRequest struct {

--- a/tests/audit_command_test.go
+++ b/tests/audit_command_test.go
@@ -629,6 +629,67 @@ func TestAuditCommandNoLongerAcceptsTheUnreleasedLintBackendFlag(t *testing.T) {
 	}
 }
 
+// auditTargetModeVocabulary mirrors every value the --mode flag accepts; the
+// help text and the unknown-mode error must both document this exact set.
+var auditTargetModeVocabulary = []string{"auto", "project", "module_in_project", "standalone"}
+
+func TestAuditModeFlagHelpDocumentsEveryTargetMode(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	help, err := executeAuditCommand(t, project, []string{"audit", "--help"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var modeUsage []string
+	for _, line := range strings.Split(string(help), "\n") {
+		if strings.Contains(line, "--mode") {
+			modeUsage = append(modeUsage, line)
+		}
+	}
+	if len(modeUsage) == 0 {
+		t.Fatalf("audit help does not document a --mode flag:\n%s", help)
+	}
+	documented := strings.Join(modeUsage, "\n")
+	for _, mode := range auditTargetModeVocabulary {
+		if !strings.Contains(documented, mode) {
+			t.Fatalf("audit --mode help does not document target mode %q; got:\n%s", mode, documented)
+		}
+	}
+}
+
+func TestAuditUnknownModeErrorNamesValidModes(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	installAuditCommandDependencies(t, &commandLintBackend{})
+	_, err := executeAuditCommand(t, project, []string{"audit", "run", "--mode", "module"})
+	if err == nil {
+		t.Fatal("an unknown audit target mode was accepted")
+	}
+	for _, mode := range auditTargetModeVocabulary {
+		if !strings.Contains(err.Error(), mode) {
+			t.Fatalf("unknown-mode error does not name valid mode %q: %v", mode, err)
+		}
+	}
+}
+
+func TestAuditUnknownModeIsRejectedWithTheModeVocabulary(t *testing.T) {
+	// Outside any framework project: the mode vocabulary check must fire
+	// before target resolution can produce its less actionable
+	// "no framework can resolve audit target" failure.
+	project := t.TempDir()
+	installAuditCommandDependencies(t, &commandLintBackend{})
+	_, err := executeAuditCommand(t, project, []string{"audit", "run", "--mode", "module"})
+	if err == nil {
+		t.Fatal("an unknown audit target mode was accepted")
+	}
+	if !strings.Contains(err.Error(), "unknown audit target mode") {
+		t.Fatalf("error does not name the unknown audit target mode problem: %v", err)
+	}
+	for _, mode := range auditTargetModeVocabulary {
+		if !strings.Contains(err.Error(), mode) {
+			t.Fatalf("unknown-mode error does not name valid mode %q: %v", mode, err)
+		}
+	}
+}
+
 func auditRunnerRequestForProvider(t *testing.T, provider string, config *engine.Config) cmd.AuditRunnerRequest {
 	t.Helper()
 	root := t.TempDir()


### PR DESCRIPTION
Closes #169

### Summary

`--mode` accepted `auto`, `project`, `module_in_project`, and `standalone` from the start, but its flag help rendered `(auto, project, or standalone)` and a typo like `--mode module` fell through to the generic `no framework can resolve audit target` failure that never named the real vocabulary. On `bebe9` the reporter ran `govard audit run` from `app/code/` and saw a whole-project audit with no clue that `module_in_project` was available.

Fix: expose the vocabulary once in `types.AuditTargetModes()` so help and validation cannot drift, validate `--mode` at the command layer so every audit subcommand fails fast with `unknown audit target mode (valid modes: auto, project, module_in_project, standalone)` before any target resolution, keep the fix framework-agnostic, update the flag help, and document the forced-mode table in both locales.

### Rationale

The classification itself (`internal/frameworks/magento2/audit_target.go`) was already correct — live reproduction with `bebe9/app/code/BeBe9/Brand` produced `mode=module_in_project` via the branch binary and the persisted store at `~/.govard/audit`. Two operator-UI gaps blocked self-correction: help hid a valid value and the typo failure named none.

### Test plan

- `tests/audit_command_test.go`: help documents every mode, an unknown mode names the valid set, and the error fires regardless of whether the cwd is inside a Magento tree (regression from the pre-fix path).
- `go vet` / `gofmt` clean; `make test` (which is `lint + fmt-check + vet + all tests`) green — unit + integration both passed before push.
- Live smoke on `bebe9` (Apache stack): `app/code/` → `unknown audit target mode` with the list before framework probing, `app/code/BeBe9/Brand --mode module_in_project` → scoped lint (56 findings scoped to that module).

### Docs

`docs/reference/cli-commands.md` and `docs/vi/reference/cli-commands.md`: the forced-mode sentence now lists `--mode project`, `--mode module_in_project`, and `--mode standalone`.
