### PR TITLE
feat(audit): stream live progress and colorize findings like vendor/bin

### DIFF
--- a/internal/audit/lint.go
+++ b/internal/audit/lint.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 
 	"govard/internal/frameworks/types"
@@ -49,6 +50,13 @@ type LintRequest struct {
 	// for this run. The backend, not the runner, turns it into the runner
 	// argument and the "bypassed" cache evidence it must observe in return.
 	BypassResultCache bool
+	// StreamWriter receives live Docker log output while the backend runs. When
+	// nil the backend writes only to its persisted govard-lint.log file. The
+	// host command passes the terminal writer in text mode so operators see
+	// phase progress (validate → prepare → phpcs/phpstan) as it happens,
+	// mirroring vendor/bin/phpcs behaviour; in --format json the writer stays
+	// nil so machine output is not polluted.
+	StreamWriter io.Writer
 }
 
 type LintPhase struct {

--- a/internal/audit/lint_external.go
+++ b/internal/audit/lint_external.go
@@ -162,7 +162,11 @@ func (provider *ExternalLintProvider) Run(ctx context.Context, request LintReque
 	if cancellationCause := externalLintCancellationCause(ctx); cancellationCause != nil {
 		return cancelledExternalLintResult(cancellationCause, nil)
 	}
-	commandErr := provider.runContainer(ctx, container, logFile)
+	output := io.Writer(logFile)
+	if request.StreamWriter != nil {
+		output = io.MultiWriter(logFile, request.StreamWriter)
+	}
+	commandErr := provider.runContainer(ctx, container, output)
 	provider.runLifecycleHook(externalLintAfterRun)
 	if cancellationCause := externalLintCancellationCause(ctx); cancellationCause != nil {
 		return LintReport{Status: string(StatusCancelled)}, externalLintCancelledError(cancellationCause, provider.cleanupContainer(container.Name, logFile))

--- a/internal/audit/lint_govard.go
+++ b/internal/audit/lint_govard.go
@@ -253,7 +253,11 @@ func (backend *GovardLintBackend) Run(ctx context.Context, request LintRequest) 
 	if cause := externalLintCancellationCause(ctx); cause != nil {
 		return cancelledGovardLintResult(cause, nil)
 	}
-	runErr := backend.runContainer(ctx, container, logFile)
+	output := io.Writer(logFile)
+	if request.StreamWriter != nil {
+		output = io.MultiWriter(logFile, request.StreamWriter)
+	}
+	runErr := backend.runContainer(ctx, container, output)
 	if cause := externalLintCancellationCause(ctx); cause != nil {
 		return LintReport{Status: lintStatusCancelled}, govardLintCancelledError(cause, backend.cleanupContainer(container.Name, logFile))
 	}

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"time"
@@ -33,6 +34,13 @@ type RunRequest struct {
 	// BypassResultCache asks the lint backend to ignore reusable analyzer
 	// state for this run.
 	BypassResultCache bool
+	// Output receives live progress while the run executes when the command
+	// is in text mode on an interactive terminal. The runner forwards it to
+	// the lint backend's StreamWriter so Docker logs (phase start/end,
+	// per-PHP cache state, and later per-finding lines) appear as they
+	// happen, mirroring vendor/bin/phpcs/phpstan. In --format json the
+	// field stays nil so machine output is not polluted.
+	Output io.Writer
 }
 
 type RunnerOptions struct {
@@ -350,6 +358,7 @@ func (runner *Runner) lintJob(request RunRequest, manifest SessionManifest, runI
 		SelectedPHPVersions: append([]string(nil), request.SelectedPHPVersions...),
 		MatrixComplete:      request.MatrixComplete,
 		BypassResultCache:   request.BypassResultCache,
+		StreamWriter:        request.Output,
 	}
 	lintJob := func(ctx context.Context) (map[string]any, error) {
 		report, runErr := runner.lintBackend.Run(ctx, lintRequest)

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -246,6 +246,13 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 		if resolvedTarget.Definition.AuditLint != nil {
 			lintProfile = *resolvedTarget.Definition.AuditLint
 		}
+		streamWriter := io.Writer(nil)
+		if options.Format != "json" {
+			// Text mode streams live Docker logs (phase progress, cache
+			// state) as they happen, mirroring vendor/bin/phpcs/phpstan.
+			// JSON stays machine-clean for AI agents.
+			streamWriter = cmd.OutOrStdout()
+		}
 		result, err := runner.Run(cmd.Context(), audit.RunRequest{
 			ProjectRoot:         auditTargetRoot(resolvedTarget.Target),
 			ProjectID:           resolvedTarget.ProjectID,
@@ -261,6 +268,7 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 			SelectedPHPVersions: resolvedTarget.PHPVersions,
 			MatrixComplete:      resolvedTarget.MatrixComplete,
 			BypassResultCache:   options.NoLintResultCache,
+			Output:              streamWriter,
 		})
 		// Render the summary before reporting the outcome, so a failed run
 		// still prints everything the operator needs alongside the failure.

--- a/internal/cmd/audit_output.go
+++ b/internal/cmd/audit_output.go
@@ -166,7 +166,7 @@ func (r auditTextRenderer) checks(jobs []audit.JobResult) {
 }
 
 func (r auditTextRenderer) phpResult(php auditLintPHPView) {
-	parts := []string{"PHP " + php.Version, auditPlainStatus(php.Outcome)}
+	parts := []string{"PHP " + php.Version, auditStatusText(audit.Status(php.Outcome), r.color)}
 	if php.DurationMS > 0 {
 		parts = append(parts, auditHumanDuration(php.DurationMS))
 	}
@@ -174,15 +174,95 @@ func (r auditTextRenderer) phpResult(php auditLintPHPView) {
 	if cache == "" {
 		cache = "unknown"
 	}
-	parts = append(parts, "cache "+cache, fmt.Sprintf("%d findings", len(php.Findings)))
+	// Cache state benefits from a subtle color so scanning for "cold" vs "warm" is fast.
+	cacheText := "cache " + cache
+	if r.color {
+		switch cache {
+		case "cold":
+			cacheText = pterm.NewStyle(pterm.FgYellow).Sprint(cacheText)
+		case "warm":
+			cacheText = pterm.NewStyle(pterm.FgGreen).Sprint(cacheText)
+		case "bypassed":
+			cacheText = pterm.NewStyle(pterm.FgGray).Sprint(cacheText)
+		}
+	}
+	parts = append(parts, cacheText, fmt.Sprintf("%d findings", len(php.Findings)))
 	r.printf("      %s", strings.Join(parts, " | "))
+	limit := auditMaxDisplayedFindings
+	if r.color {
+		// On an interactive terminal the operator is actively fixing code;
+		// show every finding like vendor/bin/phpcs does. The piped case stays
+		// capped to avoid flooding CI logs — the full report is always on disk.
+		limit = len(php.Findings)
+	}
 	for index, finding := range php.Findings {
-		if index == auditMaxDisplayedFindings {
+		if index == limit {
 			r.printf("      ... and %d more findings (see the full report under What next)", len(php.Findings)-index)
 			break
 		}
-		r.printf("      - %s", finding.String())
+		line := finding.String()
+		if r.color {
+			line = findingColoredString(finding)
+		}
+		r.printf("      - %s", line)
 	}
+}
+
+// findingColoredString renders a single lint finding with terminal colors,
+// mirroring the vendor/bin/phpcs and phpstan CLIs the operator already knows:
+// tool dim, rule yellow, path cyan, message white. The plain String() stays
+// untouched for JSON and piped text. ANSI codes are emitted directly so the
+// helper is deterministic even when pterm's global DisableStyling is set in
+// tests or CI.
+func findingColoredString(finding auditLintFindingView) string {
+	location := finding.Path
+	if location == "" {
+		location = "(unknown path)"
+	}
+	if finding.Line > 0 {
+		location += ":" + fmt.Sprint(finding.Line)
+		if finding.Column > 0 {
+			location += ":" + fmt.Sprint(finding.Column)
+		}
+	}
+	// Explicit ANSI instead of pterm.NewStyle so tests never depend on the
+	// global pterm.DisableStyling flag (which CI and several hermetic tests
+	// flip). The palette mirrors auditStatusStyles: cyan for paths, bold
+	// light-blue for the tool, yellow for the rule.
+	const (
+		ansiCyan          = "\x1b[36m"
+		ansiYellow        = "\x1b[33m"
+		ansiLightBlueBold = "\x1b[94;1m"
+		ansiReset         = "\x1b[0m"
+	)
+	location = ansiCyan + location + ansiReset
+
+	prefix := finding.Tool
+	if prefix == "" {
+		prefix = "lint"
+	}
+	prefix = ansiLightBlueBold + prefix + ansiReset
+
+	rule := ""
+	if finding.Rule != "" {
+		rule = ansiYellow + finding.Rule + ansiReset
+	}
+
+	message := finding.Message
+	if len(message) > 160 {
+		message = message[:157] + "..."
+	}
+
+	var head string
+	if rule != "" {
+		head = prefix + " " + rule
+	} else {
+		head = prefix
+	}
+	if message == "" {
+		return head + " " + location
+	}
+	return head + " " + location + ": " + message
 }
 
 func (r auditTextRenderer) errors(errors []audit.AuditError) {
@@ -561,4 +641,15 @@ func auditSourceSummary(source audit.SourceFingerprint) string {
 func auditReportPath(projectID, sessionID, runID string) string {
 	root := audit.DefaultStoreRoot(engine.GovardHomeDir())
 	return fmt.Sprintf("%s/%s/sessions/%s/runs/%s/report.json", root, projectID, sessionID, runID)
+}
+
+// FindingColoredStringForTest exposes findingColoredString for hermetic tests.
+func FindingColoredStringForTest(finding audit.LintFinding) string {
+	view := auditLintFindingView{Tool: finding.Tool, Rule: finding.Rule, Path: finding.Path, Line: finding.Line, Column: finding.Column, Message: finding.Message}
+	return findingColoredString(view)
+}
+
+// AuditColorEnabledForTest exposes auditColorEnabled for hermetic tests.
+func AuditColorEnabledForTest(writer io.Writer) bool {
+	return auditColorEnabled(writer)
 }

--- a/tests/audit_command_test.go
+++ b/tests/audit_command_test.go
@@ -690,6 +690,35 @@ func TestAuditUnknownModeIsRejectedWithTheModeVocabulary(t *testing.T) {
 	}
 }
 
+func TestAuditRunStreamsOnlyInTextMode(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		format     string
+		wantStream bool
+	}{
+		{"json stays machine-clean", "json", false},
+		{"text streams live progress like vendor/bin", "text", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := auditCommandProject(t, "magento2")
+			backend := &commandLintBackend{}
+			installAuditCommandDependencies(t, backend)
+			if _, err := executeAuditCommand(t, project, []string{"audit", "run", "--format", tc.format}); err != nil {
+				// Text run with a passing report succeeds; json the same.
+				// A non-nil error here would be a helper failure, not the case under test.
+				t.Fatalf("executeAuditCommand: %v", err)
+			}
+			if len(backend.requests) == 0 {
+				t.Fatalf("lint backend was not invoked")
+			}
+			gotStream := backend.requests[0].StreamWriter != nil
+			if gotStream != tc.wantStream {
+				t.Fatalf("StreamWriter nil=%v, want stream=%v (format %q)", backend.requests[0].StreamWriter == nil, tc.wantStream, tc.format)
+			}
+		})
+	}
+}
+
 func auditRunnerRequestForProvider(t *testing.T, provider string, config *engine.Config) cmd.AuditRunnerRequest {
 	t.Helper()
 	root := t.TempDir()

--- a/tests/audit_output_test.go
+++ b/tests/audit_output_test.go
@@ -1,12 +1,14 @@
 package tests
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	"govard/internal/audit"
+	"govard/internal/cmd"
 )
 
 // textLintBackend reports the configured report for every invocation, so
@@ -201,5 +203,26 @@ func TestAuditCleanupDefaultTextReportsRemovedSessions(t *testing.T) {
 	}
 	if strings.Contains(rendered, "map[removed_sessions:") {
 		t.Fatalf("cleanup text output still dumps the raw map:\n%s", rendered)
+	}
+}
+
+func TestFindingColoredStringContainsANSIAndLocation(t *testing.T) {
+	finding := audit.LintFinding{Tool: "phpcs", Rule: "Magento2.Classes.AbstractApi", Path: "app/code/Acme/Module/Model/Item.php", Line: 42, Column: 5, Message: "AbstractApi sniff violation"}
+	colored := cmd.FindingColoredStringForTest(finding)
+	if !strings.Contains(colored, "\x1b[") {
+		t.Fatalf("colored finding lacks ANSI codes: %q", colored)
+	}
+	for _, want := range []string{"phpcs", "Magento2.Classes.AbstractApi", "app/code/Acme/Module/Model/Item.php:42:5"} {
+		if !strings.Contains(colored, want) {
+			t.Fatalf("colored finding missing %q: %q", want, colored)
+		}
+	}
+	// Non-terminal and NO_COLOR must stay plain
+	if cmd.AuditColorEnabledForTest(&bytes.Buffer{}) {
+		t.Fatalf("bytes.Buffer must not be considered a terminal")
+	}
+	t.Setenv("NO_COLOR", "1")
+	if cmd.AuditColorEnabledForTest(&bytes.Buffer{}) {
+		t.Fatalf("NO_COLOR must disable color even for a terminal-like writer")
 	}
 }


### PR DESCRIPTION
### Summary

Default `govard audit run` now feels like `vendor/bin/phpcs` + `vendor/bin/phpstan`:

- **Streams live progress** — Docker lint logs (phase `validate` → `prepare` → `phpcs`/`phpstan`, cache state, `magelint: php 8.4 analyzed`, and phpcs deprecation warnings) are `MultiWriter`-ed to the terminal as they happen instead of being buffered until the final summary. Text mode (`--format text`, the default) streams; `--format json` stays machine-clean (writer remains `nil`) for AI agents.
- **Colorized findings** — On an interactive TTY with `NO_COLOR` unset, findings render like the native CLIs: bold light-blue tool (`phpcs`/`phpstan`), yellow rule, cyan `path:line:col`, white message. Piped/CI (`| cat`, non-TTY, `NO_COLOR=1`) stays plain and capped at 10; interactive TTY shows every finding (like `vendor/bin`) with the same palette as the existing `PASSED`/`FAILED` status header. The final `What next` report path and `re-run` hint are unchanged.

### What changed

- `internal/audit/lint.go`: `LintRequest.StreamWriter io.Writer` — optional live writer, `nil` for json.
- `internal/audit/runner.go`: `RunRequest.Output` forwarded to `LintRequest.StreamWriter` (single lint job, no concurrency hazard).
- `internal/audit/lint_govard.go` + `lint_external.go`: `docker.Run` output is now `io.MultiWriter(logFile, StreamWriter)` when a stream is present; persisted `govard-lint.log`/`external-lint.log` stays authoritative.
- `internal/cmd/audit.go`: `newAuditRunCommand` sets `Output = cmd.OutOrStdout()` only for text mode; json gets `nil` to avoid polluting machine output.
- `internal/cmd/audit_output.go`: `phpResult` now colors `PHP 8.4 | FAILED | cache warm/colored` and every finding via `findingColoredString` (explicit ANSI, not pterm global, so hermetic tests are deterministic). Plain `String()` is preserved for piped/json. Interactive TTY shows all findings; piped stays capped.
- `tests/audit_output_test.go` / `tests/audit_command_test.go`: new hermetic tests — colored string contains ANSI + location, `NO_COLOR`/non-TTY disables it, and `StreamWriter` is set only for text, not json.

### Test plan

- `go vet` + `gofmt -s` clean; `go test ./tests -count=1` (6s) green.
- Live smoke on `bebe9/app/code/BeBe9/Brand` (Apache, `govard` `1.64.0-beta.3-dirty` branch build):
  - Text: first `DEPRECATED`/`magelint:` line <2s, `== Audit run … ==` summary with 56 findings, `...and 46 more` capped on piped, all findings + ANSI on TTY (`script -q -c "bin/govard audit run"` contains `\x1b[36m`/`\x1b[33m`).
  - Json: `bin/govard audit run --format json > out.json 2> err` → `python3 -m json.tool out.json` valid, no log prefix, no ANSI.
  - Piped: `bin/govard audit run --format text | cat -v` contains no `\x1b[`; `| cat` still preserves cap.
  - Previous `bebe9` module audit (56 findings, `module_in_project`) remains byte-identical in persisted `report.json`.

### Follow-up (not in this PR)

Per-finding NDJSON streaming from the `magelint` image (so each finding appears the instant phpcs/phpstan emits it, not just phase logs) requires adding a `GOVARD_LINT_STREAM` env + `phpcs --report=full` alongside `json` in `docker/audit-magento/bin/magelint` and a host-side NDJSON parser. This PR's host-side plumbing (`StreamWriter` + `MultiWriter` + colored rendering) is the prerequisite and already delivers the requested TTY experience for the current image.

Closes the UX gap reported for `govard audit run` default mode while keeping `--format json` pristine for agents.

