### PR TITLE
docs(audit): describe streaming text output and json for AI agents

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -70,18 +70,24 @@ govard audit cleanup --older-than 168h
 ```
 
 `run` defaults to `--scope project`, `--checks lint`, `--lint-provider govard`,
-`--mode auto`, and `--lint-jobs 2`. The default `text` format prints a compact
+`--mode auto`, and `--lint-jobs 2`. The default `text` format streams live
+progress like `vendor/bin/phpcs`/`vendor/bin/phpstan` — phase `validate` →
+`prepare` → `phpcs`/`phpstan`, cache state (`cold`/`warm`/`bypassed`), and
+`magelint: php X.Y analyzed` appear as they happen — then prints a compact
 human-readable summary: the verdict first (PASSED/FAILED/CANCELLED), then scope,
-duration, environment, per-PHP results with cache state and up to ten findings,
-plus next-step hints pointing at the persisted report and the exact rerun
-command. A completed run whose checks did not pass (failed or cancelled) still
-prints its summary and then exits non-zero, so scripts and CI observe the
-outcome. Color is applied only on an interactive terminal (`NO_COLOR` disables
-it), so piped or redirected output stays free of escape codes.
-`--format json` writes one undecorated JSON object to stdout; diagnostics and
-backend logs remain out of that stream. Only `text` and `json` formats are
-accepted, and `--lint-jobs` must be between 1 and
-the number of PHP versions declared by the framework.
+duration, environment, per-PHP results with cache state and findings, plus
+next-step hints pointing at the persisted report and the exact rerun command. On
+an interactive TTY (and when `NO_COLOR` is unset) findings are colorized (tool
+bold light-blue, rule yellow, `path:line:col` cyan) and every finding is shown
+like the native CLIs; when piped or redirected the output stays plain and is
+capped at ten findings (`... and N more`) to keep CI logs readable. A completed
+run whose checks did not pass (failed or cancelled) still prints its summary
+and then exits non-zero, so scripts and CI observe the outcome.
+`--format json` writes one undecorated JSON object to stdout for AI agents;
+diagnostics, backend logs, and the `ERROR audit run … reported failed checks`
+exit hint remain on stderr or in the persisted `govard-lint.log`. Only `text`
+and `json` formats are accepted, and `--lint-jobs` must be between 1 and the
+number of PHP versions declared by the framework.
 
 `profiler` requires an explicit absolute HTTP(S) `--url` on the first run and a
 whole Govard project target (standalone modules and module-only targets are

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -72,16 +72,21 @@ govard audit cleanup --older-than 168h
 
 `run` mặc định dùng `--scope project`, `--checks lint`,
 `--lint-provider govard`, `--mode auto` và `--lint-jobs 2`. Format mặc định
-`text` in một bản tóm tắt dễ đọc: kết luận trước tiên (PASSED/FAILED/CANCELLED),
-tiếp theo là scope, thời gian chạy, môi trường, kết quả từng PHP kèm cache state
-và tối đa mười finding, cùng gợi ý lệnh kế tiếp trỏ tới report đã lưu và đúng
-lệnh rerun. Một run hoàn tất nhưng check không pass (failed hoặc cancelled) vẫn
-in đầy đủ bản tóm tắt rồi mới thoát với exit code khác 0, để script và CI nhận
-biết được kết quả. Màu chỉ được áp dụng trên terminal tương tác (`NO_COLOR` tắt
-hẳn), nên output khi pipe hay redirect không dính escape code.
-`--format json` chỉ ghi một JSON object không có terminal decoration ra stdout;
-diagnostic và log backend nằm ngoài stream đó. Chỉ chấp nhận `text`/`json`;
-`--lint-jobs` phải từ 1 đến số PHP version được framework khai báo.
+`text` stream tiến trình trực tiếp như `vendor/bin/phpcs`/`vendor/bin/phpstan` —
+giai đoạn `validate` → `prepare` → `phpcs`/`phpstan`, trạng thái cache
+(`cold`/`warm`/`bypassed`) và `magelint: php X.Y analyzed` hiện ngay khi chạy —
+rồi mới in bản tóm tắt: kết luận trước (PASSED/FAILED/CANCELLED), scope, thời
+gian, môi trường, kết quả từng PHP kèm findings và gợi ý `What next` trỏ tới
+report đã lưu cùng lệnh rerun chính xác. Trên TTY tương tác (và khi chưa đặt
+`NO_COLOR`) findings được tô màu (tool xanh nhạt đậm, rule vàng,
+`path:line:col` cyan) và hiện toàn bộ như CLI gốc; khi pipe/redirect thì giữ
+plain và chỉ hiện tối đa mười finding (`... and N more`) để log CI gọn. Một run
+hoàn tất nhưng check không pass (failed/cancelled) vẫn in tóm tắt rồi mới thoát
+khác 0 để script/CI nhận biết được. `--format json` chỉ ghi một JSON object
+không decoration ra stdout cho AI Agents; diagnostic, log backend và dòng
+`ERROR audit run … reported failed checks` nằm ở stderr hoặc `govard-lint.log`
+đã lưu. Chỉ chấp nhận `text`/`json`; `--lint-jobs` phải từ 1 đến số PHP version
+framework khai báo.
 
 `profiler` yêu cầu `--url` tuyệt đối HTTP(S) tường minh ở run đầu tiên và target
 phải là toàn bộ Govard project (standalone module lẫn module-only target đều bị


### PR DESCRIPTION
### Summary

Follow-up to #171 — document the new `govard audit run` output contract.

**En** (`docs/reference/cli-commands.md`) and **vi** (`docs/vi/reference/cli-commands.md`):
- Text streams live progress like `vendor/bin/phpcs`/`phpstan` (phase `validate` → `prepare` → `phpcs`/`phpstan`, cache `cold`/`warm`/`bypassed`, `magelint: php X.Y analyzed`) then summary.
- On interactive TTY (`NO_COLOR` unset) findings are colorized (tool bold light-blue, rule yellow, `path:line:col` cyan) and uncapped (all 56 findings like native CLIs); piped/CI stays plain and capped at 10 (`... and N more`).
- `--format json` is explicitly a single undecorated object on stdout for AI agents; diagnostics and `ERROR audit run …` remain on stderr / `govard-lint.log`.

No code change — `README.md` and `CHANGELOG.md` intentionally unchanged per release policy (changelog only on stable release commit). Wiki sync (`sync-wiki.yml`) will pick up the markdown on next `master` push.

Closes docs gap flagged after 6ffd029.
