### PR TITLE
ci(govard): add github actions via shared reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    uses: ddtcorex/.github/.github/workflows/go-lib.yml@main


### PR DESCRIPTION
Go-side pilot for the org-wide CI rollout.