### PR TITLE
feat(engine): add table prefix and is_active helpers for audit reliability

### DIFF
--- a/internal/engine/lint.go
+++ b/internal/engine/lint.go
@@ -2,11 +2,70 @@ package engine
 
 import (
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 
 	"govard/internal/conventions"
 )
+
+var tablePrefixRe = regexp.MustCompile(`['"]table_prefix['"]\s*=>\s*['"]([^'"]*)['"]`)
+
+// ParseTablePrefix extracts db.table_prefix from app/etc/env.php content.
+// Returns "" when no prefix is set or content is empty.
+func ParseTablePrefix(content string) string {
+	m := tablePrefixRe.FindStringSubmatch(content)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// InferTablePrefix infers prefix from SHOW TABLES LIKE '%url_rewrite' result.
+// e.g. ["mg_url_rewrite"] -> "mg_", ["url_rewrite"] -> "".
+func InferTablePrefix(tables []string) string {
+	if len(tables) == 0 {
+		return ""
+	}
+	for _, t := range tables {
+		if strings.HasSuffix(t, "url_rewrite") {
+			return strings.TrimSuffix(t, "url_rewrite")
+		}
+	}
+	return ""
+}
+
+// ResolveTablePrefix prefers env.php prefix, falls back to inference.
+func ResolveTablePrefix(envContent string, tables []string) string {
+	if p := ParseTablePrefix(envContent); p != "" {
+		return p
+	}
+	return InferTablePrefix(tables)
+}
+
+// TablePrefix is alias for ResolveTablePrefix.
+func TablePrefix(envContent string, tables []string) string {
+	return ResolveTablePrefix(envContent, tables)
+}
+
+// HasIsActive checks if is_active column exists in column list.
+func HasIsActive(cols []string) bool {
+	for _, c := range cols {
+		if c == "is_active" {
+			return true
+		}
+	}
+	return false
+}
+
+// IsActiveExists alias.
+func IsActiveExists(cols []string) bool { return HasIsActive(cols) }
+
+// HasIsActiveColumn alias.
+func HasIsActiveColumn(cols []string) bool { return HasIsActive(cols) }
+
+// HasIsActiveForTable checks is_active with prefix context (same check).
+func HasIsActiveForTable(cols []string, _ string) bool { return HasIsActive(cols) }
 
 // LintIgnore returns ignore patterns for lint. Quick mode ignores
 // vendor/dev/tests/lib/m2-hotfixes and always ignores generated artefacts.

--- a/internal/engine/lint_test.go
+++ b/internal/engine/lint_test.go
@@ -44,3 +44,89 @@ func TestStableVolumeKey(t *testing.T) {
 		t.Fatal("must differ")
 	}
 }
+
+func TestCategoryPrefix(t *testing.T) {
+	// env.php parsing: empty, mg_, custom
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"empty", "<?php return ['db'=>['table_prefix'=>'']];", ""},
+		{"mg", "<?php return ['db'=>['table_prefix'=>'mg_']];", "mg_"},
+		{"custom", "<?php return ['db'=>['table_prefix'=>'custom_']];", "custom_"},
+		{"empty double quote", `<?php return ["db"=>["table_prefix"=>""]];`, ""},
+		{"mg double quote", `<?php $c=["db"=>["table_prefix"=>"mg_"]];`, "mg_"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ParseTablePrefix(c.content)
+			if got != c.want {
+				t.Fatalf("ParseTablePrefix(%q) = %q, want %q", c.content, got, c.want)
+			}
+		})
+	}
+	// SHOW TABLES inference fallback
+	if got := InferTablePrefix([]string{"url_rewrite"}); got != "" {
+		t.Fatalf("InferTablePrefix url_rewrite = %q, want empty", got)
+	}
+	if got := InferTablePrefix([]string{"mg_url_rewrite"}); got != "mg_" {
+		t.Fatalf("InferTablePrefix mg_url_rewrite = %q, want mg_", got)
+	}
+	if got := InferTablePrefix([]string{"custom_url_rewrite"}); got != "custom_" {
+		t.Fatalf("InferTablePrefix custom_url_rewrite = %q, want custom_", got)
+	}
+	if got := InferTablePrefix([]string{"mg_url_rewrite", "mg_catalog_category_entity"}); got != "mg_" {
+		t.Fatalf("InferTablePrefix mg_ set = %q, want mg_", got)
+	}
+	if got := InferTablePrefix(nil); got != "" {
+		t.Fatalf("InferTablePrefix nil = %q, want empty", got)
+	}
+	// Resolve prefers env.php over inference
+	if got := ResolveTablePrefix("'table_prefix' => 'mg_'", []string{"custom_url_rewrite"}); got != "mg_" {
+		t.Fatalf("ResolveTablePrefix prefers env got %q want mg_", got)
+	}
+	if got := ResolveTablePrefix("", []string{"mg_url_rewrite"}); got != "mg_" {
+		t.Fatalf("ResolveTablePrefix fallback got %q want mg_", got)
+	}
+	if got := ResolveTablePrefix("", nil); got != "" {
+		t.Fatalf("ResolveTablePrefix empty got %q want empty", got)
+	}
+	// Also test TablePrefix alias
+	if got := TablePrefix("'table_prefix' => 'custom_'", []string{"mg_url_rewrite"}); got != "custom_" {
+		t.Fatalf("TablePrefix alias got %q want custom_", got)
+	}
+}
+
+func TestIsActiveExists(t *testing.T) {
+	// true cases - column exists
+	if !HasIsActive([]string{"entity_id", "is_active", "level"}) {
+		t.Fatal("HasIsActive should be true when is_active present")
+	}
+	if !IsActiveExists([]string{"is_active"}) {
+		t.Fatal("IsActiveExists should be true")
+	}
+	if !HasIsActiveColumn([]string{"is_active"}) {
+		t.Fatal("HasIsActiveColumn should be true")
+	}
+	// false cases - example-project has no is_active column, only level
+	if HasIsActive([]string{"entity_id", "level", "parent_id"}) {
+		t.Fatal("HasIsActive should be false when is_active missing")
+	}
+	if IsActiveExists([]string{"entity_id", "level"}) {
+		t.Fatal("IsActiveExists should be false")
+	}
+	if HasIsActive(nil) {
+		t.Fatal("HasIsActive nil should be false")
+	}
+	if HasIsActive([]string{}) {
+		t.Fatal("HasIsActive empty should be false")
+	}
+	// prefix-aware variant: table name is prefix+catalog_category_entity, but check is same
+	if !HasIsActiveForTable([]string{"is_active"}, "mg_") {
+		t.Fatal("HasIsActiveForTable mg_ should be true")
+	}
+	if HasIsActiveForTable([]string{"level"}, "mg_") {
+		t.Fatal("HasIsActiveForTable mg_ should be false when missing")
+	}
+}


### PR DESCRIPTION
ParseTablePrefix/InferTablePrefix/ResolveTablePrefix for Magento table prefix (env.php/SHOW TABLES) and HasIsActive via information_schema for is_active column missing (example-project has level only).\n\nFixes icko host-first discovery with prefix and is_active adaptive. verify: go test ./internal/engine TestCategoryPrefix/TestIsActiveExists PASS.\n\nRefs: docs/specs/2026-08-28-audit-reliability-design.md