### PR TITLE
chore: restore ci-pipeline.yml self-managed pipeline

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Govard CI Pipeline
 
 on:
   push:


### PR DESCRIPTION
Restore Govard CI Pipeline as self-managed `ci-pipeline.yml` (from pre-#179) and remove merged `ci.yml` that depended on reusable `go-lib`. Govard now fully owns its pipeline (quality_checks, fast_tests, integration_tests, build_binaries + verify gate) without `dsh-maestro-ci`.

- `ci.yml` → `ci-pipeline.yml` (rename, name: Govard CI Pipeline)
- Badge in README now matches workflow file again
- No longer uses `ddtcorex/dsh-maestro-ci/go-lib.yml`

Related: ddtcorex/dsh-maestro-ci#7 removes go-lib.yml.