### PR TITLE
chore: sync community files, CHANGELOG and checklist fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,3 +187,4 @@ Update `docs/*.md` for: command names/aliases/flags, config behavior, remote/syn
 3. Command help/flags still coherent
 4. `README.md` and relevant `docs/*.md` updated for user-visible changes
 5. `git status` reviewed for unintended file changes
+- **Always request approval before merge or release:** never merge a PR/MR or publish a release (`git tag`/`pnpm publish`/`gh release`) without an explicit human approval — request review (`gh pr ready` / `gh pr request-review` / ask in chat) and wait for `APPROVED`.


### PR DESCRIPTION
Sync per docs/PUBLIC_REPO_CHECKLIST.md 9 sections (Docs workspace-root-only + Approval before merge/release).

- CHANGELOG.md added where missing
- AGENTS.md: Always request approval before merge/release
- ISSUE_TEMPLATE bug/feature: fix maestro-skills copy-paste (remote/supervisor)
- Supervisor docs/superpowers migrated to workspace root docs/specs|plans
- Verified: pnpm verify/build where needed, blacklist 0 hits, hooks 18/18

Refs: AGENTS.md Workflow Rules, Git Rules, docs/PUBLIC_REPO_CHECKLIST.md
Approval: human approved via chat 'ok merge hết đi' on 2026-08-28.
