### PR TITLE
fix: resolve 8 fresh-install and DX issues (185-192)

### DIFF
--- a/docs/reference/frameworks.md
+++ b/docs/reference/frameworks.md
@@ -59,14 +59,21 @@ Govard detects supported frameworks and applies runtime defaults plus version-aw
 
 | Framework | Version | PHP Override | Other |
 | :--- | :--- | :--- | :--- |
-| Laravel | 10 | 8.2 | |
+| Laravel | 10 | 8.1 | |
 | Laravel | 11 | 8.3 | |
 | Laravel | 12 | 8.4 | |
-| Symfony | 6 | 8.2 | |
-| Symfony | 7 | 8.3 | |
+| Symfony | 6.0-6.3 | 8.1 | |
+| Symfony | 6.4+ | 8.2 | |
+| Symfony | 7.0-7.1 | 8.2 | |
+| Symfony | 7.2+ | 8.3 | |
 | Drupal | 10 | 8.3 | |
 | Drupal | 11 | 8.4 | |
-| WordPress | 6 | 8.3 | |
+| WordPress | 6.0 | 8.0 | MariaDB 10.6 |
+| WordPress | 6.3 | 8.1 | MariaDB 10.6 |
+| WordPress | 6.4-6.5 | 8.2 | MariaDB 10.11 |
+| WordPress | 6.6+ | 8.3 | MariaDB 10.11 |
+| WordPress | 6 (bare) | 8.3 | MariaDB 10.11 — bare major resolves to latest minor (6.6+) |
+| WordPress | 7 | 8.4 | MariaDB 11.4 |
 | Magento 2 | 2.4.9+ | 8.4 | MariaDB 11.4, Redis 7.2, OpenSearch 3.0.0, RabbitMQ 4.1.0 |
 | Magento 2 | 2.4.8 | 8.4 | MariaDB 11.4, Redis 7.2, OpenSearch 2.19.0 or 3.0.0 |
 | Magento 2 | 2.4.7 | 8.3 | MariaDB 10.6 or 10.11, Redis 7.2, OpenSearch 2.12.0-2.19.0 |

--- a/docs/vi/reference/frameworks.md
+++ b/docs/vi/reference/frameworks.md
@@ -59,14 +59,21 @@ Ký hiệu `—` nghĩa là Govard không ép buộc giá trị mặc định ch
 
 | Framework | Phiên bản | Ghi đè PHP | Khác |
 | :--- | :--- | :--- | :--- |
-| Laravel | 10 | 8.2 | |
+| Laravel | 10 | 8.1 | |
 | Laravel | 11 | 8.3 | |
 | Laravel | 12 | 8.4 | |
-| Symfony | 6 | 8.2 | |
-| Symfony | 7 | 8.3 | |
+| Symfony | 6.0-6.3 | 8.1 | |
+| Symfony | 6.4+ | 8.2 | |
+| Symfony | 7.0-7.1 | 8.2 | |
+| Symfony | 7.2+ | 8.3 | |
 | Drupal | 10 | 8.3 | |
 | Drupal | 11 | 8.4 | |
-| WordPress | 6 | 8.3 | |
+| WordPress | 6.0 | 8.0 | MariaDB 10.6 |
+| WordPress | 6.3 | 8.1 | MariaDB 10.6 |
+| WordPress | 6.4-6.5 | 8.2 | MariaDB 10.11 |
+| WordPress | 6.6+ | 8.3 | MariaDB 10.11 |
+| WordPress | 6 (bare) | 8.3 | MariaDB 10.11 — bare major resolves to latest minor (6.6+) |
+| WordPress | 7 | 8.4 | MariaDB 11.4 |
 | Magento 2 | 2.4.9+ | 8.4 | MariaDB 11.4, Redis 7.2, OpenSearch 3.0.0, RabbitMQ 4.1.0 |
 | Magento 2 | 2.4.8 | 8.4 | MariaDB 11.4, Redis 7.2, OpenSearch 2.19.0 hoặc 3.0.0 |
 | Magento 2 | 2.4.7 | 8.3 | MariaDB 10.6 hoặc 10.11, Redis 7.2, OpenSearch 2.12.0-2.19.0 |

--- a/internal/cmd/audit_target.go
+++ b/internal/cmd/audit_target.go
@@ -37,7 +37,7 @@ func resolveAuditTarget(ctx context.Context, start string, mode types.AuditTarge
 		return resolvedAuditTarget{}, err
 	}
 	if definition.AuditLint == nil {
-		return resolvedAuditTarget{}, fmt.Errorf("framework %q does not support lint audit", definition.Name)
+		return resolvedAuditTarget{}, fmt.Errorf("framework %q does not support lint audit (use govard tool php vendor/bin/phpcs, vendor/bin/phpstan or vendor/bin/pint directly)", definition.Name)
 	}
 
 	root := target.TargetPath
@@ -89,7 +89,7 @@ func resolveAuditTarget(ctx context.Context, start string, mode types.AuditTarge
 
 func resolveAuditPHPVersions(target types.AuditTarget, profile *types.AuditLintProfile, config *engine.Config, requested []string) ([]string, bool, error) {
 	if profile == nil {
-		return nil, false, fmt.Errorf("framework %q does not support lint audit", target.Framework)
+		return nil, false, fmt.Errorf("framework %q does not support lint audit (use govard tool php vendor/bin/phpcs, vendor/bin/phpstan or vendor/bin/pint directly)", target.Framework)
 	}
 	if target.Mode != types.AuditTargetStandalone {
 		if config == nil {

--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"govard/internal/conventions"
 	"govard/internal/engine"
@@ -11,12 +12,39 @@ import (
 )
 
 var shellCmd = &cobra.Command{
-	Use:                "shell",
-	Aliases:            []string{"sh"},
-	Short:              "Enter the application container",
+	Use:     "shell [-c <command>] [--] [args...]",
+	Aliases: []string{"sh"},
+	Short:   "Enter the application container",
+	Long: `Enter the application container interactively, or execute a command inside it.
+
+Without arguments, starts an interactive bash session.
+
+With -c/--command, executes the given command string via bash -c:
+
+  govard shell -c "printenv | grep APP_ENV"
+  govard shell --command "php artisan --version"
+
+Without -c, remaining arguments are joined and executed via bash -c:
+
+  govard shell php artisan --version
+  govard shell ls -la /var/www
+
+Pass -- to disambiguate flags:
+
+  govard shell -- -c "echo hi"`,
+	Example: `  govard shell
+  govard shell -c "echo hi"
+  govard shell -- -c "echo hi"
+  govard shell echo hi
+  govard shell ls -la
+  govard shell -c "printenv | grep -E 'APP_ENV|DATABASE_URL'"`,
 	DisableFlagParsing: true,
 	SilenceUsage:       true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Strip leading -- used to separate govard flags from shell command.
+		if len(args) > 0 && args[0] == "--" {
+			args = args[1:]
+		}
 		if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
 			return cmd.Help()
 		}
@@ -29,15 +57,52 @@ var shellCmd = &cobra.Command{
 			coloredPS1 := "\\[\\033[01;36m\\]\\u@\\h\\[\\033[00m\\]:\\w\\$ "
 			bashCmd := fmt.Sprintf("export PS1='%s'; exec bash", coloredPS1)
 			err = RunInContainerAt(containerName, user, workdir, "bash", []string{"-c", bashCmd})
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				code := exitErr.ExitCode()
+				if code == 126 || code == 127 {
+					err = RunInContainerAt(containerName, user, workdir, "sh", []string{"-c", bashCmd})
+				}
+			}
+		} else if args[0] == "-c" || args[0] == "--command" || strings.HasPrefix(args[0], "--command=") || strings.HasPrefix(args[0], "-c=") {
+			var commandStr string
+			if args[0] == "-c" || args[0] == "--command" {
+				if len(args) < 2 || strings.TrimSpace(args[1]) == "" {
+					return fmt.Errorf("flag -c requires an argument")
+				}
+				if len(args) > 2 {
+					commandStr = args[1] + " " + strings.Join(args[2:], " ")
+				} else {
+					commandStr = args[1]
+				}
+			} else if strings.HasPrefix(args[0], "--command=") {
+				commandStr = strings.TrimPrefix(args[0], "--command=")
+				if len(args) > 1 {
+					commandStr += " " + strings.Join(args[1:], " ")
+				}
+			} else { // -c=
+				commandStr = strings.TrimPrefix(args[0], "-c=")
+				if len(args) > 1 {
+					commandStr += " " + strings.Join(args[1:], " ")
+				}
+			}
+			if strings.TrimSpace(commandStr) == "" {
+				return fmt.Errorf("flag -c requires an argument")
+			}
+			err = RunInContainerAt(containerName, user, workdir, "bash", []string{"-c", commandStr})
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				code := exitErr.ExitCode()
+				if code == 126 || code == 127 {
+					err = RunInContainerAt(containerName, user, workdir, "sh", []string{"-c", commandStr})
+				}
+			}
 		} else {
-			err = RunInContainerAt(containerName, user, workdir, "bash", args)
-		}
-
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			code := exitErr.ExitCode()
-			if code == 126 || code == 127 {
-				// bash not found or not executable — try sh
-				err = RunInContainerAt(containerName, user, workdir, "sh", args)
+			commandStr := strings.Join(args, " ")
+			err = RunInContainerAt(containerName, user, workdir, "bash", []string{"-c", commandStr})
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				code := exitErr.ExitCode()
+				if code == 126 || code == 127 {
+					err = RunInContainerAt(containerName, user, workdir, "sh", []string{"-c", commandStr})
+				}
 			}
 		}
 

--- a/internal/cmd/test_project.go
+++ b/internal/cmd/test_project.go
@@ -6,6 +6,8 @@ import (
 	"govard/internal/engine"
 	"govard/internal/frameworks"
 	"govard/internal/frameworks/types"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pterm/pterm"
@@ -58,12 +60,58 @@ func runPHPUnit(config engine.Config, args []string) error {
 	pterm.NewStyle(pterm.BgLightBlue, pterm.FgBlack, pterm.Bold).Println(" Running PHPUnit Tests ")
 	fmt.Println()
 	binaryPath := "vendor/bin/phpunit"
-	// We check for binaryPath but we use it in RunInContainer
+	if hasConfigFlag(args) {
+		cmdArgs := []string{"-d", "memory_limit=-1", binaryPath}
+		cmdArgs = append(cmdArgs, args...)
+		err := RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), "php", cmdArgs)
+		if err != nil {
+			if hinted := hintMissingTestBinary(err, "phpunit", binaryPath, "composer require --dev phpunit/phpunit (Laravel Pest users: composer require --dev pestphp/pest)"); hinted != err {
+				return hinted
+			}
+			return fmt.Errorf("phpunit failed: %w\nHint: If you see \"Trait \\\"Magento\\Framework\\TestFramework\\Unit\\Helper\\MockCreationTrait\\\" not found\", run composer install and bin/magento setup:di:compile (or ensure dev/tests/unit/framework autoload is available)", err)
+		}
+		return nil
+	}
+
+	// No explicit -c: Magento projects keep their unit config only as a
+	// .dist file on fresh checkout (dev/tests/unit/phpunit.xml.dist). A
+	// plain `vendor/bin/phpunit` therefore shows help / "Available test
+	// suite(s):" empty. Detect via host file probe and retry with fallback.
+	projectRoot := findProjectRootForTest()
+	fallbackChosen := ""
+	if pathExists(filepath.Join(projectRoot, "dev/tests/unit/phpunit.xml")) {
+		fallbackChosen = "dev/tests/unit/phpunit.xml"
+	} else if pathExists(filepath.Join(projectRoot, "dev/tests/unit/phpunit.xml.dist")) {
+		fallbackChosen = "dev/tests/unit/phpunit.xml.dist"
+	}
+	hasRootPHPUnit := pathExists(filepath.Join(projectRoot, "phpunit.xml")) || pathExists(filepath.Join(projectRoot, "phpunit.xml.dist"))
+	if fallbackChosen != "" && !hasRootPHPUnit {
+		pterm.Info.Printf("No -c provided and no phpunit.xml found at project root; using fallback -c %s\n", fallbackChosen)
+		cmdArgs := []string{"-d", "memory_limit=-1", binaryPath, "-c", fallbackChosen}
+		cmdArgs = append(cmdArgs, args...)
+		err := RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), "php", cmdArgs)
+		if err != nil {
+			if hinted := hintMissingTestBinary(err, "phpunit", binaryPath, "composer require --dev phpunit/phpunit (Laravel Pest users: composer require --dev pestphp/pest)"); hinted != err {
+				return hinted
+			}
+			return fmt.Errorf("phpunit failed with fallback -c %s: %w\nHint: Trait \"Magento\\Framework\\TestFramework\\Unit\\Helper\\MockCreationTrait\" not found usually means missing generated code — run composer install and bin/magento setup:di:compile, or ensure dev/tests/unit/framework autoload is available. No suites? Verify %s exists and lists suites via: govard tool php -d memory_limit=-1 vendor/bin/phpunit -c %s --list-suites", fallbackChosen, err, fallbackChosen, fallbackChosen)
+		}
+		return nil
+	}
 
 	cmdArgs := []string{"-d", "memory_limit=-1", binaryPath}
 	cmdArgs = append(cmdArgs, args...)
-
-	return RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), "php", cmdArgs)
+	err := RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), "php", cmdArgs)
+	if err != nil {
+		if hinted := hintMissingTestBinary(err, "phpunit", binaryPath, "composer require --dev phpunit/phpunit (Laravel Pest users: composer require --dev pestphp/pest)"); hinted != err {
+			return hinted
+		}
+		if fallbackChosen != "" {
+			return fmt.Errorf("phpunit failed (no test suites / help shown): %w\nHint: Try govard test unit -- -c %s or ensure phpunit.xml exists at project root", err, fallbackChosen)
+		}
+		return fmt.Errorf("phpunit failed (no test suites found — try -c dev/tests/unit/phpunit.xml.dist or ensure phpunit.xml exists): %w", err)
+	}
+	return nil
 }
 
 func runPHPStan(config engine.Config, args []string) error {
@@ -80,7 +128,43 @@ func runPHPStan(config engine.Config, args []string) error {
 		cmdArgs = append(cmdArgs, "app", "src")
 	}
 
-	return RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), "php", cmdArgs)
+	err := RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), "php", cmdArgs)
+	if err != nil {
+		if hinted := hintMissingTestBinary(err, "phpstan", binaryPath, "composer require --dev phpstan/phpstan"); hinted != err {
+			return hinted
+		}
+		return err
+	}
+	return nil
+}
+
+// hintMissingTestBinary wraps a container-exec error with an actionable hint when the
+// project's vendor binary is absent.
+func hintMissingTestBinary(origErr error, name, binaryPath, installHint string) error {
+	if origErr == nil {
+		return nil
+	}
+	msg := origErr.Error()
+	missingHints := []string{"No such file", "not found", "could not open input file", binaryPath, "phpstan", "phpunit", "pest"}
+	missing := false
+	for _, h := range missingHints {
+		if strings.Contains(strings.ToLower(msg), strings.ToLower(h)) {
+			if wd, err := os.Getwd(); err == nil {
+				if _, statErr := os.Stat(filepath.Join(wd, binaryPath)); os.IsNotExist(statErr) {
+					missing = true
+					break
+				}
+			}
+			if strings.Contains(msg, binaryPath) {
+				missing = true
+				break
+			}
+		}
+	}
+	if !missing {
+		return origErr
+	}
+	return fmt.Errorf("%w\n\nHint: %s is not installed in this project (missing %s). Install it with:\n  %s", origErr, name, binaryPath, installHint)
 }
 
 func runMFTF(config engine.Config, args []string) error {
@@ -101,8 +185,28 @@ func runFrameworkTestSuite(config engine.Config, suite string, args []string) er
 		pterm.NewStyle(pterm.BgLightBlue, pterm.FgBlack, pterm.Bold).Println(" Running " + command.Label + " ")
 		fmt.Println()
 	}
+	// For integration, the framework command embeds "-c dev/tests/integration/phpunit.xml".
+	// Fresh Magento only has phpunit.xml.dist and install-config-mysql.php.dist.
+	// Probe host files and rewrite the config path to the available fallback, and
+	// emit hints for missing install-config-mysql.php.
+	if suite == "integration" {
+		command.Args = resolveIntegrationArgs(command.Args, args)
+		if hint := integrationConfigHint(findProjectRootForTest()); hint != "" {
+			pterm.Warning.Println(hint)
+		}
+		commandArgs := append(append([]string(nil), command.Args...), args...)
+		err := RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), command.Binary, commandArgs)
+		if err != nil {
+			return fmt.Errorf("integration tests failed: %w\nHint: %s", err, integrationFailureHint(findProjectRootForTest()))
+		}
+		return nil
+	}
 	commandArgs := append(append([]string(nil), command.Args...), args...)
-	return RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), command.Binary, commandArgs)
+	err := RunInContainer(config.ProjectName+conventions.PHPSuffix, ResolveProjectExecUser(config, conventions.UserWWWData), command.Binary, commandArgs)
+	if err != nil {
+		return fmt.Errorf("%s tests failed: %w", suite, err)
+	}
+	return nil
 }
 
 func frameworkTestCommand(framework string, suite string) (types.TestCommand, bool) {
@@ -133,4 +237,78 @@ func runInPHPContainer(config engine.Config, binary string, args []string) error
 	user := ResolveProjectExecUser(config, conventions.UserWWWData)
 
 	return RunInContainer(containerName, user, binary, args)
+}
+
+// hasConfigFlag reports whether args already specify a phpunit config.
+func hasConfigFlag(args []string) bool {
+	for _, a := range args {
+		if a == "-c" || a == "--configuration" || strings.HasPrefix(a, "-c=") || strings.HasPrefix(a, "--configuration=") {
+			return true
+		}
+	}
+	return false
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func findProjectRootForTest() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if pathExists(filepath.Join(dir, ".govard.yml")) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return wd
+		}
+	}
+}
+
+func resolveIntegrationArgs(baseArgs []string, userArgs []string) []string {
+	if hasConfigFlag(userArgs) {
+		return baseArgs
+	}
+	for i := 0; i < len(baseArgs)-1; i++ {
+		if baseArgs[i] == "-c" {
+			original := baseArgs[i+1]
+			projectRoot := findProjectRootForTest()
+			if !pathExists(filepath.Join(projectRoot, original)) && pathExists(filepath.Join(projectRoot, original+".dist")) {
+				pterm.Info.Printf("Integration config %s not found; using fallback %s.dist\n", original, original)
+				baseArgs[i+1] = original + ".dist"
+			} else if !pathExists(filepath.Join(projectRoot, original)) {
+				if pathExists(filepath.Join(projectRoot, "dev/tests/integration/phpunit.xml.dist")) {
+					pterm.Info.Printf("Integration config %s not found; using fallback dev/tests/integration/phpunit.xml.dist\n", original)
+					baseArgs[i+1] = "dev/tests/integration/phpunit.xml.dist"
+				}
+			}
+			break
+		}
+	}
+	return baseArgs
+}
+
+func integrationConfigHint(projectRoot string) string {
+	php := filepath.Join(projectRoot, "dev/tests/integration/etc/install-config-mysql.php")
+	dist := php + ".dist"
+	if !pathExists(php) && pathExists(dist) {
+		return fmt.Sprintf("Missing %s — copy %s to %s and create database magento_integration_tests (see dev/tests/integration/etc/install-config-mysql.php.dist)", php, dist, php)
+	}
+	if !pathExists(php) && !pathExists(dist) {
+		return ""
+	}
+	return ""
+}
+
+func integrationFailureHint(projectRoot string) string {
+	hint := "If install-config-mysql.php is missing, copy dev/tests/integration/etc/install-config-mysql.php.dist to install-config-mysql.php and create database magento_integration_tests. For phpunit config, use -c dev/tests/integration/phpunit.xml or .dist"
+	if h := integrationConfigHint(projectRoot); h != "" {
+		return h + " | " + hint
+	}
+	return hint
 }

--- a/internal/engine/config_normalize.go
+++ b/internal/engine/config_normalize.go
@@ -12,10 +12,16 @@ func NormalizeConfig(config *Config, root string) {
 	}
 
 	normalizeBlueprintRegistryConfig(&config.BlueprintRegistry)
-	normalizeAuditConfig(&config.Audit)
-	config.StoreDomains = normalizeStoreDomainMappings(config.StoreDomains)
-
 	config.Framework = NormalizeFrameworkAlias(config.Framework)
+	normalizeAuditConfig(&config.Audit)
+	// Frameworks without a lint profile (e.g. symfony, laravel) must not
+	// carry a default audit.lint.provider that promises a non-existent gate.
+	// Clearing it here prevents govard init/bootstrap from writing
+	// audit.lint.provider: govard for those frameworks.
+	if !FrameworkSupportsAuditLint(config.Framework) {
+		config.Audit.Lint.Provider = ""
+	}
+	config.StoreDomains = normalizeStoreDomainMappings(config.StoreDomains)
 	config.TablePrefix = NormalizeTablePrefix(config.TablePrefix)
 	if config.TablePrefix == "" && root != "" {
 		config.TablePrefix = DetectFrameworkTablePrefix(root, config.Framework)

--- a/internal/engine/config_persist.go
+++ b/internal/engine/config_persist.go
@@ -113,6 +113,21 @@ func PrepareConfigForWrite(config Config) Config {
 		}
 	}
 
+	// Do not persist a default audit.lint.provider for frameworks that do
+	// not implement audit lint. This prevents bootstrap/init from writing
+	// audit.lint.provider: govard for Symfony/Laravel where audit run would
+	// otherwise promise a gate that immediately fails with "no framework can
+	// resolve audit target".
+	if !FrameworkSupportsAuditLint(writable.Framework) {
+		writable.Audit.Lint.Provider = ""
+		if len(writable.Audit.Lint.ExternalProviders) == 0 {
+			writable.Audit.Lint.ExternalProviders = nil
+		}
+		if writable.Audit.Lint.Provider == "" && writable.Audit.Lint.ExternalProviders == nil {
+			writable.Audit = AuditConfig{}
+		}
+	}
+
 	return writable
 }
 

--- a/internal/engine/config_validate.go
+++ b/internal/engine/config_validate.go
@@ -44,8 +44,14 @@ func ValidateConfig(cfg Config) error {
 	if err := validateBlueprintRegistryConfig(cfg.BlueprintRegistry); err != nil {
 		return err
 	}
-	if err := validateAuditConfig(cfg.Audit); err != nil {
-		return err
+	// Audit lint is framework-owned. Frameworks without a lint profile
+	// (e.g. symfony, laravel) may have an empty audit section; do not
+	// default it to govard or require validation in that case. If they
+	// explicitly configure a provider, still validate it.
+	if FrameworkSupportsAuditLint(cfg.Framework) || strings.TrimSpace(cfg.Audit.Lint.Provider) != "" || len(cfg.Audit.Lint.ExternalProviders) > 0 {
+		if err := validateAuditConfig(cfg.Audit); err != nil {
+			return err
+		}
 	}
 	if cfg.Stack.XdebugVersion != "" && !ValidateXdebugVersion(cfg.Stack.XdebugVersion) {
 		return fmt.Errorf("stack.xdebug_version %q is invalid (use a PECL Xdebug version, e.g. 3.5.3)", cfg.Stack.XdebugVersion)

--- a/internal/engine/framework_capabilities.go
+++ b/internal/engine/framework_capabilities.go
@@ -7,6 +7,7 @@ import "strings"
 type FrameworkCapabilities struct {
 	FrontendSync  bool
 	AuditProfiler bool
+	AuditLint     bool
 }
 
 var registeredFrameworkCapabilities = map[string]FrameworkCapabilities{}
@@ -29,4 +30,13 @@ func FrameworkSupportsFrontendSync(name string) bool {
 func FrameworkSupportsAuditProfiler(name string) bool {
 	capabilities, ok := registeredFrameworkCapabilities[NormalizeFrameworkAlias(name)]
 	return ok && capabilities.AuditProfiler
+}
+
+// FrameworkSupportsAuditLint reports whether the framework registered a
+// lint-audit capability. Frameworks without AuditLint (e.g. Symfony,
+// Laravel) return false so config normalization can omit the default
+// audit.lint.provider that would otherwise promise a non-existent gate.
+func FrameworkSupportsAuditLint(name string) bool {
+	capabilities, ok := registeredFrameworkCapabilities[NormalizeFrameworkAlias(name)]
+	return ok && capabilities.AuditLint
 }

--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -129,6 +129,21 @@ func ResolveRuntimeProfile(framework string, version string) (RuntimeProfileResu
 		return result, nil
 	}
 	_, minor, _ := parseMajorMinor(version)
+	// Bare major versions like "6" (no dot) historically resolved to the
+	// lowest minor rule (e.g. WordPress 6.0 -> PHP 8.0) while docs claim
+	// WordPress 6 -> PHP 8.3. Treat a bare major as "latest minor within that
+	// major" so `govard bootstrap --framework-version 6` pins to the newest
+	// profile (WordPress 6.6 -> PHP 8.3, DB 10.11) and `govard init` defaults
+	// (no version) remain framework defaults (PHP 8.3, DB 11.4). Explicit
+	// minor versions like "6.0" still resolve to their specific rule.
+	if isBareMajorVersion(version) {
+		if override, source, ok := resolveFrameworkProfileBareMajor(framework, major); ok {
+			applyRuntimeProfileOverride(&result.Profile, override)
+			normalizeProfile(&result.Profile)
+			result.Source = source
+			return result, nil
+		}
+	}
 	if override, source, ok := resolveFrameworkProfileFromRegistry(framework, major, minor); ok {
 		applyRuntimeProfileOverride(&result.Profile, override)
 		normalizeProfile(&result.Profile)
@@ -290,4 +305,62 @@ func parseMajorMinor(version string) (major int, minor int, ok bool) {
 		return 0, 0, false
 	}
 	return mj, mn, true
+}
+
+func isBareMajorVersion(version string) bool {
+	v := strings.TrimSpace(version)
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	// Strip common constraint prefixes that still indicate a bare major request.
+	v = strings.TrimPrefix(v, "^")
+	v = strings.TrimPrefix(v, "~")
+	v = strings.TrimPrefix(v, ">=")
+	v = strings.TrimPrefix(v, ">")
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	if strings.Contains(v, ".") {
+		return false
+	}
+	_, err := strconv.Atoi(v)
+	return err == nil
+}
+
+func resolveFrameworkProfileBareMajor(framework string, major int) (VersionProfileOverride, string, bool) {
+	rules, ok := registry.Frameworks[framework]
+	if !ok {
+		return VersionProfileOverride{}, "", false
+	}
+	var best *frameworkRule
+	var bestMinor = -1
+	for i := range rules {
+		if rules[i].Major != major {
+			continue
+		}
+		minor := 0
+		if rules[i].MinorMin != nil {
+			minor = *rules[i].MinorMin
+		}
+		if best == nil || minor > bestMinor {
+			best = &rules[i]
+			bestMinor = minor
+		}
+	}
+	if best == nil {
+		return VersionProfileOverride{}, "", false
+	}
+	override := VersionProfileOverride{
+		PHPVersion:      best.PHPVersion,
+		DB:              best.DB,
+		DBVersion:       best.DBVersion,
+		ComposerVersion: best.ComposerVersion,
+	}
+	var source string
+	if best.MinorMin != nil {
+		source = fmt.Sprintf("version-specific:%s@%d.%d", framework, major, *best.MinorMin)
+	} else {
+		source = fmt.Sprintf("version-specific:%s@%d", framework, major)
+	}
+	return override, source, true
 }

--- a/internal/frameworks/laravel/audit_target.go
+++ b/internal/frameworks/laravel/audit_target.go
@@ -1,0 +1,153 @@
+package laravel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"govard/internal/frameworks/types"
+)
+
+var laravelAuditPackages = map[string]struct{}{
+	"laravel/framework": {},
+}
+
+// ResolveAuditTarget detects a Laravel project for audit routing. Laravel
+// currently has no Govard-native lint profile (AuditLint is nil), so the
+// resolver exists only to turn the generic "no framework can resolve audit
+// target" into a helpful framework-specific message via the audit command's
+// follow-up AuditLint-nil check.
+func ResolveAuditTarget(request types.AuditTargetResolveRequest) (types.AuditTarget, bool, error) {
+	startPath, err := canonicalAuditPath(request.StartPath)
+	if err != nil {
+		return types.AuditTarget{}, false, err
+	}
+
+	projectRoot, err := findLaravelAuditProject(startPath)
+	if err != nil {
+		return types.AuditTarget{}, false, err
+	}
+	hasEvidence := projectRoot != ""
+
+	switch request.ModeOverride {
+	case "", types.AuditTargetAuto:
+		if projectRoot != "" {
+			return projectAuditTarget(projectRoot), true, nil
+		}
+		return types.AuditTarget{}, false, nil
+	case types.AuditTargetProject:
+		if projectRoot != "" {
+			return projectAuditTarget(projectRoot), true, nil
+		}
+	case types.AuditTargetModule:
+		if hasEvidence {
+			return types.AuditTarget{}, true, fmt.Errorf("audit target mode %q is not supported for framework %q: laravel audit lint is not yet implemented (use govard tool php vendor/bin/pint or vendor/bin/phpstan directly)", request.ModeOverride, "laravel")
+		}
+		return types.AuditTarget{}, false, nil
+	case types.AuditTargetStandalone:
+		if hasEvidence {
+			return types.AuditTarget{}, true, fmt.Errorf("audit target mode %q is not supported for framework %q: laravel audit lint is not yet implemented (use govard tool php vendor/bin/pint or vendor/bin/phpstan directly)", request.ModeOverride, "laravel")
+		}
+		return types.AuditTarget{}, false, nil
+	default:
+		if hasEvidence {
+			return types.AuditTarget{}, true, fmt.Errorf("unknown audit target mode %q", request.ModeOverride)
+		}
+		return types.AuditTarget{}, false, nil
+	}
+
+	if hasEvidence {
+		return types.AuditTarget{}, true, fmt.Errorf("audit target mode %q requires a Laravel project", request.ModeOverride)
+	}
+	return types.AuditTarget{}, false, nil
+}
+
+func canonicalAuditPath(startPath string) (string, error) {
+	if strings.TrimSpace(startPath) == "" {
+		return "", fmt.Errorf("audit target path is required")
+	}
+	resolved, err := filepath.EvalSymlinks(startPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve audit target path %q: %w", startPath, err)
+	}
+	absolute, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("make audit target path absolute: %w", err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return "", fmt.Errorf("stat audit target path %q: %w", absolute, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("audit target path %q is not a directory", absolute)
+	}
+	return absolute, nil
+}
+
+func findLaravelAuditProject(startPath string) (string, error) {
+	for current := startPath; ; current = filepath.Dir(current) {
+		isProject, err := isLaravelProject(current)
+		if err != nil {
+			return "", err
+		}
+		if isProject {
+			return current, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", nil
+		}
+	}
+}
+
+func isLaravelProject(directory string) (bool, error) {
+	marker, err := os.Lstat(filepath.Join(directory, BinArtisan))
+	hasArtisan := err == nil && marker.Mode().IsRegular()
+	if err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("inspect Laravel artisan marker in %q: %w", directory, err)
+	}
+	manifest, exists, err := readAuditComposerManifest(directory)
+	if err != nil || !exists {
+		return false, err
+	}
+	for pkg := range manifest.Require {
+		if _, ok := laravelAuditPackages[pkg]; ok {
+			if hasArtisan {
+				return true, nil
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type auditComposerManifest struct {
+	Require map[string]json.RawMessage `json:"require"`
+}
+
+func readAuditComposerManifest(directory string) (auditComposerManifest, bool, error) {
+	path := filepath.Join(directory, "composer.json")
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return auditComposerManifest{}, false, nil
+		}
+		return auditComposerManifest{}, false, fmt.Errorf("read Composer manifest %q: %w", path, err)
+	}
+	var manifest auditComposerManifest
+	if err := json.Unmarshal(contents, &manifest); err != nil {
+		return auditComposerManifest{}, false, fmt.Errorf("parse Composer manifest %q: %w", path, err)
+	}
+	return manifest, true, nil
+}
+
+func projectAuditTarget(projectRoot string) types.AuditTarget {
+	return types.AuditTarget{
+		Framework:   "laravel",
+		ProjectRoot: projectRoot,
+		TargetPath:  projectRoot,
+		Mode:        types.AuditTargetProject,
+	}
+}

--- a/internal/frameworks/laravel/bootstrap.go
+++ b/internal/frameworks/laravel/bootstrap.go
@@ -42,9 +42,9 @@ func (l *LaravelBootstrap) FreshCommands() []string {
 	majorVersion := strings.Split(version, ".")[0]
 	switch majorVersion {
 	case "12":
-		laravelVersion = "laravel/laravel"
+		laravelVersion = "laravel/laravel:^12.0"
 	case "11":
-		laravelVersion = "laravel/laravel"
+		laravelVersion = "laravel/laravel:^11.0"
 	case "10":
 		laravelVersion = "laravel/laravel:^10.0"
 	case "9":
@@ -207,7 +207,7 @@ func (l *LaravelBootstrap) PostClone(projectDir string) error {
 
 func (l *LaravelBootstrap) getLaravelVersion(version string) string {
 	if version == "" {
-		return "laravel/laravel"
+		return "laravel/laravel:^11.0"
 	}
 
 	parts := strings.Split(version, ".")
@@ -215,9 +215,9 @@ func (l *LaravelBootstrap) getLaravelVersion(version string) string {
 
 	switch major {
 	case "12":
-		return "laravel/laravel"
+		return "laravel/laravel:^12.0"
 	case "11":
-		return "laravel/laravel"
+		return "laravel/laravel:^11.0"
 	case "10":
 		return "laravel/laravel:^10.0"
 	case "9":

--- a/internal/frameworks/laravel/laravel.go
+++ b/internal/frameworks/laravel/laravel.go
@@ -33,6 +33,7 @@ func Definition() types.FrameworkDefinition {
 		Detect: engine.DetectionSpec{
 			ComposerPackages: []string{"laravel/framework"},
 		},
+		AuditTargetResolver: ResolveAuditTarget,
 		ToolCommands: []types.ToolCommand{
 			{Name: "artisan", Short: "Run Laravel Artisan commands", Binary: "php", PrependArgs: []string{"artisan"}},
 		},

--- a/internal/frameworks/registry.go
+++ b/internal/frameworks/registry.go
@@ -232,7 +232,7 @@ func (r *Registry) ResolveAuditTarget(request types.AuditTargetResolveRequest) (
 	}
 
 	if !selected {
-		return types.FrameworkDefinition{}, types.AuditTarget{}, fmt.Errorf("no framework can resolve audit target %q", request.StartPath)
+		return types.FrameworkDefinition{}, types.AuditTarget{}, fmt.Errorf("no framework can resolve audit target %q (audit lint is only supported for Magento 2/Mage-OS; for other frameworks use govard tool php vendor/bin/phpcs, vendor/bin/phpstan or vendor/bin/pint directly)", request.StartPath)
 	}
 	selectedTarget.Framework = selectedDefinition.Name
 	return selectedDefinition, selectedTarget, nil
@@ -283,6 +283,7 @@ func registerEngineDefinition(def types.FrameworkDefinition) {
 	engine.RegisterFrameworkCapabilities(def.Name, engine.FrameworkCapabilities{
 		FrontendSync:  def.FrontendSyncRenderer != nil,
 		AuditProfiler: def.AuditProfiler != nil,
+		AuditLint:     def.AuditLint != nil,
 	})
 	for _, migrationType := range def.MigrationTypes.DDEV {
 		engine.RegisterMigrationFramework("ddev", migrationType, def.Name)

--- a/internal/frameworks/symfony/audit_target.go
+++ b/internal/frameworks/symfony/audit_target.go
@@ -1,0 +1,154 @@
+package symfony
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"govard/internal/frameworks/types"
+)
+
+var symfonyAuditPackages = map[string]struct{}{
+	"symfony/framework-bundle": {},
+	"symfony/symfony":          {},
+}
+
+// ResolveAuditTarget detects a Symfony project for audit routing. Symfony
+// currently has no Govard-native lint profile (AuditLint is nil), so the
+// resolver exists only to turn the generic "no framework can resolve audit
+// target" into a helpful framework-specific message via the audit command's
+// follow-up AuditLint-nil check.
+func ResolveAuditTarget(request types.AuditTargetResolveRequest) (types.AuditTarget, bool, error) {
+	startPath, err := canonicalAuditPath(request.StartPath)
+	if err != nil {
+		return types.AuditTarget{}, false, err
+	}
+
+	projectRoot, err := findSymfonyAuditProject(startPath)
+	if err != nil {
+		return types.AuditTarget{}, false, err
+	}
+	hasEvidence := projectRoot != ""
+
+	switch request.ModeOverride {
+	case "", types.AuditTargetAuto:
+		if projectRoot != "" {
+			return projectAuditTarget(projectRoot), true, nil
+		}
+		return types.AuditTarget{}, false, nil
+	case types.AuditTargetProject:
+		if projectRoot != "" {
+			return projectAuditTarget(projectRoot), true, nil
+		}
+	case types.AuditTargetModule:
+		if hasEvidence {
+			return types.AuditTarget{}, true, fmt.Errorf("audit target mode %q is not supported for framework %q: symfony audit lint is not yet implemented (use govard tool php vendor/bin/phpcs or vendor/bin/phpstan directly)", request.ModeOverride, "symfony")
+		}
+		return types.AuditTarget{}, false, nil
+	case types.AuditTargetStandalone:
+		if hasEvidence {
+			return types.AuditTarget{}, true, fmt.Errorf("audit target mode %q is not supported for framework %q: symfony audit lint is not yet implemented (use govard tool php vendor/bin/phpcs or vendor/bin/phpstan directly)", request.ModeOverride, "symfony")
+		}
+		return types.AuditTarget{}, false, nil
+	default:
+		if hasEvidence {
+			return types.AuditTarget{}, true, fmt.Errorf("unknown audit target mode %q", request.ModeOverride)
+		}
+		return types.AuditTarget{}, false, nil
+	}
+
+	if hasEvidence {
+		return types.AuditTarget{}, true, fmt.Errorf("audit target mode %q requires a Symfony project", request.ModeOverride)
+	}
+	return types.AuditTarget{}, false, nil
+}
+
+func canonicalAuditPath(startPath string) (string, error) {
+	if strings.TrimSpace(startPath) == "" {
+		return "", fmt.Errorf("audit target path is required")
+	}
+	resolved, err := filepath.EvalSymlinks(startPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve audit target path %q: %w", startPath, err)
+	}
+	absolute, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("make audit target path absolute: %w", err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return "", fmt.Errorf("stat audit target path %q: %w", absolute, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("audit target path %q is not a directory", absolute)
+	}
+	return absolute, nil
+}
+
+func findSymfonyAuditProject(startPath string) (string, error) {
+	for current := startPath; ; current = filepath.Dir(current) {
+		isProject, err := isSymfonyProject(current)
+		if err != nil {
+			return "", err
+		}
+		if isProject {
+			return current, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", nil
+		}
+	}
+}
+
+func isSymfonyProject(directory string) (bool, error) {
+	marker, err := os.Lstat(filepath.Join(directory, BinConsole))
+	hasConsole := err == nil && marker.Mode().IsRegular()
+	if err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("inspect Symfony console marker in %q: %w", directory, err)
+	}
+	manifest, exists, err := readAuditComposerManifest(directory)
+	if err != nil || !exists {
+		return false, err
+	}
+	for pkg := range manifest.Require {
+		if _, ok := symfonyAuditPackages[pkg]; ok {
+			if hasConsole {
+				return true, nil
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type auditComposerManifest struct {
+	Require map[string]json.RawMessage `json:"require"`
+}
+
+func readAuditComposerManifest(directory string) (auditComposerManifest, bool, error) {
+	path := filepath.Join(directory, "composer.json")
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return auditComposerManifest{}, false, nil
+		}
+		return auditComposerManifest{}, false, fmt.Errorf("read Composer manifest %q: %w", path, err)
+	}
+	var manifest auditComposerManifest
+	if err := json.Unmarshal(contents, &manifest); err != nil {
+		return auditComposerManifest{}, false, fmt.Errorf("parse Composer manifest %q: %w", path, err)
+	}
+	return manifest, true, nil
+}
+
+func projectAuditTarget(projectRoot string) types.AuditTarget {
+	return types.AuditTarget{
+		Framework:   "symfony",
+		ProjectRoot: projectRoot,
+		TargetPath:  projectRoot,
+		Mode:        types.AuditTargetProject,
+	}
+}

--- a/internal/frameworks/symfony/symfony.go
+++ b/internal/frameworks/symfony/symfony.go
@@ -30,6 +30,7 @@ func Definition() types.FrameworkDefinition {
 			Password: DefaultDBPass,
 			Database: DefaultDBName,
 		},
+		AuditTargetResolver: ResolveAuditTarget,
 		Detect: engine.DetectionSpec{
 			ComposerPackages: []string{"symfony/framework-bundle", "symfony/symfony"},
 		},

--- a/internal/frameworks/wordpress/bootstrap.go
+++ b/internal/frameworks/wordpress/bootstrap.go
@@ -23,10 +23,32 @@ import (
 
 const (
 	wordpressCoreArchiveURL = "https://wordpress.org/latest.tar.gz"
+	wordpressCoreBaseURL    = "https://wordpress.org"
 	wordpressCorePrefix     = "wordpress/"
 )
 
 var wordpressCoreDownloader = downloadAndExtractWordPressCore
+
+// getWordPressArchiveURL returns the version-pinned WordPress core archive URL.
+// When version is empty or "latest" it returns the canonical latest.tar.gz URL
+// so existing fresh installs without --framework-version keep current behavior.
+// For a pinned version (e.g. "6", "6.7", "6.7.1") it returns the versioned
+// archive at https://wordpress.org/wordpress-<version>.tar.gz. A bare major
+// like "6" is normalized to "6.0" because WordPress publishes versioned
+// archives per minor (wordpress-6.0.tar.gz, wordpress-6.7.tar.gz, etc.) and
+// there is no wordpress-6.tar.gz.
+func getWordPressArchiveURL(version string) string {
+	v := strings.TrimSpace(version)
+	if v == "" || strings.EqualFold(v, "latest") {
+		return wordpressCoreArchiveURL
+	}
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	if !strings.Contains(v, ".") {
+		v = v + ".0"
+	}
+	return fmt.Sprintf("%s/wordpress-%s.tar.gz", wordpressCoreBaseURL, v)
+}
 
 type WordPressBootstrap struct {
 	Options bootstrap.Options
@@ -59,6 +81,21 @@ func (w *WordPressBootstrap) CreateProject(projectDir string) error {
 
 	if err := bootstrap.RemoveProjectContents(projectDir); err != nil {
 		return err
+	}
+	// When version is pinned via --framework-version (e.g. "6", "6.7"), download
+	// the versioned archive instead of latest.tar.gz. This keeps fresh installs
+	// reproducible and matches the --framework-version contract. See
+	// getWordPressArchiveURL for normalization rules.
+	if strings.TrimSpace(w.Options.Version) != "" {
+		archiveURL := getWordPressArchiveURL(w.Options.Version)
+		if archiveURL != wordpressCoreArchiveURL {
+			pterm.Info.Printf("Downloading WordPress %s from %s...\n", strings.TrimSpace(w.Options.Version), archiveURL)
+			if err := downloadAndExtractWordPressCoreFromURL(projectDir, archiveURL); err != nil {
+				return fmt.Errorf("failed to download WordPress core: %w", err)
+			}
+			pterm.Success.Println("WordPress downloaded successfully")
+			return nil
+		}
 	}
 	if err := wordpressCoreDownloader(projectDir); err != nil {
 		return fmt.Errorf("failed to download WordPress core: %w", err)
@@ -201,6 +238,24 @@ func (w *WordPressBootstrap) installWordPressSite(projectDir, siteURL string) er
 	}, "\n")
 
 	if err := bootstrap.RunPHPOneLiner(projectDir, w.Options.Runner, code); err != nil {
+		pterm.Warning.Printf("PHP one-liner install failed (%v), trying wp-cli fallback...\n", err)
+		if w.Options.Runner != nil {
+			fallback := fmt.Sprintf("wp core install --url=%s --title=%s --admin_user=%s --admin_email=%s --admin_password=%s --skip-email",
+				conventions.ShellQuote(siteURL),
+				conventions.ShellQuote("WordPress Site"),
+				conventions.ShellQuote(conventions.DefaultAdminUser),
+				conventions.ShellQuote(conventions.DefaultAdminEmail),
+				conventions.ShellQuote(conventions.DefaultAdminPassword),
+			)
+			// Only treat fallback as success if wp-cli is present and install succeeds;
+			// otherwise surface the original PHP error for diagnosability.
+			if fallbackErr := w.Options.Runner(fallback); fallbackErr == nil {
+				pterm.Success.Println("WordPress installed via wp-cli fallback")
+				return nil
+			} else {
+				pterm.Warning.Printf("wp-cli fallback also failed: %v\n", fallbackErr)
+			}
+		}
 		return fmt.Errorf("install WordPress site: %w", err)
 	}
 
@@ -259,12 +314,24 @@ func (w *WordPressBootstrap) resolveDBConfig() (host, user, pass, name string) {
 
 func (w *WordPressBootstrap) waitForWordPressDatabase(projectDir string) error {
 	dbHost, dbUser, dbPass, dbName := w.resolveDBConfig()
-	return bootstrap.WaitForMySQLDatabase(projectDir, w.Options.Runner, dbHost, dbUser, dbPass, dbName)
+	// WordPress fresh install requires a running DB container; manifest sets
+	// RequiresRunningEnvForFreshInstall=true so env up happens before
+	// CreateProject->Install. If Runner is nil (host-side fallback) we still
+	// poll via local php, but we surface the wait error explicitly rather than
+	// letting installWordPressSite silently create an empty DB.
+	if err := bootstrap.WaitForMySQLDatabase(projectDir, w.Options.Runner, dbHost, dbUser, dbPass, dbName); err != nil {
+		return fmt.Errorf("database not ready for WordPress install (db=%s user=%s host=%s): %w", dbName, dbUser, dbHost, err)
+	}
+	return nil
 }
 
 func downloadAndExtractWordPressCore(projectDir string) error {
+	return downloadAndExtractWordPressCoreFromURL(projectDir, wordpressCoreArchiveURL)
+}
+
+func downloadAndExtractWordPressCoreFromURL(projectDir string, archiveURL string) error {
 	client := &http.Client{Timeout: 2 * time.Minute}
-	resp, err := client.Get(wordpressCoreArchiveURL)
+	resp, err := client.Get(archiveURL)
 	if err != nil {
 		return fmt.Errorf("download WordPress core: %w", err)
 	}
@@ -371,4 +438,9 @@ func SetWordPressCoreDownloaderForTest(fn func(projectDir string) error) func() 
 	return func() {
 		wordpressCoreDownloader = previous
 	}
+}
+
+// GetWordPressArchiveURLForTest exposes getWordPressArchiveURL for tests.
+func GetWordPressArchiveURLForTest(version string) string {
+	return getWordPressArchiveURL(version)
 }

--- a/tests/bootstrap_laravel_test.go
+++ b/tests/bootstrap_laravel_test.go
@@ -15,10 +15,11 @@ func TestBootstrapPkgLaravelFreshCommands(t *testing.T) {
 		version  string
 		expected string
 	}{
-		{"11", "laravel/laravel"},
+		{"12", "laravel/laravel:^12.0"},
+		{"11", "laravel/laravel:^11.0"},
 		{"10", "laravel/laravel:^10.0"},
 		{"9", "laravel/laravel:^9.0"},
-		{"", "laravel/laravel"},
+		{"", "laravel/laravel:^11.0"},
 	}
 
 	for _, tc := range cases {
@@ -55,7 +56,7 @@ func TestLaravelCreateProjectWithRunnerStagesComposerCreateProject(t *testing.T)
 		t.Fatalf("CreateProject() error = %v", err)
 	}
 
-	if !strings.Contains(capturedCommand, `composer create-project laravel/laravel "$GOVARD_STAGE_DIR" --no-interaction`) {
+	if !strings.Contains(capturedCommand, `composer create-project laravel/laravel:^11.0 "$GOVARD_STAGE_DIR" --no-interaction`) {
 		t.Fatalf("unexpected runner command: %s", capturedCommand)
 	}
 	if _, err := os.Stat(filepath.Join(projectDir, "package.json")); err != nil {

--- a/tests/testdata/framework_snapshots/laravel/bootstrap_fresh_commands.json
+++ b/tests/testdata/framework_snapshots/laravel/bootstrap_fresh_commands.json
@@ -1,3 +1,3 @@
 [
-  "composer create-project laravel/laravel ."
+  "composer create-project laravel/laravel:^11.0 ."
 ]


### PR DESCRIPTION
Closes #185 #186 #187 #188 #189 #190 #191 #192

## Summary
Single-branch fix for all 8 issues opened from fresh-install validation on govard v1.65.0 (Symfony 7, WordPress 6, Laravel 11->13, Magento 2.4.8).

### Changes by issue
- **#185 `govard shell -c` does not exist** — `internal/cmd/shell.go`: support `-c/--command` with `bash -c` dispatch, `--` separator, plain args join, `sh` fallback on 126/127, updated Long/Example help.
- **#186 WordPress DB empty** — `internal/frameworks/wordpress/bootstrap.go`: `waitForWordPressDatabase` now returns contextual error, `installWordPressSite` keeps `is_blog_installed()` guard but adds `wp core install` fallback via Runner when php one-liner fails; ordering verified `RequiresRunningEnvForFreshInstall=true` brings env up before Install.
- **#187 audit cannot resolve target** — add `AuditTargetResolver` for symfony/laravel (`internal/frameworks/*/audit_target.go`), add `FrameworkCapabilities{AuditLint}` and stop generating `audit.lint.provider: govard` for unsupported frameworks (`engine/config_normalize|persist|validate`, `registry.go`, `cmd/audit_target.go` with fallback hints).
- **#188 version unpinned** — `laravel/bootstrap.go`: pin `11->^11.0`, `12->^12.0` in both `FreshCommands` and `getLaravelVersion` (empty now -> ^11.0); `wordpress/bootstrap.go`: add `getWordPressArchiveURL` helper, versioned URL `wordpress-<version>.tar.gz` when `--framework-version` set.
- **#189 stack drift & missing php:8.0-debug** — `engine/profile.go`: bare major `"6"` now resolves to latest minor (`6.6->8.3/10.11`) instead of lowest (`6.0->8.0/10.6`); `docs/reference/frameworks.md` + `docs/vi/reference/frameworks.md` Version-Aware Overrides updated to granular rows matching `profiles.json` (Laravel 10 8.1, Symfony 6.0-6.3 8.1/6.4+ 8.2/7.0-7.1 8.2/7.2+ 8.3, WordPress 6.0 8.0/6.3 8.1/6.4-6.5 8.2/6.6+ 8.3/7 8.4).
- **#190/#192 test ergonomics** — `internal/cmd/test_project.go`: `govard test unit` auto-falls back to `dev/tests/unit/phpunit.xml.dist` when no `-c` and no root phpunit.xml, prints MockCreationTrait hint; `govard test integration` rewrites `-c` to `.dist` when needed and warns about missing `install-config-mysql.php`; add `hintMissingTestBinary` for phpstan/phpunit/pest.
- **#191 pest/phpstan/coverage** — covered by 188 pin + test hints (pest/phpstan now hint `composer require --dev ...`).

## Verification
- `go vet ./...` clean, `gofmt -l` clean, `go build` OK
- `go test ./tests -run TestBootstrap|TestAudit|TestConfig` PASS (filtered full suite skips 5 pre-existing doctor/desktop failures also present on master)
- `docs/reference/frameworks.md` now matches `profiles.json` and `internal/frameworks/*/config.go`

## Test plan
- Fresh installs: `govard bootstrap --fresh --framework-version 6|7|11 --yes` then `govard shell -c "echo hi"`, `govard audit run --checks lint`, `govard test unit` on Magento 2.4.8, `wp core is-installed` on WordPress
