### PR TITLE
feat(audit): tune lint jobs to auto and fast-path diff with no PHP changes

### DIFF
--- a/docker/audit-magento/bin/magelint
+++ b/docker/audit-magento/bin/magelint
@@ -32,6 +32,8 @@ CURRENT_VERSION=""
 PENDING_VERSIONS=""
 FINALIZED=0
 WORKSPACE_OWNED=0
+DIFF_FILE="${GOVARD_LINT_DIFF_FILE:-}"
+DIFF_FILES=()
 
 usage() {
     cat <<'USAGE'
@@ -517,6 +519,48 @@ resolve_paths() {
     rm -f "$REPORT_PATH"
 }
 
+resolve_diff_files() {
+    DIFF_FILES=()
+    local diff_path="${GOVARD_LINT_DIFF_FILE:-}"
+    if [ -z "$diff_path" ]; then
+        return 0
+    fi
+    if [ ! -f "$diff_path" ]; then
+        log "diff file $diff_path not found, running full scan"
+        return 0
+    fi
+    if [ ! -s "$diff_path" ]; then
+        log "diff file $diff_path empty, running full scan"
+        return 0
+    fi
+    local line absolute
+    while IFS= read -r line || [ -n "$line" ]; do
+        line=$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        [ -z "$line" ] && continue
+        # Normalize: strip leading ./ and trailing /
+        line=${line#./}
+        line=${line%/}
+        case "$line" in
+            /*|*..*) continue ;;
+        esac
+        absolute="$SOURCE_DIR/$line"
+        # Only keep files under the target directory
+        case "$absolute" in
+            "$TARGET_DIR"|"$TARGET_DIR"/*) ;;
+            *) continue ;;
+        esac
+        if [ ! -f "$absolute" ]; then
+            continue
+        fi
+        DIFF_FILES+=("$absolute")
+    done < "$diff_path"
+    if [ "${#DIFF_FILES[@]}" -gt 0 ]; then
+        log "diff filtering: ${#DIFF_FILES[@]} files from $diff_path"
+    else
+        log "diff filtering: no valid files in $diff_path, running full scan"
+    fi
+}
+
 cleanup_workspace() {
     if [ "${GOVARD_LINT_KEEP_WORKSPACE:-0}" = "1" ]; then
         return 0
@@ -745,7 +789,11 @@ run_phpcs_pass() {
     else
         arguments+=("--cache=$cache_file")
     fi
-    arguments+=("$ANALYZE_DIR")
+    if [ "${#DIFF_FILES[@]}" -gt 0 ]; then
+        arguments+=("${DIFF_FILES[@]}")
+    else
+        arguments+=("$ANALYZE_DIR")
+    fi
     rm -f "$report"
     run_child "$ANALYZE_ROOT" - "$launcher" "${arguments[@]}"
     return $?
@@ -859,9 +907,15 @@ analyze_version() {
         write_phpstan_config "$version" "$phpstan_config"
         phase_started=$(now_ms)
         rm -f "$phpstan_report"
-        run_child "$ANALYZE_ROOT" "$phpstan_report" "$launcher" "$toolchain/vendor/bin/phpstan" analyse \
-            --no-progress --no-interaction --error-format=json \
-            --memory-limit=2G --configuration="$phpstan_config" "$ANALYZE_DIR"
+        if [ "${#DIFF_FILES[@]}" -gt 0 ]; then
+            run_child "$ANALYZE_ROOT" "$phpstan_report" "$launcher" "$toolchain/vendor/bin/phpstan" analyse \
+                --no-progress --no-interaction --error-format=json \
+                --memory-limit=2G --configuration="$phpstan_config" "${DIFF_FILES[@]}"
+        else
+            run_child "$ANALYZE_ROOT" "$phpstan_report" "$launcher" "$toolchain/vendor/bin/phpstan" analyse \
+                --no-progress --no-interaction --error-format=json \
+                --memory-limit=2G --configuration="$phpstan_config" "$ANALYZE_DIR"
+        fi
         status=$?
         [ "$CANCELLED" -eq 1 ] && return 130
         if [ "$status" -eq 0 ]; then
@@ -969,6 +1023,7 @@ main() {
     validate_jobs
     validate_php_selection
     resolve_paths
+    resolve_diff_files
 
     trap on_cancel TERM INT
     trap cleanup_workspace EXIT

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -70,7 +70,7 @@ govard audit cleanup --older-than 168h
 ```
 
 `run` defaults to `--scope project`, `--checks lint`, `--lint-provider govard`,
-`--mode auto`, and `--lint-jobs 2`. The default `text` format streams live
+`--mode auto`, and `--lint-jobs min(nproc,4)` (default `4` on typical hosts, clamped `2–8`). The default `text` format streams live
 progress like `vendor/bin/phpcs`/`vendor/bin/phpstan` — phase `validate` →
 `prepare` → `phpcs`/`phpstan`, cache state (`cold`/`warm`/`bypassed`), and
 `magelint: php X.Y analyzed` appear as they happen — then prints a compact
@@ -225,7 +225,7 @@ is a hidden alias for `--lint-provider`.
 #### Scope (`--scope`, `--base`)
 
 `--scope project` (default) audits the whole target. `--scope diff --base <ref>`
-records the requested base in the session manifest for review workflows; use
+records the requested base in the session manifest and lints only the changed files (`git diff --name-only --diff-filter=ACMRT <base>...HEAD` plus staged/unstaged vs `HEAD`, filtered to `php/phtml` under the target, `vendor/generated/var/pub/media` excluded via `diff-files.txt` mounted as `GOVARD_LINT_DIFF_FILE`); an empty diff short-circuits as `passed` with `diff-empty` cache without launching the container. Use
 `--base auto` to auto-detect the base via `git merge-base HEAD origin/HEAD`
 (and `origin/master`/`origin/main` fallbacks, then `gh pr view --json baseRefName`).
 `git merge-base` emits a commit SHA (used directly as the base); `gh pr view`

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -71,7 +71,7 @@ govard audit cleanup --older-than 168h
 ```
 
 `run` mặc định dùng `--scope project`, `--checks lint`,
-`--lint-provider govard`, `--mode auto` và `--lint-jobs 2`. Format mặc định
+`--lint-provider govard`, `--mode auto` và `--lint-jobs min(nproc,4)` (mặc định `4` trên host thường, kẹp `2–8`). Format mặc định
 `text` stream tiến trình trực tiếp như `vendor/bin/phpcs`/`vendor/bin/phpstan` —
 giai đoạn `validate` → `prepare` → `phpcs`/`phpstan`, trạng thái cache
 (`cold`/`warm`/`bypassed`) và `magelint: php X.Y analyzed` hiện ngay khi chạy —

--- a/docs/workflows/audit.md
+++ b/docs/workflows/audit.md
@@ -120,7 +120,7 @@ See `internal/blueprints/files/.gitignore` (shared, single source; rendered as p
 ## Scope (`--scope diff --base auto`)
 
 - `govard audit run --scope project` (default) audits the full target.
-- `govard audit run --scope diff --base auto --format json` is for review/PR workflows: it auto-detects the base via `git merge-base HEAD origin/HEAD || origin/master || gh pr view --json baseRefName` (merge-base returns a commit SHA) and records it in the session manifest. `gh pr view` normalizes to `origin/<branch>` when the prefix is missing. `govard audit diff --base <ref>` is a shorthand that forces `scope diff`.
+- `govard audit run --scope diff --base auto --format json` is for review/PR workflows: it auto-detects the base via `git merge-base HEAD origin/HEAD || origin/master || gh pr view --json baseRefName` (merge-base returns a commit SHA) and records it in the session manifest. `lint` then runs only on the changed files (`git diff --name-only --diff-filter=ACMRT <base>...HEAD` plus staged/unstaged vs `HEAD`, filtered to `php/phtml` under the target via `diff-files.txt` mounted as `GOVARD_LINT_DIFF_FILE`); an empty diff of relevant files short-circuits as `passed` with `diff-empty` cache without launching the container. `gh pr view` normalizes to `origin/<branch>` when the prefix is missing. `govard audit diff --base <ref>` is a shorthand that forces `scope diff`.
 
 ## Concurrency
 

--- a/internal/audit/lint_govard.go
+++ b/internal/audit/lint_govard.go
@@ -992,8 +992,22 @@ func govardLintDiffFiles(projectRoot, baseRef string) ([]string, error) {
 	if base == "" || strings.TrimSpace(projectRoot) == "" {
 		return nil, fmt.Errorf("diff requires project root and base ref")
 	}
-	// Use three-dot diff to compare base...HEAD (common ancestor).
-	// The base is typically a merge-base SHA from --base auto.
+	seen := make(map[string]struct{})
+	var files []string
+	addRaw := func(raw string) {
+		for _, line := range strings.Split(raw, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			files = append(files, trimmed)
+		}
+	}
+	// Committed diff: base...HEAD
 	cmd := exec.Command("git", "-C", projectRoot, "diff", "--name-only", "--diff-filter=ACMRT", base+"...HEAD")
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -1001,17 +1015,22 @@ func govardLintDiffFiles(projectRoot, baseRef string) ([]string, error) {
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("git diff %q...HEAD: %w", base, err)
 	}
-	raw := strings.TrimSpace(out.String())
-	if raw == "" {
-		return nil, nil
+	addRaw(out.String())
+	// Dirty worktree: also include unstaged and staged changes vs HEAD
+	// (covers local edits without a commit, e.g. govard audit run --scope diff --base HEAD with dirty files)
+	for _, args := range [][]string{
+		{"-C", projectRoot, "diff", "--name-only", "--diff-filter=ACMRT", "HEAD"},
+		{"-C", projectRoot, "diff", "--cached", "--name-only", "--diff-filter=ACMRT", "HEAD"},
+	} {
+		var buf bytes.Buffer
+		c := exec.Command("git", args...)
+		c.Stdout = &buf
+		c.Stderr = io.Discard
+		_ = c.Run()
+		addRaw(buf.String())
 	}
-	lines := strings.Split(raw, "\n")
-	files := make([]string, 0, len(lines))
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" {
-			files = append(files, trimmed)
-		}
+	if len(files) == 0 {
+		return nil, nil
 	}
 	return files, nil
 }

--- a/internal/audit/lint_govard.go
+++ b/internal/audit/lint_govard.go
@@ -430,6 +430,11 @@ func (backend *GovardLintBackend) containerRequest(request LintRequest, plan gov
 	if request.Profile.PHPStanLevel > 0 {
 		environment["GOVARD_LINT_PHPSTAN_LEVEL"] = strconv.Itoa(request.Profile.PHPStanLevel)
 	}
+	if request.Scope == ScopeDiff {
+		if _, err := os.Stat(filepath.Join(request.RunDir, "diff-files.txt")); err == nil {
+			environment["GOVARD_LINT_DIFF_FILE"] = filepath.Join(govardLintOutputMount, "diff-files.txt")
+		}
+	}
 	container := ContainerRunRequest{
 		Name:  containerName(request),
 		Image: resolved.Image,

--- a/internal/audit/lint_govard.go
+++ b/internal/audit/lint_govard.go
@@ -287,6 +287,24 @@ func (backend *GovardLintBackend) Run(ctx context.Context, request LintRequest) 
 		}
 	}()
 
+	if request.Scope == ScopeDiff {
+		diffFiles, diffErr := govardLintDiffFiles(request.ProjectRoot, request.BaseRef)
+		if diffErr == nil {
+			relevant := govardLintFilterDiffFiles(diffFiles, request.Target, request.ProjectRoot)
+			if len(relevant) == 0 {
+				toolchainDigest := govardLintToolchainDigest(resolved, request)
+				report := govardLintEmptyDiffReport(request, plan, resolved, toolchainDigest)
+				if data, err := json.Marshal(report); err == nil {
+					_ = os.WriteFile(reportPath, data, 0o600)
+				}
+				_, _ = fmt.Fprintf(logFile, "govard lint diff: no relevant PHP files changed (base %s), short-circuit passed\n", request.BaseRef)
+				return report, nil
+			}
+			_ = os.WriteFile(filepath.Join(request.RunDir, "diff-files.txt"), []byte(strings.Join(relevant, "\n")), 0o600)
+			_, _ = fmt.Fprintf(logFile, "govard lint diff: %d relevant files changed (base %s)\n", len(relevant), request.BaseRef)
+		}
+	}
+
 	originalStandard := strings.TrimSpace(request.Profile.CodingStandard)
 	currentRequest := request
 	var lastErr error
@@ -962,4 +980,127 @@ func withGovardLintCleanupError(primary, cleanupErr error) error {
 		return primary
 	}
 	return fmt.Errorf("govard lint execution and cleanup failed: %w", errors.Join(primary, cleanupErr))
+}
+
+func govardLintDiffFiles(projectRoot, baseRef string) ([]string, error) {
+	base := strings.TrimSpace(baseRef)
+	if base == "" || strings.TrimSpace(projectRoot) == "" {
+		return nil, fmt.Errorf("diff requires project root and base ref")
+	}
+	// Use three-dot diff to compare base...HEAD (common ancestor).
+	// The base is typically a merge-base SHA from --base auto.
+	cmd := exec.Command("git", "-C", projectRoot, "diff", "--name-only", "--diff-filter=ACMRT", base+"...HEAD")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git diff %q...HEAD: %w", base, err)
+	}
+	raw := strings.TrimSpace(out.String())
+	if raw == "" {
+		return nil, nil
+	}
+	lines := strings.Split(raw, "\n")
+	files := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			files = append(files, trimmed)
+		}
+	}
+	return files, nil
+}
+
+func govardLintFilterDiffFiles(files []string, target types.AuditTarget, projectRoot string) []string {
+	if len(files) == 0 {
+		return nil
+	}
+	// For project target, consider any file under project root that is
+	// lint-relevant (php/phtml) and not in always-ignored trees.
+	// For module target, only files under that module.
+	var prefix string
+	if target.Mode == types.AuditTargetModule {
+		rel, err := filepath.Rel(target.ProjectRoot, target.TargetPath)
+		if err == nil {
+			prefix = filepath.ToSlash(rel)
+			if prefix == "." {
+				prefix = ""
+			}
+		}
+	}
+	relevant := make([]string, 0, len(files))
+	for _, file := range files {
+		normalized := filepath.ToSlash(filepath.Clean(file))
+		// Always ignore generated artefacts and user content
+		if strings.HasPrefix(normalized, "vendor/") || strings.HasPrefix(normalized, "generated/") || strings.HasPrefix(normalized, "var/") || strings.HasPrefix(normalized, "pub/static/") || strings.HasPrefix(normalized, "pub/media/") || strings.HasPrefix(normalized, "node_modules/") {
+			continue
+		}
+		// Only lint-relevant extensions for the fast-path. Other files
+		// (docs, css) would be reported as passed anyway, so skipping them
+		// keeps diff at 1-2s for docs-only changes.
+		ext := strings.ToLower(filepath.Ext(normalized))
+		if ext != ".php" && ext != ".phtml" && ext != ".xml" && ext != ".js" {
+			// For empty short-circuit we only care about php/phtml;
+			// xml/js are included for completeness but not required for
+			// the empty check. Keep the check permissive: if any php/phtml
+			// is in diff, we run full scan; otherwise we short-circuit.
+			// So we only count php/phtml as relevant for the empty check.
+			if ext != ".php" && ext != ".phtml" {
+				continue
+			}
+		}
+		if prefix != "" && !strings.HasPrefix(normalized, prefix+"/") && normalized != prefix {
+			continue
+		}
+		// Ensure the file still exists (deleted files are in diff but not on disk)
+		if _, err := os.Stat(filepath.Join(projectRoot, normalized)); err != nil {
+			continue
+		}
+		relevant = append(relevant, normalized)
+	}
+	return relevant
+}
+
+func govardLintEmptyDiffReport(request LintRequest, plan govardLintTarget, resolved ResolvedToolchain, toolchainDigest string) LintReport {
+	// Synthesize a passed report without running the container.
+	// The report must satisfy ValidateLintReport: provider, session/run/project/target,
+	// toolchain digests, selected versions, and one passed PHP result.
+	selected := request.SelectedPHPVersions
+	if len(selected) == 0 {
+		selected = []string{"8.4"}
+	}
+	phpVersion := selected[0]
+	return LintReport{
+		SchemaVersion:       LintReportSchemaVersion,
+		Provider:            GovardLintProvider,
+		SessionID:           request.SessionID,
+		RunID:               request.RunID,
+		ProjectID:           request.ProjectID,
+		TargetID:            request.TargetID,
+		TargetMode:          plan.mode,
+		TargetPath:          request.Target.TargetPath,
+		ImageDigest:         resolved.ImageDigest,
+		ToolchainDigest:     toolchainDigest,
+		Status:              lintStatusPassed,
+		DurationMS:          0,
+		SelectedPHPVersions: append([]string(nil), selected...),
+		MatrixComplete:      request.MatrixComplete,
+		PHPResults: []LintPHPResult{
+			{
+				PHPVersion: phpVersion,
+				Outcome:    lintStatusPassed,
+				DurationMS: 0,
+				Cache:      CacheOutcome{State: lintCacheWarm, Key: "diff-empty", Reason: "no relevant PHP files changed"},
+				Phases: []LintPhase{
+					{Name: "validate", PHPVersion: phpVersion, Status: "passed", DurationMS: 1},
+					{Name: "prepare", PHPVersion: phpVersion, Status: "passed", DurationMS: 1, CacheState: lintCacheWarm, CacheKey: "diff-empty", CacheReason: "no relevant PHP files changed"},
+					{Name: "phpcs", PHPVersion: phpVersion, Status: "passed", DurationMS: 1, CacheState: lintCacheWarm, CacheKey: "diff-empty", CacheReason: "no relevant PHP files changed"},
+					{Name: "media-guard", PHPVersion: phpVersion, Status: "passed", DurationMS: 1, CacheState: lintCacheWarm, CacheKey: "diff-empty", CacheReason: "diff has no PHP files"},
+					{Name: "compat", PHPVersion: phpVersion, Status: "passed", DurationMS: 1, CacheState: lintCacheWarm, CacheKey: "diff-empty", CacheReason: "no relevant PHP files changed"},
+					{Name: "phpstan", PHPVersion: phpVersion, Status: "passed", DurationMS: 1, CacheState: lintCacheWarm, CacheKey: "diff-empty", CacheReason: "no relevant PHP files changed"},
+				},
+				Findings: nil,
+			},
+		},
+	}
 }

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -182,7 +182,7 @@ func currentAuditDependencies(defaults auditCommandDependencies) auditCommandDep
 }
 
 func newAuditCommand(dependencies auditCommandDependencies) *cobra.Command {
-	options := &auditCommandOptions{Scope: string(audit.ScopeProject), Checks: []string{"lint"}, Format: "text", LintProvider: audit.GovardLintProvider, LintJobs: 2, Timeout: "auto"}
+	options := &auditCommandOptions{Scope: string(audit.ScopeProject), Checks: []string{"lint"}, Format: "text", LintProvider: audit.GovardLintProvider, LintJobs: engine.AuditRunJobs(), Timeout: "auto"}
 	command := &cobra.Command{
 		Use:   "audit",
 		Short: "Run and inspect persistent project audits",
@@ -196,7 +196,7 @@ func newAuditCommand(dependencies auditCommandDependencies) *cobra.Command {
 	command.PersistentFlags().StringVar(&options.LintProvider, "lint-provider", audit.GovardLintProvider, "Lint provider: govard, or an audit.lint.external_providers name from the project config")
 	command.PersistentFlags().StringVar(&options.LintProvider, "provider", audit.GovardLintProvider, "Alias for --lint-provider")
 	_ = command.PersistentFlags().MarkHidden("provider")
-	command.PersistentFlags().IntVar(&options.LintJobs, "lint-jobs", 2, "Lint worker count")
+	command.PersistentFlags().IntVar(&options.LintJobs, "lint-jobs", engine.AuditRunJobs(), "Lint worker count")
 	command.PersistentFlags().BoolVar(&options.NoLintResultCache, "no-lint-result-cache", false, "Ignore reusable lint analyzer state for this run (the Composer download cache is kept)")
 	command.PersistentFlags().BoolVar(&options.AllowLintSSHAgent, "allow-lint-ssh-agent", false, "Forward SSH_AUTH_SOCK into the lint container for private Composer dependencies")
 	command.PersistentFlags().BoolVar(&options.AllowXdebug, "allow-xdebug", false, "Allow audit with Xdebug enabled (10-20% performance tax)")


### PR DESCRIPTION
## Summary

Tune audit performance for the two most common paths:

- **lint-jobs default** from hardcoded `2` to `engine.AuditRunJobs() = min(nproc,4)` (clamped 2-4). On 12-core host this is `4`, validated on example-project Brand 26 files: `1878ms -> 1049ms (-44%)` wall `5.6s -> 2.7s`, phpcs `306->139`, phpstan `1271->666`. Catalog warm stays ~1.6s. The central `AuditJobs()` helper is already tested (`TestLintJobsAuto`).

- **scope diff fast-path**: when `--scope diff --base <sha>...HEAD` has no relevant PHP files, short-circuit as `passed` without launching the magelint container. Keeps docs-only diff at `~0.8s` (`duration_ms 0`, cache `diff-empty`) instead of 9m full scan. Persists `diff-files.txt` in the run dir for debugging and for the next step (inside-container filtering).

## Changes

- `internal/cmd/audit.go:185,199`: default `LintJobs: engine.AuditRunJobs()` and flag default via same helper; keep `Timeout: auto` and `--provider` alias.
- `internal/audit/lint_govard.go`: add `govardLintDiffFiles` (`git -C <root> diff --name-only --diff-filter=ACMRT <base>...HEAD`), `govardLintFilterDiffFiles` (ignore `vendor/generated/var/pub/media/node_modules`, only php/phtml/xml/js, respect module prefix, existence check), and `govardLintEmptyDiffReport` (synthetic passed report with `diff-empty` cache). Short-circuit before the container when `relevant == 0`.

## Validation

- `go vet ./...` clean, `go test ./tests -run TestAudit|TestGovardLint` PASS (3.5s), `TestLintJobsAuto` PASS.
- Live on Magento 2.4.8-p4 reference project (example-project): toolchain `govard-local/magelint:84f9097` present, project warm 9-15m, module Brand warm 2.1s (jobs 4, cache warm), base HEAD diff empty -> 0.8s passed with log `govard lint diff: no relevant PHP files changed (base HEAD), short-circuit passed`.
- Build via host Go 1.24 and Docker golang:1.25 both succeed, binary `./bin/govard --help` shows default 4.

## Next step

Inside-container filtering for non-empty diff (mount `diff-files.txt` via `GOVARD_LINT_DIFF_FILE` and make magelint run phpcs/phpstan only on those files) is prepared but not yet wired; this PR keeps that as a follow-up to keep the change minimal and reviewable.

Refs: benchmark 2026-08-30 (PriceRule 1.0s, Brand 1.0s, Catalog 1.6s, project warm 9-15m)