### PR TITLE
fix(tunnel): correct WordPress container suffix, Symfony env handling

### DIFF
--- a/internal/frameworks/laravel/base_url_manager.go
+++ b/internal/frameworks/laravel/base_url_manager.go
@@ -30,7 +30,13 @@ func (m *LaravelManager) Revert(projectRoot string, config engine.Config) error 
 // UpdateEnv is exported so symfony.SymfonyManager can reach it through
 // embedding - Go does not promote unexported methods across packages.
 func (m *LaravelManager) UpdateEnv(projectRoot string, key string, value string) error {
-	envPath := filepath.Join(projectRoot, ".env")
+	return m.UpdateEnvFile(projectRoot, ".env", key, value)
+}
+
+// UpdateEnvFile updates a specific env file (e.g. ".env" or ".env.local") for key=value.
+// Exported for Symfony which stores runtime env in .env.local.
+func (m *LaravelManager) UpdateEnvFile(projectRoot string, envFile string, key string, value string) error {
+	envPath := filepath.Join(projectRoot, envFile)
 	read := m.ReadFile
 	if read == nil {
 		read = os.ReadFile
@@ -43,7 +49,12 @@ func (m *LaravelManager) UpdateEnv(projectRoot string, key string, value string)
 	lines := strings.Split(string(content), "\n")
 	found := false
 	for i, line := range lines {
-		if strings.HasPrefix(line, key+"=") {
+		trimmed := strings.TrimSpace(line)
+		// Skip comments and empty lines; match key= prefix exactly.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, key+"=") {
 			lines[i] = fmt.Sprintf("%s=%s", key, value)
 			found = true
 			break

--- a/internal/frameworks/symfony/base_url_manager.go
+++ b/internal/frameworks/symfony/base_url_manager.go
@@ -12,10 +12,21 @@ type SymfonyManager struct {
 }
 
 func (m *SymfonyManager) Update(projectRoot string, config engine.Config, tunnelURL string) error {
-	// Symfony often uses APP_URL or similar, but frequently SITE_URL
-	// Let's support both or just APP_URL for consistency if it's there
+	// Symfony's primary env file is .env.local (created by bootstrap with DATABASE_URL).
+	// Update .env.local first, then .env as fallback so tunnel works regardless of
+	// which file the project uses for APP_URL. Laravel's .env handling stays
+	// unchanged — this only affects Symfony.
+	if err := m.UpdateEnvFile(projectRoot, ".env.local", "APP_URL", tunnelURL); err == nil {
+		_ = m.UpdateEnv(projectRoot, "APP_URL", tunnelURL)
+		return nil
+	}
 	return m.UpdateEnv(projectRoot, "APP_URL", tunnelURL)
 }
 func (m *SymfonyManager) Revert(projectRoot string, config engine.Config) error {
-	return m.UpdateEnv(projectRoot, "APP_URL", fmt.Sprintf("https://%s", config.Domain))
+	localURL := fmt.Sprintf("https://%s", config.Domain)
+	if err := m.UpdateEnvFile(projectRoot, ".env.local", "APP_URL", localURL); err == nil {
+		_ = m.UpdateEnv(projectRoot, "APP_URL", localURL)
+		return nil
+	}
+	return m.UpdateEnv(projectRoot, "APP_URL", localURL)
 }

--- a/internal/frameworks/wordpress/base_url_manager.go
+++ b/internal/frameworks/wordpress/base_url_manager.go
@@ -14,7 +14,7 @@ type WordPressManager struct {
 
 func (m *WordPressManager) Backup(projectRoot string, config engine.Config) error { return nil }
 func (m *WordPressManager) Update(projectRoot string, config engine.Config, tunnelURL string) error {
-	containerName := fmt.Sprintf("%s%s", config.ProjectName, conventions.PHPFPMSuffix)
+	containerName := fmt.Sprintf("%s%s", config.ProjectName, conventions.PHPSuffix)
 	// wp option update siteurl <url> && wp option update home <url>
 	_, err := m.executeWP(containerName, "option", "update", "siteurl", tunnelURL)
 	if err != nil {
@@ -24,7 +24,7 @@ func (m *WordPressManager) Update(projectRoot string, config engine.Config, tunn
 	return err
 }
 func (m *WordPressManager) Revert(projectRoot string, config engine.Config) error {
-	containerName := fmt.Sprintf("%s%s", config.ProjectName, conventions.PHPFPMSuffix)
+	containerName := fmt.Sprintf("%s%s", config.ProjectName, conventions.PHPSuffix)
 	localURL := fmt.Sprintf("https://%s", config.Domain)
 	_, err := m.executeWP(containerName, "option", "update", "siteurl", localURL)
 	if err != nil {
@@ -40,6 +40,6 @@ func (m *WordPressManager) executeWP(container string, args ...string) ([]byte, 
 			return exec.Command(name, args...).CombinedOutput()
 		}
 	}
-	fullArgs := append([]string{"exec", "-u", conventions.UserWWWData, container, "wp"}, args...)
+	fullArgs := append([]string{"exec", "-u", conventions.UserWWWData, "-w", conventions.DefaultWorkDir, container, "wp", "--allow-root"}, args...)
 	return executor("docker", fullArgs...)
 }


### PR DESCRIPTION
Closes #200

### Summary

Review kỹ tunnel cho 4 frameworks chính (Magento2/Laravel/Symfony/WordPress) với fresh install. Fix 2 bug blocker và 1 polish:

- **wordpress/base_url_manager.go**: `PHPSuffix` (`-php-1`) thay vì `PHPFPMSuffix` (`-php-fpm-1`), thêm `-w /var/www/html` và `--allow-root` cho `wp-cli` (container thực tế là `govard-tunnel-wordpress-php-1`, không phải `-php-fpm-1`).
- **symfony/base_url_manager.go**: fresh Symfony tạo `.env.local` (DATABASE_URL) — tunnel giờ ghi `.env.local` trước rồi fallback `.env`, đảm bảo `APP_URL` runtime được rewrite.
- **laravel/base_url_manager.go**: thêm `UpdateEnvFile` + skip comment/empty, hỗ trợ Symfony; `UpdateEnv` giờ delegate qua `UpdateEnvFile(".env")`.

### Validation — fresh install (ephemeral, 2026-08-30)

Tạo tại `/home/kai/govard-tunnel-validation` với `govard bootstrap --fresh` (binary `bin/govard v1.68.0-tunnel-fix`):

| Framework | Dir | Bootstrap | local curl | tunnel --plan | live tunnel (captured) | base-URL rewrite | Caddy alias |
|---|---|---|---|---|---|---|---|
| Laravel 11 | `govard-tunnel-laravel` | 39s | `https://govard-tunnel-laravel.test` 200 `<title>Laravel` | `cloudflared tunnel --url https://govard-tunnel-laravel.test --no-tls-verify` | `inside-pro-informal-spring.trycloudflare.com` (hkg12) | `.env APP_URL` → tunnel, revert OK | `curl -H Host:tunnel-host https://govard-tunnel-laravel.test` → Laravel |
| Symfony 7 | `govard-tunnel-symfony` | 29s | `https://govard-tunnel-symfony.test` Welcome | same | `chris-und-volleyball-best.trycloudflare.com` (hkg13) | `.env.local APP_URL` → tunnel, revert OK | Host-header curl → Symfony welcome |
| WordPress | `govard-tunnel-wordpress` | 23s | `https://govard-tunnel-wordpress.test` 200 `<title>Test` | same | `criticism-suites-concerns-quantities.trycloudflare.com` (hkg01) | `wp option get siteurl/home` → tunnel, feed link chứa tunnel URL, revert OK | Host-header curl → WordPress |
| Magento2 | `/tmp/magento-tunnel-test` (mock) | — | — | `target: https://magento-tunnel-test.test` | `TestMagento2ManagerUpdate` PASS, `PHPSuffix` đúng | `bin/magento setup:store-config:set` + `cache:flush` | — |

`go vet` clean, `go test ./tests -run TestTunnel|TestBaseURL|TestLaravelManager|TestMagento2Manager` PASS.

### Links để validate (local, luôn sống — mkcert)

- `https://govard-tunnel-laravel.test`
- `https://govard-tunnel-symfony.test`
- `https://govard-tunnel-wordpress.test`

Tunnel URLs trên là ephemeral (chỉ sống khi `govard tunnel start` chạy). Để tự validate live:

```bash
cd /home/kai/govard-tunnel-validation/govard-tunnel-laravel && govard tunnel start
# đợi "Tunnel URL detected: https://xxx.trycloudflare.com" rồi mở browser
```

Tương tự cho `govard-tunnel-symfony` (`cat .env.local | grep APP_URL`) và `govard-tunnel-wordpress` (`govard tool wp --allow-root option get siteurl`).

### Risk

- Chỉ 3 manager files, không chạm provider/proxy.
- `tunnel stop` hiện không xóa Caddy alias nếu tunnel bị kill abrupt — để lại alias orphan nhưng không ảnh hưởng local (env up không xóa alias). Có thể follow-up để persist tunnelHost nếu cần.