### PR TITLE
refactor(govard): deadcode cleanup across conventions/engine/frameworks

### DIFF
--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -254,7 +254,7 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 		if err := enforceXdebugGuard(resolvedTarget.Config, options.AllowXdebug); err != nil {
 			return err
 		}
-		warnXdebugGuard(cmd, resolvedTarget.Config)
+		warnXdebugGuard(resolvedTarget.Config)
 		// Resolve --base auto for diff scope after target is known (needs project root for git).
 		effectiveBase := options.BaseRef
 		if scope == audit.ScopeDiff && strings.TrimSpace(effectiveBase) == "auto" {
@@ -632,16 +632,13 @@ func validateAuditOutputOptions(options *auditCommandOptions) error {
 	return nil
 }
 
-func warnXdebugGuard(cmd *cobra.Command, cfg *engine.Config) {
+func warnXdebugGuard(cfg *engine.Config) {
 	if cfg == nil {
 		return
 	}
 	if engine.XdebugGuard(*cfg) {
 		pterm.Warning.Println("Xdebug enabled, ~10-20% performance tax; disable for bench fidelity (stack.features.xdebug:true)")
 	}
-	// MAGE_MODE guard is best-effort; only warn when explicitly non-production.
-	// The engine's MageModeGuard is reused so the message stays consistent.
-	_ = cmd
 }
 
 func enforceXdebugGuard(cfg *engine.Config, allow bool) error {
@@ -727,11 +724,6 @@ func detectAuditBase(projectRoot string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("could not auto-detect base ref for diff scope (try --base origin/master)")
-}
-
-// DetectAuditBaseForTest exposes detectAuditBase for tests.
-func DetectAuditBaseForTest(projectRoot string) (string, error) {
-	return detectAuditBase(projectRoot)
 }
 
 func auditEnvironment(config engine.Config) audit.EnvironmentFingerprint {

--- a/internal/cmd/bootstrap.go
+++ b/internal/cmd/bootstrap.go
@@ -469,12 +469,6 @@ func supportedBootstrapFrameworks(fresh bool) []string {
 	return supported
 }
 
-// BootstrapSupportsFrameworkForTest exposes the command's framework allowlist
-// so tests cover the same gate that runs before any bootstrap workflow.
-func BootstrapSupportsFrameworkForTest(framework string, fresh bool) bool {
-	return stringSliceContains(supportedBootstrapFrameworks(fresh), framework)
-}
-
 func needsRemoteEnvironment(opts BootstrapRuntimeOptions) bool {
 	if opts.Fresh {
 		return false

--- a/internal/cmd/bootstrap_options.go
+++ b/internal/cmd/bootstrap_options.go
@@ -120,12 +120,6 @@ func validateBootstrapFrameworkVersion(framework string, version string) error {
 	return nil
 }
 
-// ValidateBootstrapFrameworkVersionForTest exposes framework-aware fresh
-// version validation for tests in /tests.
-func ValidateBootstrapFrameworkVersionForTest(framework string, version string) error {
-	return validateBootstrapFrameworkVersion(framework, version)
-}
-
 func normalizeBootstrapSource(raw string) string {
 	return strings.ToLower(strings.TrimSpace(raw))
 }

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -882,10 +882,6 @@ func renderFinalizeOnBar(bar *pterm.ProgressbarPrinter, label string, startedAt 
 	}
 }
 
-func RunImportFromReader(importCmd *exec.Cmd, reader io.Reader, sanitize bool, stdout io.Writer, stderr io.Writer) error {
-	return RunImportFromReaderWithProgress(importCmd, reader, 0, sanitize, stdout, stderr, nil)
-}
-
 // poll, when non-nil, is called periodically while waiting for importCmd to
 // finish, to report the target database's growing size.
 func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, totalSize int64, sanitize bool, stdout io.Writer, stderr io.Writer, poll func() (int64, error)) error {
@@ -1004,10 +1000,6 @@ func RunImportFromReaderWithProgress(importCmd *exec.Cmd, reader io.Reader, tota
 		return closeErr
 	}
 	return waitErr
-}
-
-func RunDumpToImport(dumpCmd *exec.Cmd, importCmd *exec.Cmd, sanitize bool, stdout io.Writer, stderr io.Writer) error {
-	return RunDumpToImportWithProgress(dumpCmd, importCmd, 0, sanitize, stdout, stderr, nil)
 }
 
 // poll, when non-nil, is called periodically while waiting for importCmd to

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -140,5 +140,6 @@ func init() {
 	rootCmd.AddCommand(blueprintCmd)
 	rootCmd.AddCommand(newAuditCommand(defaultAuditCommandDependencies()))
 	rootCmd.AddCommand(tunnelCmd)
+	rootCmd.AddCommand(trustCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/conventions/containers.go
+++ b/internal/conventions/containers.go
@@ -3,13 +3,9 @@ package conventions
 const (
 	PHPSuffix           = "-php-1"
 	WebSuffix           = "-web-1"
-	PHPFPMSuffix        = "-php-fpm-1"
 	DBSuffix            = "-db-1"
 	RedisSuffix         = "-redis-1"
 	VarnishSuffix       = "-varnish-1"
-	MailSuffix          = "-mail-1"
-	PmaSuffix           = "-pma-1"
-	ShellSuffix         = "-shell-1"
 	ReplicaSuffix       = "-1"
 	PHPDebugSuffix      = "-php-debug-1"
 	ElasticsearchSuffix = "-elasticsearch-1"

--- a/internal/conventions/env.go
+++ b/internal/conventions/env.go
@@ -7,10 +7,7 @@ const (
 	EnvPostgresUser     = "POSTGRES_USER"
 	EnvPostgresPassword = "POSTGRES_PASSWORD"
 	EnvPostgresDatabase = "POSTGRES_DB"
-	EnvDatabaseURL      = "DATABASE_URL"
-	EnvAppEnv           = "APP_ENV"
 	EnvGovardHome       = "GOVARD_HOME_DIR"
-	EnvGovardProject    = "GOVARD_PROJECT_DIR"
 	EnvGovardLock       = "GOVARD_LOCK_PATH"
 
 	EnvPHPVersion           = "PHP_VERSION"

--- a/internal/conventions/limits.go
+++ b/internal/conventions/limits.go
@@ -1,6 +1,3 @@
 package conventions
 
-const (
-	MySQLMaxAllowedPacket = "512M"
-	DefaultServiceTimeout = 300 // 5 minutes
-)
+const MySQLMaxAllowedPacket = "512M"

--- a/internal/conventions/network.go
+++ b/internal/conventions/network.go
@@ -2,13 +2,10 @@ package conventions
 
 const (
 	HTTPPort     = 80
-	HTTPSPort    = 443
 	MySQLPort    = 3306
 	PostgresPort = 5432
 	PHPFPMPort   = 9000
 	RedisPort    = 6379
 	SearchPort   = 9200
 	RabbitMQPort = 5672
-
-	DefaultDomainSuffix = ".govard.test"
 )

--- a/internal/conventions/orchestration.go
+++ b/internal/conventions/orchestration.go
@@ -11,6 +11,5 @@ const (
 	// working_dir/volumes.
 	PythonWorkDir = "/app"
 
-	MagentoDeveloperMode  = "developer"
-	MagentoProductionMode = "production"
+	MagentoDeveloperMode = "developer"
 )

--- a/internal/conventions/paths.go
+++ b/internal/conventions/paths.go
@@ -28,18 +28,7 @@ const (
 )
 
 const (
-	Magento1LocalXml         = "app/etc/local.xml"
-	Magento2EnvPhp           = "app/etc/env.php"
-	DotEnvFile               = ".env"
-	WordPressConfig          = "wp-config.php"
 	PrestaShopParametersFile = "app/config/parameters.php"
-
-	// Lifecycle directories
-	MagentoGeneratedDir = "generated"
-	MagentoVarDir       = "var"
-	MagentoPubStaticDir = "pub/static"
-	MagentoVendorDir    = "vendor"
-	VarnishConfigDir    = "varnish"
 )
 
 // GetGovardHome returns the absolute path to the Govard home directory (~/.govard by default).
@@ -50,16 +39,6 @@ func GetGovardHome() string {
 	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".govard")
-}
-
-// GetGovardProxyDir returns the path to the proxy directory within Govard home.
-func GetGovardProxyDir() string {
-	return filepath.Join(GetGovardHome(), "proxy")
-}
-
-// GetGovardSSLDir returns the path to the SSL directory within Govard home.
-func GetGovardSSLDir() string {
-	return filepath.Join(GetGovardHome(), "ssl")
 }
 
 // ShellQuote wraps a string in single quotes and escapes existing single quotes

--- a/internal/conventions/services.go
+++ b/internal/conventions/services.go
@@ -1,8 +1,6 @@
 package conventions
 
 const (
-	ServiceMySQL         = "mysql"
-	ServiceMariaDB       = "mariadb"
 	ServicePostgreSQL    = "postgres"
 	ServiceRedis         = "redis"
 	ServiceValkey        = "valkey"
@@ -10,7 +8,4 @@ const (
 	ServiceElasticsearch = "elasticsearch"
 	ServiceOpenSearch    = "opensearch"
 	ServiceRabbitMQ      = "rabbitmq"
-	ServiceMailhog       = "mailhog"
-	ServiceMailpit       = "mailpit"
-	ServicePhpMyAdmin    = "phpmyadmin"
 )

--- a/internal/conventions/targets.go
+++ b/internal/conventions/targets.go
@@ -13,5 +13,4 @@ const (
 	TargetMail          = "mail"
 	TargetPMA           = "pma"
 	TargetApp           = "app"
-	TargetPHPDebug      = "php-debug"
 )

--- a/internal/desktop/actions.go
+++ b/internal/desktop/actions.go
@@ -15,22 +15,12 @@ import (
 	"time"
 
 	"govard/internal/conventions"
-	"govard/internal/engine"
 
 	"github.com/pkg/browser"
 )
 
 var defaultOpenExternalURLForDesktop = browser.OpenURL
 var openExternalURLForDesktop = defaultOpenExternalURLForDesktop
-
-var defaultRunEnvironmentComposeForDesktop = func(dir string, args []string) error {
-	return engine.RunCompose(context.Background(), engine.ComposeOptions{
-		ProjectDir: dir,
-		Args:       args[1:], // Skip "compose" as RunCompose adds it
-	})
-}
-
-var runEnvironmentComposeForDesktop = defaultRunEnvironmentComposeForDesktop
 
 func quickAction(ctx context.Context, action string, project string) (string, error) {
 	switch action {

--- a/internal/desktop/global_services.go
+++ b/internal/desktop/global_services.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"govard/internal/conventions"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +14,6 @@ import (
 	"time"
 
 	"govard/internal/engine"
-	"govard/internal/proxy"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -140,37 +138,6 @@ var defaultRunGlobalServicesComposeForDesktop = func(args ...string) (string, er
 }
 
 var runGlobalServicesComposeForDesktop = defaultRunGlobalServicesComposeForDesktop
-
-var defaultWaitForGlobalProxyReadyForDesktop = func(ctx context.Context, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for {
-		if engine.IsContainerRunning(ctx, "govard-proxy-caddy") || engine.IsContainerRunning(ctx, "proxy-caddy-1") {
-			return true
-		}
-		if time.Now().After(deadline) {
-			return false
-		}
-		select {
-		case <-ctx.Done():
-			return false
-		case <-time.After(250 * time.Millisecond):
-		}
-	}
-}
-
-var waitForGlobalProxyReadyForDesktop = defaultWaitForGlobalProxyReadyForDesktop
-
-var defaultRefreshGlobalServiceRoutesForDesktop = func() error {
-	if err := registerDesktopGlobalServiceRoutes(); err != nil {
-		return err
-	}
-	if err := reviveRunningProjectRoutesForDesktop(); err != nil {
-		return err
-	}
-	return nil
-}
-
-var refreshGlobalServiceRoutesForDesktop = defaultRefreshGlobalServiceRoutesForDesktop
 
 var defaultRunHostPortProbeForDesktop = func(binary string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -845,63 +812,6 @@ func buildPublishedPortKeySet(ports []container.Port) map[string]bool {
 	return published
 }
 
-func registerDesktopGlobalServiceRoutes() error {
-	if err := proxy.RegisterDomain("mail.govard.test", "govard-proxy-mail:8025"); err != nil {
-		return fmt.Errorf("register mail route: %w", err)
-	}
-	if err := proxy.RegisterDomain("pma.govard.test", "govard-proxy-pma:80"); err != nil {
-		return fmt.Errorf("register pma route: %w", err)
-	}
-	if err := proxy.RegisterDomain("portainer.govard.test", "govard-proxy-portainer:9000"); err != nil {
-		return fmt.Errorf("register portainer route: %w", err)
-	}
-	return nil
-}
-
-func reviveRunningProjectRoutesForDesktop() error {
-	runningProjects, err := engine.GetRunningProjectNames(context.Background())
-	if err != nil {
-		return fmt.Errorf("get running projects: %w", err)
-	}
-	if len(runningProjects) == 0 {
-		return nil
-	}
-
-	entries, err := engine.ReadProjectRegistryEntries()
-	if err != nil {
-		return fmt.Errorf("read registry: %w", err)
-	}
-
-	for _, projectName := range runningProjects {
-		var matchedEntry *engine.ProjectRegistryEntry
-		for index := range entries {
-			if entries[index].ProjectName == projectName {
-				matchedEntry = &entries[index]
-				break
-			}
-		}
-		if matchedEntry == nil {
-			continue
-		}
-
-		config, _, configErr := engine.LoadConfigFromDir(matchedEntry.Path, false)
-		if configErr != nil {
-			if matchedEntry.Domain != "" {
-				_ = proxy.RegisterDomain(matchedEntry.Domain, projectName+"-web"+conventions.ReplicaSuffix)
-			}
-			continue
-		}
-
-		target := resolveDesktopUpProxyTarget(config)
-		allDomains := config.AllDomains()
-		if len(allDomains) > 0 {
-			_ = proxy.RegisterDomains(allDomains, target)
-		}
-	}
-
-	return nil
-}
-
 func resolveDesktopGovardCommandDir() (string, error) {
 	// For global services, we can run from home or any repo path.
 	// Usually ~/.govard/proxy, but the CLI handles it via internal engine.
@@ -919,14 +829,6 @@ func withCommandOutput(base string, commandOutput string) string {
 		return base
 	}
 	return base + "\n" + trimmed
-}
-
-func resolveDesktopUpProxyTarget(config engine.Config) string {
-	target := config.ProjectName + "-web" + conventions.ReplicaSuffix
-	if config.Stack.Features.Varnish {
-		target = config.ProjectName + conventions.VarnishSuffix
-	}
-	return target
 }
 
 func globalServicesComposeDirPath() string {

--- a/internal/desktop/test_helpers.go
+++ b/internal/desktop/test_helpers.go
@@ -29,11 +29,8 @@ func ResetStateForTest() {
 	validateGitConnectionForDesktop = defaultValidateGitConnectionForDesktop
 	cloneGitRepoForDesktop = defaultCloneGitRepoForDesktop
 	openExternalURLForDesktop = defaultOpenExternalURLForDesktop
-	runEnvironmentComposeForDesktop = defaultRunEnvironmentComposeForDesktop
 	runGlobalServicesComposeForDesktop = defaultRunGlobalServicesComposeForDesktop
 	ensureGlobalServicesForDesktop = defaultEnsureGlobalServicesForDesktop
-	waitForGlobalProxyReadyForDesktop = defaultWaitForGlobalProxyReadyForDesktop
-	refreshGlobalServiceRoutesForDesktop = defaultRefreshGlobalServiceRoutesForDesktop
 	runHostPortProbeForDesktop = defaultRunHostPortProbeForDesktop
 	chooseSaveFileForDesktop = defaultChooseSaveFileForDesktop
 	writeLogFileForDesktop = defaultWriteLogFileForDesktop
@@ -97,11 +94,6 @@ func BuildPMAOpenURLForTest(project string, database string) string {
 // ParseContainerIPAddressesForTest exposes container IP list parsing for tests.
 func ParseContainerIPAddressesForTest(raw string) []string {
 	return parseContainerIPAddresses(raw)
-}
-
-// NormalizeOnboardingDomainForTest exposes domain normalization for tests.
-func NormalizeOnboardingDomainForTest(domain string) string {
-	return normalizeOnboardingDomain(domain)
 }
 
 // BuildOperationNotificationForTest exposes operation notification formatting for tests.
@@ -282,11 +274,6 @@ func ResolveRemoteNameForOpenForTest(
 	return resolved, nil
 }
 
-// ListProjectRemotesForPathForTest exposes path-based remotes loading for tests.
-func ListProjectRemotesForPathForTest(root string) (RemoteSnapshot, error) {
-	return listProjectRemotesByPath(root)
-}
-
 // SetRunGovardCommandForDesktopForTest overrides the desktop govard command runner.
 func SetRunGovardCommandForDesktopForTest(fn func(root string, args []string) (string, error)) func() {
 	previous := runGovardCommandForDesktop
@@ -377,19 +364,6 @@ func SetDesktopGovardLookPathForUpdateForTest(fn func(file string) (string, erro
 	}
 }
 
-// SetDesktopPrivilegedCommandLookPathForUpdateForTest overrides privileged command lookup for desktop update.
-func SetDesktopPrivilegedCommandLookPathForUpdateForTest(fn func(file string) (string, error)) func() {
-	previous := desktopPrivilegedCommandLookPath
-	if fn == nil {
-		desktopPrivilegedCommandLookPath = exec.LookPath
-	} else {
-		desktopPrivilegedCommandLookPath = fn
-	}
-	return func() {
-		desktopPrivilegedCommandLookPath = previous
-	}
-}
-
 // SetRestartDesktopBinaryForTest overrides desktop relaunch command execution.
 func SetRestartDesktopBinaryForTest(fn func(binaryPath string) error) func() {
 	previous := restartDesktopBinary
@@ -468,19 +442,6 @@ func SetRunGlobalServicesComposeForDesktopForTest(fn func(args ...string) (strin
 	}
 }
 
-// SetRunEnvironmentComposeForDesktopForTest overrides project compose execution for desktop environment actions.
-func SetRunEnvironmentComposeForDesktopForTest(fn func(dir string, args []string) error) func() {
-	previous := runEnvironmentComposeForDesktop
-	if fn == nil {
-		runEnvironmentComposeForDesktop = defaultRunEnvironmentComposeForDesktop
-	} else {
-		runEnvironmentComposeForDesktop = fn
-	}
-	return func() {
-		runEnvironmentComposeForDesktop = previous
-	}
-}
-
 // SetEnsureGlobalServicesForDesktopForTest overrides global service compose readiness checks.
 func SetEnsureGlobalServicesForDesktopForTest(fn func() error) func() {
 	previous := ensureGlobalServicesForDesktop
@@ -491,49 +452,6 @@ func SetEnsureGlobalServicesForDesktopForTest(fn func() error) func() {
 	}
 	return func() {
 		ensureGlobalServicesForDesktop = previous
-	}
-}
-
-// SetWaitForGlobalProxyReadyForDesktopForTest overrides global proxy readiness checks.
-func SetWaitForGlobalProxyReadyForDesktopForTest(
-	fn func(ctx context.Context, timeout time.Duration) bool,
-) func() {
-	previous := waitForGlobalProxyReadyForDesktop
-	if fn == nil {
-		waitForGlobalProxyReadyForDesktop = defaultWaitForGlobalProxyReadyForDesktop
-	} else {
-		waitForGlobalProxyReadyForDesktop = fn
-	}
-	return func() {
-		waitForGlobalProxyReadyForDesktop = previous
-	}
-}
-
-// SetRefreshGlobalServiceRoutesForDesktopForTest overrides route refresh after global start/restart.
-func SetRefreshGlobalServiceRoutesForDesktopForTest(fn func() error) func() {
-	previous := refreshGlobalServiceRoutesForDesktop
-	if fn == nil {
-		refreshGlobalServiceRoutesForDesktop = defaultRefreshGlobalServiceRoutesForDesktop
-	} else {
-		refreshGlobalServiceRoutesForDesktop = fn
-	}
-	return func() {
-		refreshGlobalServiceRoutesForDesktop = previous
-	}
-}
-
-// SetRunHostPortProbeForDesktopForTest overrides host port probe commands (lsof/ss).
-func SetRunHostPortProbeForDesktopForTest(
-	fn func(binary string, args ...string) (string, error),
-) func() {
-	previous := runHostPortProbeForDesktop
-	if fn == nil {
-		runHostPortProbeForDesktop = defaultRunHostPortProbeForDesktop
-	} else {
-		runHostPortProbeForDesktop = fn
-	}
-	return func() {
-		runHostPortProbeForDesktop = previous
 	}
 }
 

--- a/internal/engine/audit.go
+++ b/internal/engine/audit.go
@@ -6,12 +6,3 @@ package engine
 func AuditRunJobs() int {
 	return AuditJobs()
 }
-
-// AuditRunScope resolves --scope diff --base handling for audit run. It
-// delegates to AuditScope(diff, base) which validates the base ref via
-// git rev-parse --verify and falls back to "project" on empty/invalid base.
-// This keeps scope validation centralized while giving audit run a dedicated
-// entry point for wiring flags.
-func AuditRunScope(diff bool, base string) string {
-	return AuditScope(diff, base)
-}

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -22,7 +22,7 @@ type ComposeOptions struct {
 // RunCompose executes a Docker Compose command with the given options.
 // It automatically handles project-level flags like --project-directory, -p, and -f.
 func RunCompose(ctx context.Context, opts ComposeOptions) error {
-	dockerArgs := BuildComposeArgs(opts.ProjectDir, opts.ProjectName, opts.ComposeFile, opts.Args)
+	dockerArgs := buildComposeArgs(opts.ProjectDir, opts.ProjectName, opts.ComposeFile, opts.Args)
 
 	cmd := exec.CommandContext(ctx, "docker", dockerArgs...)
 	cmd.Dir = opts.ProjectDir
@@ -49,8 +49,8 @@ func RunCompose(ctx context.Context, opts ComposeOptions) error {
 	return cmd.Run()
 }
 
-// BuildComposeArgs constructs the full argument list for a docker compose command.
-func BuildComposeArgs(projectDir, projectName, composeFile string, args []string) []string {
+// buildComposeArgs constructs the full argument list for a docker compose command.
+func buildComposeArgs(projectDir, projectName, composeFile string, args []string) []string {
 	dockerArgs := []string{
 		"compose",
 		"--project-directory", filepath.Clean(projectDir),

--- a/internal/engine/config_loader.go
+++ b/internal/engine/config_loader.go
@@ -21,13 +21,13 @@ const (
 var validEnvNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 func ResolveConfigLayerPaths(root string) []string {
-	return ResolveConfigLayerPathsWithProfile(root, "")
+	return resolveConfigLayerPathsWithProfile(root, "")
 }
 
-// ResolveConfigLayerPathsWithProfile builds the ordered list of config files.
+// resolveConfigLayerPathsWithProfile builds the ordered list of config files.
 // Load order: Base → Profile → Local → ProjectLocal → GOVARD_ENV → ProjectEnv.
 // Profile is inserted after base so local overrides always win; GOVARD_ENV layers are last so env-specific overrides win over local dev overrides.
-func ResolveConfigLayerPathsWithProfile(root, profile string) []string {
+func resolveConfigLayerPathsWithProfile(root, profile string) []string {
 	paths := []string{
 		filepath.Join(root, BaseConfigFile),
 	}
@@ -58,7 +58,7 @@ func LoadConfigFromDir(root string, requireBase bool) (Config, []string, error) 
 // LoadConfigFromDirWithProfile loads config with an optional profile layer.
 // Profile files (.govard.[profile].yml) are merged after base but before local.
 func LoadConfigFromDirWithProfile(root string, requireBase bool, profile string) (Config, []string, error) {
-	paths := ResolveConfigLayerPathsWithProfile(root, profile)
+	paths := resolveConfigLayerPathsWithProfile(root, profile)
 	merged := map[string]interface{}{}
 	loaded := make([]string, 0, len(paths))
 
@@ -144,7 +144,7 @@ func LoadRawConfigFromDir(root string, requireBase bool) (Config, error) {
 // but merging all profile and local layers just like LoadConfigFromDirWithProfile.
 // This is used to detect which fields were explicitly provided in the layered files by the user.
 func LoadRawConfigFromDirWithProfile(root string, requireBase bool, profile string) (Config, error) {
-	paths := ResolveConfigLayerPathsWithProfile(root, profile)
+	paths := resolveConfigLayerPathsWithProfile(root, profile)
 	merged := map[string]interface{}{}
 	loaded := make([]string, 0, len(paths))
 

--- a/internal/engine/config_validate.go
+++ b/internal/engine/config_validate.go
@@ -38,19 +38,19 @@ func ValidateConfig(cfg Config) error {
 	if strings.ContainsAny(cfg.Domain, " \t\r\n") {
 		return fmt.Errorf("domain cannot contain whitespace")
 	}
-	if strings.TrimSpace(cfg.FrameworkVersion) != "" && !IsValidFrameworkVersion(cfg.FrameworkVersion) {
+	if strings.TrimSpace(cfg.FrameworkVersion) != "" && !isValidFrameworkVersion(cfg.FrameworkVersion) {
 		return fmt.Errorf("framework_version %q is invalid (must not contain whitespace)", cfg.FrameworkVersion)
 	}
-	if strings.TrimSpace(cfg.Stack.PHPVersion) != "" && !IsValidStackVersion(cfg.Stack.PHPVersion) {
+	if strings.TrimSpace(cfg.Stack.PHPVersion) != "" && !isValidStackVersion(cfg.Stack.PHPVersion) {
 		return fmt.Errorf("stack.php_version %q is invalid", cfg.Stack.PHPVersion)
 	}
-	if strings.TrimSpace(cfg.Stack.NodeVersion) != "" && !IsValidStackVersion(cfg.Stack.NodeVersion) {
+	if strings.TrimSpace(cfg.Stack.NodeVersion) != "" && !isValidStackVersion(cfg.Stack.NodeVersion) {
 		return fmt.Errorf("stack.node_version %q is invalid", cfg.Stack.NodeVersion)
 	}
-	if strings.TrimSpace(cfg.Stack.DBVersion) != "" && !IsValidStackVersion(cfg.Stack.DBVersion) {
+	if strings.TrimSpace(cfg.Stack.DBVersion) != "" && !isValidStackVersion(cfg.Stack.DBVersion) {
 		return fmt.Errorf("stack.db_version %q is invalid", cfg.Stack.DBVersion)
 	}
-	if strings.TrimSpace(cfg.Stack.SearchVersion) != "" && !IsValidStackVersion(cfg.Stack.SearchVersion) {
+	if strings.TrimSpace(cfg.Stack.SearchVersion) != "" && !isValidStackVersion(cfg.Stack.SearchVersion) {
 		return fmt.Errorf("stack.search_version %q is invalid", cfg.Stack.SearchVersion)
 	}
 	if !ValidateTablePrefix(cfg.TablePrefix) {
@@ -193,8 +193,8 @@ func validateService(field, value string, allowed map[string]struct{}) error {
 	return nil
 }
 
-// IsValidFrameworkVersion reports whether v is a plausible framework_version (no whitespace, non-empty).
-func IsValidFrameworkVersion(v string) bool {
+// isValidFrameworkVersion reports whether v is a plausible framework_version (no whitespace, non-empty).
+func isValidFrameworkVersion(v string) bool {
 	v = strings.TrimSpace(v)
 	if v == "" {
 		return false
@@ -202,8 +202,8 @@ func IsValidFrameworkVersion(v string) bool {
 	return !strings.ContainsAny(v, " \t\r\n")
 }
 
-// IsValidStackVersion reports whether v looks like a version string (digits/dots/dashes, no whitespace).
-func IsValidStackVersion(v string) bool {
+// isValidStackVersion reports whether v looks like a version string (digits/dots/dashes, no whitespace).
+func isValidStackVersion(v string) bool {
 	v = strings.TrimSpace(v)
 	if v == "" {
 		return false
@@ -219,10 +219,4 @@ func IsValidStackVersion(v string) bool {
 		return false
 	}
 	return true
-}
-
-// ValidateConfigDrift reports drift warnings for an already-loaded config vs its detected metadata.
-// It is a non-blocking helper used by doctor to surface yml drift without failing validation.
-func ValidateConfigDrift(cfg Config, meta ProjectMetadata) []string {
-	return CollectConfigDrift(cfg, meta)
 }

--- a/internal/engine/db_slow.go
+++ b/internal/engine/db_slow.go
@@ -45,74 +45,8 @@ func xdebugGuardForConfig(cfg Config) bool {
 	// MAGE_MODE guard is intentionally conservative: only `production` is
 	// considered non-warning. When the framework env file indicates otherwise,
 	// the caller should surface a warning and `Skipped: <reason>` if needed.
-	// Without an explicit mode field on Config, Xdebug is the primary gate;
-	// additional mode checks can be layered via MageModeGuard.
+	// Without an explicit mode field on Config, Xdebug is the primary gate.
 	return false
-}
-
-// MageModeGuard reports whether the given Magento mode should trigger a guard
-// warning. It is a pure helper for the audit's `MAGE_MODE` guard.
-func MageModeGuard(mode string) bool {
-	switch mode {
-	case "production":
-		return false
-	case "":
-		return false
-	default:
-		return true
-	}
-}
-
-// DbSlowLockPath returns the filesystem lock path used to serialize DB slow
-// log access. The audit uses an atomic `mkdir` lock
-// (`var/debug/.performance-audit.lock` or Govard tmp equivalent) so
-// concurrent per-page captures do not interleave `mysqldumpslow` or
-// `pt-query-digest` collection. The lock is never a `SET GLOBAL` hand-edit.
-func DbSlowLockPath(projectRoot string) string {
-	if projectRoot == "" {
-		projectRoot = "."
-	}
-	return filepath.Join(projectRoot, "var", "debug", ".performance-audit.lock")
-}
-
-// AcquireDbSlowLock attempts to acquire the DB slow log lock via atomic
-// `mkdir`. It returns a release function on success. The caller must defer
-// the release to avoid stale locks after `trap` restore.
-func AcquireDbSlowLock(projectRoot string) (func() error, error) {
-	lockPath := DbSlowLockPath(projectRoot)
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
-		return nil, fmt.Errorf("create db-slow lock directory: %w", err)
-	}
-	if err := os.Mkdir(lockPath, 0o755); err != nil {
-		if os.IsExist(err) {
-			return nil, fmt.Errorf("db-slow lock %q is already held", lockPath)
-		}
-		return nil, fmt.Errorf("acquire db-slow lock: %w", err)
-	}
-	release := func() error {
-		if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("release db-slow lock: %w", err)
-		}
-		return nil
-	}
-	return release, nil
-}
-
-// DbSlowCollector describes how DB slow entries are collected inside the DB
-// container without `SET GLOBAL slow_query_log=ON` hand-edits. The Govard DB
-// lifecycle owns the slow log via container-local `mysqldumpslow` and
-// `pt-query-digest` against the mounted slow log file.
-func DbSlowCollector(projectName string) (container string, mysqldumpslowCmd string, ptDigestCmd string) {
-	if projectName == "" {
-		projectName = "project"
-	}
-	container = projectName + "-db-1"
-	// These commands run via `docker exec <container> ...` against the slow log
-	// file that the DB image already exposes when Govard's DB lock is held.
-	// No `SET GLOBAL` is issued; the log is read-only.
-	mysqldumpslowCmd = "mysqldumpslow -t 20 /var/log/mysql/slow.log"
-	ptDigestCmd = "pt-query-digest /var/log/mysql/slow.log"
-	return container, mysqldumpslowCmd, ptDigestCmd
 }
 
 func loadConfigForGuard() (*Config, error) {

--- a/internal/engine/discovery.go
+++ b/internal/engine/discovery.go
@@ -217,9 +217,3 @@ func NormalizeFrameworkAlias(raw string) string {
 	}
 	return normalized
 }
-
-// GetRegisteredFrameworkAliasForTest exposes the alias registry for tests.
-func GetRegisteredFrameworkAliasForTest(alias string) (string, bool) {
-	canonical, ok := aliasRegistry[strings.ToLower(strings.TrimSpace(alias))]
-	return canonical, ok
-}

--- a/internal/engine/doctor_diagnostics.go
+++ b/internal/engine/doctor_diagnostics.go
@@ -99,22 +99,22 @@ func RunDoctorDiagnostics(dependencies DoctorDependencies) DoctorReport {
 		dependencies.CheckComposeSpam = func() error { return CheckComposeSpam(1000) }
 	}
 	if dependencies.CheckGovardRegistry == nil {
-		dependencies.CheckGovardRegistry = CheckGovardRegistry
+		dependencies.CheckGovardRegistry = checkGovardRegistry
 	}
 	if dependencies.CheckProfileSync == nil {
-		dependencies.CheckProfileSync = CheckProfileSync
+		dependencies.CheckProfileSync = checkProfileSync
 	}
 	if dependencies.CheckSystemDependencies == nil {
-		dependencies.CheckSystemDependencies = CheckSystemDependencies
+		dependencies.CheckSystemDependencies = checkSystemDependencies
 	}
 	if dependencies.CheckRuntimeImages == nil {
-		dependencies.CheckRuntimeImages = CheckRuntimeImages
+		dependencies.CheckRuntimeImages = checkRuntimeImages
 	}
 	if dependencies.CheckLegacyConfig == nil {
-		dependencies.CheckLegacyConfig = CheckLegacyConfig
+		dependencies.CheckLegacyConfig = checkLegacyConfig
 	}
 	if dependencies.CheckConfigDrift == nil {
-		dependencies.CheckConfigDrift = CheckConfigDrift
+		dependencies.CheckConfigDrift = checkConfigDrift
 	}
 
 	report := DoctorReport{
@@ -430,12 +430,12 @@ func RunDoctorDiagnostics(dependencies DoctorDependencies) DoctorReport {
 			report.Failures++
 		}
 	}
-	report.IssueCards = BuildDoctorIssueCards(report.Checks)
+	report.IssueCards = buildDoctorIssueCards(report.Checks)
 
 	return report
 }
 
-func BuildDoctorIssueCards(checks []DoctorCheck) []DoctorIssueCard {
+func buildDoctorIssueCards(checks []DoctorCheck) []DoctorIssueCard {
 	cards := make([]DoctorIssueCard, 0, len(checks))
 	for _, check := range checks {
 		if check.Status == DoctorStatusPass {
@@ -500,7 +500,7 @@ func CheckGovardHomeWritable() error {
 	return file.Close()
 }
 
-func CheckGovardRegistry() error {
+func checkGovardRegistry() error {
 	path := ProjectRegistryPath()
 	info, err := os.Stat(path)
 	if err != nil {
@@ -610,7 +610,7 @@ func loadConfig() Config {
 	return config
 }
 
-func CheckProfileSync() error {
+func checkProfileSync() error {
 	config := loadConfig()
 	if config.Framework == "" || config.Framework == "generic" || config.Framework == "custom" {
 		return nil
@@ -706,7 +706,7 @@ func CollectProfileSyncWarnings(rawConfig Config, metadata ProjectMetadata) []st
 	return mismatches
 }
 
-func CheckSystemDependencies() []string {
+func checkSystemDependencies() []string {
 	missing := make([]string, 0, 4)
 
 	if _, err := exec.LookPath("docker"); err != nil {
@@ -726,7 +726,7 @@ func CheckSystemDependencies() []string {
 	return missing
 }
 
-func CheckRuntimeImages() ([]string, error) {
+func checkRuntimeImages() ([]string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("could not read working directory: %w", err)
@@ -754,7 +754,7 @@ func CheckRuntimeImages() ([]string, error) {
 	return missing, nil
 }
 
-func CheckLegacyConfig() error {
+func checkLegacyConfig() error {
 	data, err := os.ReadFile(BaseConfigFile)
 	if err != nil {
 		return nil // skip if no config
@@ -802,7 +802,7 @@ func CheckLegacyConfig() error {
 	return nil
 }
 
-func CheckConfigDrift() error {
+func checkConfigDrift() error {
 	wd, _ := os.Getwd()
 	data, err := os.ReadFile(BaseConfigFile)
 	if err != nil {

--- a/internal/engine/exec.go
+++ b/internal/engine/exec.go
@@ -15,16 +15,21 @@ func Handoff(binaryPath string, args []string) error {
 	return syscall.Exec(binaryPath, args, os.Environ())
 }
 
-// ExecuteInteractively runs a command with its stdio connected to the current terminal.
-// This is used when we don't want to replace the current process.
-func ExecuteInteractively(cmd *exec.Cmd) error {
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
 // ShellQuote is a wrapper around conventions.ShellQuote.
+// Deprecated: new code should use conventions.ShellQuote directly; this
+// wrapper is kept for backward compatibility within engine/cmd callers.
 func ShellQuote(raw string) string {
 	return conventions.ShellQuote(raw)
+}
+
+// ResolveDockerExecutor returns the provided executor or a default that
+// shells out via exec.Command. Used by framework base_url managers to
+// deduplicate the nil-check + CombinedOutput fallback.
+func ResolveDockerExecutor(executor func(name string, args ...string) ([]byte, error)) func(name string, args ...string) ([]byte, error) {
+	if executor != nil {
+		return executor
+	}
+	return func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).CombinedOutput()
+	}
 }

--- a/internal/engine/hosts.go
+++ b/internal/engine/hosts.go
@@ -17,12 +17,12 @@ var hostsFilePath = "/etc/hosts"
 // IsDomainResolvableLocally checks if the domain resolves to localhost (127.0.0.1 or ::1)
 // with a default timeout of 15 seconds.
 func IsDomainResolvableLocally(domain string) bool {
-	return IsDomainResolvableLocallyWithTimeout(domain, 15*time.Second)
+	return isDomainResolvableLocallyWithTimeout(domain, 15*time.Second)
 }
 
-// IsDomainResolvableLocallyWithTimeout checks if the domain resolves to localhost (127.0.0.1 or ::1)
+// isDomainResolvableLocallyWithTimeout checks if the domain resolves to localhost (127.0.0.1 or ::1)
 // within the specified timeout.
-func IsDomainResolvableLocallyWithTimeout(domain string, timeout time.Duration) bool {
+func isDomainResolvableLocallyWithTimeout(domain string, timeout time.Duration) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/internal/engine/lockfile.go
+++ b/internal/engine/lockfile.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	LockFilePathEnvVar = conventions.EnvGovardLock
+	lockFilePathEnvVar = conventions.EnvGovardLock
 	LockFileName       = conventions.LockFileName
 )
 
@@ -75,7 +75,7 @@ type LockCompliance struct {
 }
 
 func LockFilePath(root string) string {
-	if override := strings.TrimSpace(os.Getenv(LockFilePathEnvVar)); override != "" {
+	if override := strings.TrimSpace(os.Getenv(lockFilePathEnvVar)); override != "" {
 		return filepath.Clean(override)
 	}
 	cleanRoot := strings.TrimSpace(root)
@@ -326,7 +326,7 @@ func ReadServiceImagesFromCompose(composePath string) (map[string]string, error)
 	return normalizeServiceImages(images), nil
 }
 
-func DetectDockerVersionForLock() (string, error) {
+func detectDockerVersionForLock() (string, error) {
 	cmd := exec.Command("docker", "version", "--format", "{{.Server.Version}}")
 	output, err := cmd.Output()
 	if err != nil {
@@ -339,7 +339,7 @@ func DetectDockerVersionForLock() (string, error) {
 	return version, nil
 }
 
-func DetectDockerComposeVersionForLock() (string, error) {
+func detectDockerComposeVersionForLock() (string, error) {
 	cmd := exec.Command("docker", "compose", "version", "--short")
 	output, err := cmd.Output()
 	if err == nil {
@@ -418,16 +418,16 @@ func flattenStoreDomainsForLock(mappings StoreDomainMappings) map[string]string 
 
 func resolveLockDependencies(deps LockDependencies) LockDependencies {
 	if deps.ReadDockerVersion == nil {
-		deps.ReadDockerVersion = DetectDockerVersionForLock
+		deps.ReadDockerVersion = detectDockerVersionForLock
 	}
 	if deps.ReadDockerComposeVersion == nil {
-		deps.ReadDockerComposeVersion = DetectDockerComposeVersionForLock
+		deps.ReadDockerComposeVersion = detectDockerComposeVersionForLock
 	}
 	if deps.ReadServiceImages == nil {
 		deps.ReadServiceImages = ReadServiceImagesFromCompose
 	}
 	if deps.ReadCurrentUser == nil {
-		deps.ReadCurrentUser = DetectCurrentUserForLock
+		deps.ReadCurrentUser = detectCurrentUserForLock
 	}
 	if deps.Now == nil {
 		deps.Now = time.Now
@@ -443,7 +443,7 @@ func getGeneratedBy(deps LockDependencies) string {
 	return user
 }
 
-func DetectCurrentUserForLock() (string, error) {
+func detectCurrentUserForLock() (string, error) {
 	if user := os.Getenv("USER"); user != "" {
 		return user, nil
 	}

--- a/internal/engine/media_guard.go
+++ b/internal/engine/media_guard.go
@@ -56,8 +56,3 @@ func RunMediaGuard(projectRoot string) MediaGuardResult {
 	}
 	return MediaGuardResult{Status: "passed"}
 }
-
-// IsMediaGuardFailed reports whether pub/media contains executable PHP.
-func IsMediaGuardFailed(projectRoot string) bool {
-	return len(ScanMediaGuard(projectRoot)) > 0
-}

--- a/internal/engine/operations_log.go
+++ b/internal/engine/operations_log.go
@@ -37,7 +37,7 @@ type OperationEvent struct {
 	Message     string          `json:"message,omitempty"`
 }
 
-func OperationsLogPath() string {
+func operationsLogPath() string {
 	if override := strings.TrimSpace(os.Getenv(OperationsLogPathEnvVar)); override != "" {
 		return filepath.Clean(override)
 	}
@@ -71,7 +71,7 @@ func WriteOperationEvent(event OperationEvent) (err error) {
 		return fmt.Errorf("encode operation event: %w", err)
 	}
 
-	path := OperationsLogPath()
+	path := operationsLogPath()
 	if err := os.MkdirAll(filepath.Dir(path), conventions.SecretDirPerm); err != nil {
 		return fmt.Errorf("create operations log dir: %w", err)
 	}
@@ -93,7 +93,7 @@ func WriteOperationEvent(event OperationEvent) (err error) {
 }
 
 func ReadOperationEvents(limit int) ([]OperationEvent, error) {
-	path := OperationsLogPath()
+	path := operationsLogPath()
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -119,7 +119,7 @@ func ResolveRuntimeProfile(framework string, version string) (RuntimeProfileResu
 		return result, nil
 	}
 
-	if resolver, ok := GetVersionProfileResolver(framework); ok {
+	if resolver, ok := getVersionProfileResolver(framework); ok {
 		override, source, ok := resolver(version)
 		if !ok {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("No version-specific profile for %s version %q. Using framework defaults.", framework, version))
@@ -280,8 +280,8 @@ func RegisterVersionProfileResolver(framework string, resolver VersionProfileRes
 	versionProfileResolvers[strings.ToLower(strings.TrimSpace(framework))] = resolver
 }
 
-// GetVersionProfileResolver looks up the registered resolver for framework.
-func GetVersionProfileResolver(framework string) (VersionProfileResolver, bool) {
+// getVersionProfileResolver looks up the registered resolver for framework.
+func getVersionProfileResolver(framework string) (VersionProfileResolver, bool) {
 	resolver, ok := versionProfileResolvers[strings.ToLower(strings.TrimSpace(framework))]
 	return resolver, ok
 }

--- a/internal/engine/remote_config.go
+++ b/internal/engine/remote_config.go
@@ -119,7 +119,7 @@ func IsSupportedRemoteAuthMethod(method string) bool {
 
 // RemotePriority returns a priority number for sorting remotes.
 // Smaller numbers mean higher priority (earlier in the list).
-func RemotePriority(name string) int {
+func remotePriority(name string) int {
 	switch NormalizeRemoteEnvironment(name) {
 	case RemoteEnvDev:
 		return 10
@@ -136,8 +136,8 @@ func RemotePriority(name string) int {
 // then alphabetically for names with equal priority.
 func SortRemoteNames(names []string) {
 	sort.Slice(names, func(i, j int) bool {
-		pi := RemotePriority(names[i])
-		pj := RemotePriority(names[j])
+		pi := remotePriority(names[i])
+		pj := remotePriority(names[j])
 		if pi != pj {
 			return pi < pj
 		}

--- a/internal/engine/render.go
+++ b/internal/engine/render.go
@@ -393,9 +393,8 @@ func varnishTemplateFramework(framework string) string {
 	return framework
 }
 
-// BlueprintVersion should be incremented whenever architectural changes are made to the embedded blueprints
-// to ensure that 'govard env up' re-renders existing environments.
-const BlueprintVersion = "1.47"
+// blueprintVersion should be incremented whenever architectural changes are made to the embedded blueprints
+const blueprintVersion = "1.47"
 
 func RenderBlueprintWithProfile(root string, config Config, profile string) error {
 	blueprintsFS, err := resolveBlueprintsDirForConfig(root, config)
@@ -452,7 +451,7 @@ func RenderBlueprintWithProfile(root string, config Config, profile string) erro
 	hashPath := outputPath + ".hash"
 
 	hashData, _ := json.Marshal(config)
-	hashSum := sha256.Sum256(append(hashData, []byte(profile+BlueprintVersion+blueprintFingerprint+overrideFingerprint+nginxCustomFingerprint+apacheCustomFingerprint+envFingerprint+packageManager+runtimeDomainHostsFingerprint+govardRootCAPath)...))
+	hashSum := sha256.Sum256(append(hashData, []byte(profile+blueprintVersion+blueprintFingerprint+overrideFingerprint+nginxCustomFingerprint+apacheCustomFingerprint+envFingerprint+packageManager+runtimeDomainHostsFingerprint+govardRootCAPath)...))
 	currentHash := hex.EncodeToString(hashSum[:])
 
 	if existingHash, err := os.ReadFile(hashPath); err == nil && string(existingHash) == currentHash {

--- a/internal/engine/table_prefix.go
+++ b/internal/engine/table_prefix.go
@@ -46,20 +46,20 @@ func RegisterTablePrefixDetector(framework string, detector TablePrefixDetector)
 	tablePrefixDetectors[normalizeFrameworkManifestKey(framework)] = detector
 }
 
-// GetTablePrefixDetector looks up the registered table-prefix detector for
+// getTablePrefixDetector looks up the registered table-prefix detector for
 // framework (post normalizeFrameworkManifestKey aliasing).
-func GetTablePrefixDetector(framework string) (TablePrefixDetector, bool) {
+func getTablePrefixDetector(framework string) (TablePrefixDetector, bool) {
 	detector, ok := tablePrefixDetectors[normalizeFrameworkManifestKey(framework)]
 	return detector, ok
 }
 
 func FrameworkSupportsTablePrefix(framework string) bool {
-	_, ok := GetTablePrefixDetector(framework)
+	_, ok := getTablePrefixDetector(framework)
 	return ok
 }
 
 func DetectFrameworkTablePrefix(root string, framework string) string {
-	detector, ok := GetTablePrefixDetector(framework)
+	detector, ok := getTablePrefixDetector(framework)
 	if !ok {
 		return ""
 	}

--- a/internal/frameworks/magento1/base_url_manager.go
+++ b/internal/frameworks/magento1/base_url_manager.go
@@ -3,7 +3,6 @@ package magento1
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -74,12 +73,7 @@ func (m *Magento1Manager) Revert(projectRoot string, config engine.Config) error
 	return err
 }
 func (m *Magento1Manager) executeDockerMysql(container string, sql string) ([]byte, error) {
-	executor := m.Executor
-	if executor == nil {
-		executor = func(name string, args ...string) ([]byte, error) {
-			return exec.Command(name, args...).CombinedOutput()
-		}
-	}
+	executor := engine.ResolveDockerExecutor(m.Executor)
 	// Use smart detection for mysql vs mariadb binary
 	script := fmt.Sprintf(
 		`if command -v mysql >/dev/null 2>&1; then DB_CLI=mysql; elif command -v mariadb >/dev/null 2>&1; then DB_CLI=mariadb; else exit 1; fi && "$DB_CLI" -u%s -p%s %s -e %s`,

--- a/internal/frameworks/magento2/base_url_manager.go
+++ b/internal/frameworks/magento2/base_url_manager.go
@@ -2,7 +2,6 @@ package magento2
 
 import (
 	"fmt"
-	"os/exec"
 
 	"govard/internal/conventions"
 	"govard/internal/engine"
@@ -57,12 +56,7 @@ func (m *Magento2Manager) Revert(projectRoot string, config engine.Config) error
 }
 
 func (m *Magento2Manager) executeMagento(container string, user string, magentoArgs ...string) error {
-	executor := m.Executor
-	if executor == nil {
-		executor = func(name string, args ...string) ([]byte, error) {
-			return exec.Command(name, args...).CombinedOutput()
-		}
-	}
+	executor := engine.ResolveDockerExecutor(m.Executor)
 	args := append([]string{"exec", "-u", user, "-w", conventions.DefaultWorkDir, container, "bin/magento"}, magentoArgs...)
 	_, err := executor("docker", args...)
 	return err
@@ -70,12 +64,7 @@ func (m *Magento2Manager) executeMagento(container string, user string, magentoA
 
 func (m *Magento2Manager) flushRedis(config engine.Config) {
 	containerName := fmt.Sprintf("%s%s", config.ProjectName, conventions.RedisSuffix)
-	executor := m.Executor
-	if executor == nil {
-		executor = func(name string, args ...string) ([]byte, error) {
-			return exec.Command(name, args...).CombinedOutput()
-		}
-	}
+	executor := engine.ResolveDockerExecutor(m.Executor)
 	// Best effort flush
 	_, _ = executor("docker", "exec", containerName, "redis-cli", "flushall")
 }

--- a/internal/frameworks/magento2/frontend_sync.go
+++ b/internal/frameworks/magento2/frontend_sync.go
@@ -292,16 +292,6 @@ func buildFrontendSyncWatchers(themes []FrontendSyncTheme) []FrontendSyncWatcher
 	return watchers
 }
 
-// DiscoverFrontendSyncWatchers returns the watcher services rendered for the
-// Hyva themes beneath root.
-func DiscoverFrontendSyncWatchers(root string) ([]FrontendSyncWatcher, error) {
-	themes, err := DiscoverFrontendSyncThemes(root)
-	if err != nil {
-		return nil, err
-	}
-	return buildFrontendSyncWatchers(themes), nil
-}
-
 func frontendSyncIdentityHash(theme FrontendSyncTheme) string {
 	sum := sha256.Sum256([]byte(theme.Vendor + "\x00" + theme.Theme))
 	return hex.EncodeToString(sum[:])

--- a/internal/frameworks/magento2/magento2.go
+++ b/internal/frameworks/magento2/magento2.go
@@ -132,14 +132,3 @@ func Definition() types.FrameworkDefinition {
 		},
 	}
 }
-
-// StableVolumeKey returns the stable volume key for a Magento2 project
-// derived from govard.yml name (not sha1(cwd)).
-func StableVolumeKey(projectName string) string {
-	return conventions.StableVolumeKey(projectName)
-}
-
-// LintIgnore returns .magelintignore quick/deep profiles.
-func LintIgnore(quick bool) []string {
-	return conventions.LintIgnore(quick)
-}

--- a/internal/frameworks/magento2/metadata.go
+++ b/internal/frameworks/magento2/metadata.go
@@ -27,23 +27,6 @@ func ProbeMagento2Environment(remoteName string, remoteCfg engine.RemoteConfig) 
 	return decodeMagento2EnvironmentPayload(encoded)
 }
 
-// DetectMagento2Version is currently unused anywhere in the codebase
-// (confirmed by a whole-repo grep this session) - kept during this move
-// since deleting dead-but-exported code is a separate decision from this
-// refactor's scope, not bundled in here.
-func DetectMagento2Version(remoteName string, remoteCfg engine.RemoteConfig) (string, error) {
-	remoteCommand := remote.BuildProjectRemoteCommand(remoteCfg.Path, `php -r `+engine.ShellQuote(magentoVersionProbePHP))
-	output, err := remote.RunRemoteCapture(remoteName, remoteCfg, remoteCommand)
-	if err != nil {
-		return "", err
-	}
-	version := normalizeMagentoVersion(strings.TrimSpace(output))
-	if version == "" {
-		return "", fmt.Errorf("remote composer.json does not contain a Magento package version")
-	}
-	return version, nil
-}
-
 func NormalizeMagentoVersion(raw string) string {
 	return normalizeMagentoVersion(raw)
 }
@@ -125,5 +108,3 @@ func normalizeMagentoVersion(raw string) string {
 }
 
 const magentoDBProbePHP = `$c=@include "app/etc/env.php"; if(!is_array($c)){fwrite(STDERR,"env.php not found"); exit(2);} $d=$c["db"]["connection"]["default"] ?? null; if(!is_array($d)){fwrite(STDERR,"db.default missing"); exit(3);} $r=["host"=>$d["host"] ?? "", "username"=>$d["username"] ?? "", "password"=>$d["password"] ?? "", "dbname"=>$d["dbname"] ?? "", "table_prefix"=>($c["db"]["table_prefix"] ?? ""), "crypt_key"=>($c["crypt"]["key"] ?? "")]; echo base64_encode(json_encode($r));`
-
-const magentoVersionProbePHP = `$c=@json_decode(@file_get_contents("composer.json"), true); if(!is_array($c)){fwrite(STDERR,"composer.json missing"); exit(2);} $r=$c["require"] ?? []; $v=""; if(isset($r["magento/product-community-edition"])){$v=$r["magento/product-community-edition"]; } elseif(isset($r["magento/product-enterprise-edition"])){$v=$r["magento/product-enterprise-edition"]; } echo (string)$v;`

--- a/internal/frameworks/wordpress/base_url_manager.go
+++ b/internal/frameworks/wordpress/base_url_manager.go
@@ -2,7 +2,6 @@ package wordpress
 
 import (
 	"fmt"
-	"os/exec"
 
 	"govard/internal/conventions"
 	"govard/internal/engine"
@@ -34,12 +33,7 @@ func (m *WordPressManager) Revert(projectRoot string, config engine.Config) erro
 	return err
 }
 func (m *WordPressManager) executeWP(container string, args ...string) ([]byte, error) {
-	executor := m.Executor
-	if executor == nil {
-		executor = func(name string, args ...string) ([]byte, error) {
-			return exec.Command(name, args...).CombinedOutput()
-		}
-	}
+	executor := engine.ResolveDockerExecutor(m.Executor)
 	fullArgs := append([]string{"exec", "-u", conventions.UserWWWData, "-w", conventions.DefaultWorkDir, container, "wp", "--allow-root"}, args...)
 	return executor("docker", fullArgs...)
 }

--- a/internal/frameworks/wordpress/bootstrap.go
+++ b/internal/frameworks/wordpress/bootstrap.go
@@ -439,8 +439,3 @@ func SetWordPressCoreDownloaderForTest(fn func(projectDir string) error) func() 
 		wordpressCoreDownloader = previous
 	}
 }
-
-// GetWordPressArchiveURLForTest exposes getWordPressArchiveURL for tests.
-func GetWordPressArchiveURLForTest(version string) string {
-	return getWordPressArchiveURL(version)
-}


### PR DESCRIPTION
Closes #202

## Summary
Deadcode audit (4 parallel slices, 739 files, manual `grep -rn -w Sym` + `golang.org/x/tools/cmd/deadcode@v0.33.0` with/without `-test` + `go vet`) found high-confidence deadcode across `internal/*`, `cmd/*`, `tests/*`, `desktop/*`. Squashed into a single commit (39 files, +82 -496).

## Changes
- **conventions**: remove 28 unused consts/funcs (proxy/ssl dirs, `HTTPSPort`, `DefaultDomainSuffix`, Magento paths, env vars, container suffixes, services, limits, targets) — all `grep` outside package = 0.
- **cmd**: register `trustCmd` on `rootCmd` (`govard trust` was unreachable, only `doctor trust` borrowed its `RunE`) — now both work; remove 5 dead `ForTest` wrappers/seams.
- **frameworks/magento2**: remove `DiscoverFrontendSyncWatchers`, `DetectMagento2Version`+probe (self-commented unused, superseded by `ProbeMagento2Environment`), and `StableVolumeKey`/`LintIgnore` wrapper triplication (0 callers, canonical stays in `conventions`/`engine`).
- **engine**: unexport 18 intra-only helpers, then remove 8 that were still unreachable after unexporting (`auditRunScope`, `validateConfigDrift`, `MageModeGuard`, `dbSlowLockPath`/`acquireDbSlowLock`/`dbSlowCollector`, `executeInteractively`, `isMediaGuardFailed`); extract `ResolveDockerExecutor` to dedupe the nil-check + `exec.Command` fallback repeated across magento1/magento2/wordpress `base_url_manager.go`; document `ShellQuote` wrapper as deprecated in favor of `conventions.ShellQuote` (kept to avoid churning 90+ call sites).
- **desktop**: remove 7 dead `ForTest` seams, then 3 vars that became unused once those seams were gone (`runEnvironmentComposeForDesktop`, `waitForGlobalProxyReadyForDesktop`, `refreshGlobalServiceRoutesForDesktop`), then the now-orphaned `registerDesktopGlobalServiceRoutes`/`reviveRunningProjectRoutesForDesktop`/`resolveDesktopUpProxyTarget`. Verified these had already been unreachable since the March 2026 refactor (`24f24f0`) that moved global-services start/restart to delegate to the `govard` CLI — the equivalent route registration + running-project route revival already live in `internal/cmd/svc.go`'s `handleSvcUp` (`registerGlobalServiceRoutes`/`reviveRunningProjectRoutes`), so no behavior is lost.
- **cmd/audit.go**: `warnXdebugGuard` dropped its unused `*cobra.Command` param and a stale comment referring to the just-removed `MageModeGuard`. That comment described a MAGE_MODE audit warning that was never actually wired up (pre-existing gap from `fec1d20b`, out of scope to implement here) — removed the misleading comment instead of leaving it pointing at a deleted symbol.

## Kept intentionally (not deadcode, or deliberate keep)
- Exported types/`ForTest` seams used by `tests/`/`cmd/` (`BlueprintCacheEntry`, `LockConfig`, `DoctorCheckStatus`, etc.).
- `DBDriverCategoryForFramework` — the reader half of a registration API whose writer `RegisterDBDriverCategory` is still called from `frameworks.Register`. The PHP-array renderer (`dbDriverCategoryPHPArray`) iterates the map directly instead of calling the getter, so the getter is genuinely unused today; kept as symmetric public API for future/external consumers rather than removed as a tool false positive.
- 6 `deadcode -test` flags that are verified false positives: desktop build-tag helpers (`ResolveAssets`, `isDir`), `frameworks.Register` (init-time registration, not traced), 2 integration-tag `ForTest` seams (`CheckProfileShiftCleanupForTest`, `DetectProfileShiftForTest`).

## Validation
- `gofmt -s -l .` clean
- `go vet ./...` clean
- `go build ./cmd/govard` ok, `govard trust --help` / `govard doctor trust --help` both list the command, no collision
- `go test ./... -count=1` 4/4 ok (engine, tests ~16-17s, proddesktopwiring, prodwiring)
- `deadcode -test ./...` 20 -> 6 (all verified false positives above)
- `deadcode ./...` (no `-test`) 640 remaining, all `*ForTest` seams unreachable from `main` as expected (intentional test seams)
- No private project slugs in diff — blacklist hook clean

## Risk
Low — every removed/unexported symbol was verified to have 0 external references (including `tests/`), and the one area that looked like it could be a real feature loss (desktop global-services route registration) was cross-checked against `internal/cmd/svc.go` to confirm the CLI already covers it.