### PR TITLE
docs(govard): update audit docs for glint rename and laravel excludes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ internal/desktop/               # Desktop backend
 internal/proxy/                 # Caddy/proxy TLS
 internal/ui/                    # Terminal rendering
 internal/updater/               # Self-update
+docker/audit/                   # Lint image (glint, formerly magelint/audit-magento) — Dockerfile + bin/glint (magelint symlink) + toolchains
 tests/                          # Unit tests
 tests/integration/              # Integration tests
 tests/frontend/                 # Frontend JS tests

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -74,7 +74,7 @@ govard audit cleanup --older-than 168h
 `--lint-provider govard`, `--mode auto` và `--lint-jobs min(nproc,4)` (mặc định `4` trên host thường, kẹp `2–8`). Format mặc định
 `text` stream tiến trình trực tiếp như `vendor/bin/phpcs`/`vendor/bin/phpstan` —
 giai đoạn `validate` → `prepare` → `phpcs`/`phpstan`, trạng thái cache
-(`cold`/`warm`/`bypassed`) và `magelint: php X.Y analyzed` hiện ngay khi chạy —
+(`cold`/`warm`/`bypassed`) và `glint: php X.Y analyzed` (`magelint` legacy) hiện ngay khi chạy —
 rồi mới in bản tóm tắt: kết luận trước (PASSED/FAILED/CANCELLED), scope, thời
 gian, môi trường, kết quả từng PHP kèm findings và gợi ý `What next` trỏ tới
 report đã lưu cùng lệnh rerun chính xác. Trên TTY tương tác (và khi chưa đặt

--- a/docs/workflows/audit.md
+++ b/docs/workflows/audit.md
@@ -80,7 +80,7 @@ Govard-native lint (`govard audit run --checks lint --mode project`) matrix:
 | Symfony | Symfony | 5 | 8.1-8.4 | 8.1-8.4 | phpcs, phpstan |
 | WordPress | WordPress | 5 | 8.1-8.4 | 8.1-8.4 | phpcs, phpstan |
 
-Image `govard-magelint` bundles WPCS 3.1 (`wp-coding-standards/wpcs`) + Symfony CS + `phpstan-symfony`/`phpstan-wordpress` so WordPress (classic `wp-includes/version.php` + Bedrock `web/wp`) and Symfony (`bin/console`) run natively — no fallback to PSR12.
+Image `govard-magelint` (now `glint`, `docker/audit`, `govard-local/glint:` — `magelint` kept as symlink for compat, `ghcr.io/ddtcorex/govard-magelint` unchanged) bundles WPCS 3.1 (`wp-coding-standards/wpcs`) + Symfony CS + `phpstan-symfony`/`phpstan-wordpress` so WordPress (classic `wp-includes/version.php` + Bedrock `web/wp`) and Symfony (`bin/console`) run natively — no fallback to PSR12. Laravel excludes `bootstrap/cache/*` and `storage/*` (`storage/framework/*`, `storage/logs`) — filtered in `docker/audit/bin/glint` (`--ignore` + `excludePaths`) and Go-side `govardLintDigest` filter, so fresh `laravel 11` no longer fails on generated `packages.php`/`services.php`/`storage/framework/views/*.php`.
 
 ## PHP Versions (`--php`)
 
@@ -124,7 +124,7 @@ See `internal/blueprints/files/.gitignore` (shared, single source; rendered as p
 
 ## Concurrency
 
-Runs for the same project are queued via `~/.govard/audit/<projectId>/lock` (under `GovardHomeDir`, respecting `GOVARD_HOME_DIR`; wait up to 30s, `audit run waiting for prior run`), not cancelled. A stale lock after 30s fails with a hint to remove the lock or run `govard audit cleanup`.
+Runs for the same project are queued via `~/.govard/audit/<projectId>/lock` (under `GovardHomeDir`, respecting `GOVARD_HOME_DIR`; wait up to 30s, `audit run waiting for prior run`), not cancelled. Since `v1.68.0` a stale lock is auto-removed if `mtime>10m` or holder PID dead (`syscall.Signal(0)`), otherwise after 30s fails with a hint to remove the lock or run `govard audit cleanup`.
 
 ## Xdebug guard
 


### PR DESCRIPTION
Updates docs for 2026-08-31 session (eb129e2 + ad95b74):

- docs/workflows/audit.md: govard-magelint -> glint (docker/audit, govard-local/glint, magelint symlink kept), document Laravel bootstrap/cache and storage excludes
- docs/vi/reference/cli-commands.md: magelint -> glint (magelint legacy)
- AGENTS.md: add docker/audit (glint, formerly magelint/audit-magento) to Repository Map

Refs: govard eb129e2, ad95b74, maestro-skills #50