### PR TITLE
chore(release): 1.69.0 — verify harness + glint-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.69.0] - 2026-08-31
+
+### ✨ New Features
+
+- **Executable QA Harness `govard verify`:** 5-phase registry (`56` items `P1 7` · `P2 14` · `P3 15` · `P4 12` · `P5 8`, Guard `READ-ONLY-REMOTE`/`DESTRUCTIVE-LOCAL`, `When isMagento2` → `46` for Laravel/Symfony/WordPress), runner with `P4-08` + `--allow-destructive` gates (`--plan` bypasses), writes `~/.govard/verify-runs/<ISO>-phaseN.json` (migrates `checklist-runs`), JSON schema frozen, Cobra `govard verify` (`--phase`, `--json`, `--plan`, `--allow-destructive`/`--yes`, `--lint-jobs`, `--timeout`, `--checks`, `--base`, `--remote`, `--project`) combines all phases into single JSON `phase: "all"` when `--json`, framework fallback via `DetectFramework`, docs in `docs/reference/cli-commands.md` (EN/VI) and `README`. Checklist markdown template removed — `govard verify` is the single source. (#213)
+
+### ♻️ Refactor
+
+- **Audit: remove magelint completely, use glint only:** `audit-magento` → `audit`, `govard-magelint` (`ghcr.io/ddtcorex/govard-magelint`) → `govard-glint` (`ghcr.io/ddtcorex/govard-glint`), `docker/audit/bin/magelint` kept as symlink for transition, `scripts/benchmark-magelint.sh` → `benchmark-glint.sh`, tests `audit_magelint_live_test.go` → `audit_glint_live_test.go`, docs and `govard-toolbox` synced. (#212)
+
 ## [1.68.0] - 2026-08-30
 
 ### ✨ New Features

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.68.0"
+    "productVersion": "1.69.0"
   }
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.68.0"
+var Version = "1.69.0"
 
 var verbose bool
 

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.68.0"
+var Version = "1.69.0"
 
 type App struct {
 	ctx context.Context


### PR DESCRIPTION
Release 1.69.0

- feat(verify): executable checklist via govard verify (56 items, 5 phases) #213
- refactor(audit): remove magelint completely, use glint only #212

Version bump: internal/cmd/root.go, internal/desktop/app.go, desktop/frontend/package.json, desktop/wails.json, CHANGELOG.md

Verification: make vet, make generate-check, make build (VERSION=1.69.0), govard version, govard verify --plan --json 56/46 per framework, audit glint

Closes #213, #212