### PR TITLE
fix(audit): bucket analyzer tooling limitations out of lint findings

### DIFF
--- a/docker/audit/bin/glint
+++ b/docker/audit/bin/glint
@@ -735,9 +735,12 @@ write_phpstan_config() {
         # it for PHP uploads instead.
         # bootstrap/cache and storage are Laravel generated trees (also safe to
         # ignore for any framework).
+        # dev/tests holds framework test fixtures that crash PHPStan with
+        # severe internal errors on full-project analysis; excluding it keeps
+        # the per-file findings instead of an "incomplete result".
         # Use `/**/*` so nested trees like `var/deployer/releases/1/var/www/html` are always excluded,
         # not just the top-level `var/*` glob.
-        for excluded in vendor generated var pub/static pub/media bootstrap/cache storage; do
+        for excluded in vendor generated var pub/static pub/media bootstrap/cache storage dev/tests; do
             printf '\t\t\t- %s\n' "$ANALYZE_DIR/$excluded/**/*"
         done
         if [ "$TARGET_MODE" = "standalone" ] && [ -d "$ANALYZE_DIR/vendor" ]; then

--- a/docker/audit/tests/contract_test.sh
+++ b/docker/audit/tests/contract_test.sh
@@ -893,6 +893,27 @@ case_phpstan_excludes_var_deployer() {
     fi
 }
 
+case_phpstan_excludes_test_fixtures() {
+    new_case phpstan_excludes_test_fixtures
+    CASE_TARGET_MODE="project"
+    # Framework test fixtures (dev/tests) crash PHPStan with severe internal
+    # errors on full-project analysis, discarding every per-file finding.
+    mkdir -p "$CASE_DIR/source/dev/tests/integration/_files"
+    printf '<?php class Fixture_Broken {}\n' >"$CASE_DIR/source/dev/tests/integration/_files/broken.php"
+    # Verify write_phpstan_config emits a recursive exclude for dev/tests.
+    invoke_runner --php 8.3
+    assert_equals "exclude fixtures exit status" "0" "$RUN_STATUS"
+    local config_file
+    config_file=$(find "$CASE_DIR/workspace" -name "phpstan.neon" 2>/dev/null | head -1)
+    if [ -z "$config_file" ]; then
+        fail "phpstan config not found"
+    else
+        assert_contains "phpstan config excludes dev/tests recursively" "$(cat "$config_file")" "dev/tests/**/*"
+        # The fixture file should not contribute to findings (it is excluded) - report should be clean.
+        assert_equals "fixture file not analyzed" "passed" "$(json_php_field "$REPORT" outcome)"
+    fi
+}
+
 CASES="
 case_help_documents_contract
 case_rejects_unknown_flag
@@ -921,6 +942,7 @@ case_media_guard_reports_php_in_media
 case_media_guard_passes_clean_media
 case_phpstan_stale_cache_is_healed
 case_phpstan_excludes_var_deployer
+case_phpstan_excludes_test_fixtures
 "
 
 run_case() {

--- a/internal/audit/lint.go
+++ b/internal/audit/lint.go
@@ -87,6 +87,10 @@ type LintPHPResult struct {
 	Cache      CacheOutcome  `json:"cache"`
 	Phases     []LintPhase   `json:"phases"`
 	Findings   []LintFinding `json:"findings"`
+	// LimitedFindings counts findings partitioned out as analyzer tooling
+	// limitations (crashes, test fixtures) rather than project code. The
+	// container never writes it; the host sets it in acceptReport.
+	LimitedFindings int `json:"limited_findings,omitempty"`
 }
 
 type LintReport struct {

--- a/internal/audit/lint_govard.go
+++ b/internal/audit/lint_govard.go
@@ -412,7 +412,8 @@ func (backend *GovardLintBackend) acceptReport(request LintRequest, resolved Res
 	// match the intended glint excludes without waiting for an image
 	// rebuild.
 	filtered := filterGeneratedFindings(report)
-	if filtered {
+	limited := partitionToolingLimitations(report)
+	if filtered || limited > 0 {
 		// Recompute aggregate status and per-PHP outcomes after filtering;
 		// the container's exit code may still be 1 (findings) while the
 		// filtered report is now passed, so we do not enforce the exit-code
@@ -477,6 +478,64 @@ func recomputeLintReportStatus(report LintReport) LintReport {
 	}
 	report.Status = status
 	return report
+}
+
+// isToolingLimitationFinding reports whether a finding describes an analyzer
+// tooling limitation rather than project code: a PHPStan internal crash
+// ("Internal error: ...", which normalize_phpstan surfaces as a pathless
+// compatibility finding) or any finding inside the dev/tests fixture tree,
+// which is never shipped. Both signals are framework-agnostic: crash-message
+// shape and test-fixture location, never a framework name.
+func isToolingLimitationFinding(finding LintFinding) bool {
+	if strings.HasPrefix(finding.Message, "Internal error:") {
+		return true
+	}
+	normalized := filepath.ToSlash(finding.Path)
+	return normalized == "dev/tests" || strings.HasPrefix(normalized, "dev/tests/")
+}
+
+func partitionToolingLimitationFindings(findings []LintFinding) (actionable, limited []LintFinding) {
+	for _, finding := range findings {
+		if isToolingLimitationFinding(finding) {
+			limited = append(limited, finding)
+			continue
+		}
+		actionable = append(actionable, finding)
+	}
+	return actionable, limited
+}
+
+// partitionToolingLimitations removes tooling-limitation findings from every
+// PHP result in place and recomputes each outcome: failed while actionable
+// findings remain, passed when only limitations were present. It returns the
+// number of partitioned findings.
+func partitionToolingLimitations(report LintReport) int {
+	limited := 0
+	for idx := range report.PHPResults {
+		actionable, dropped := partitionToolingLimitationFindings(report.PHPResults[idx].Findings)
+		if len(dropped) == 0 {
+			continue
+		}
+		limited += len(dropped)
+		report.PHPResults[idx].Findings = actionable
+		report.PHPResults[idx].LimitedFindings = len(dropped)
+		if len(actionable) == 0 {
+			report.PHPResults[idx].Outcome = "passed"
+		} else {
+			report.PHPResults[idx].Outcome = "failed"
+		}
+	}
+	return limited
+}
+
+// PartitionToolingLimitationsForTest exposes partitionToolingLimitationFindings for external tests.
+func PartitionToolingLimitationsForTest(findings []LintFinding) (actionable, limited []LintFinding) {
+	return partitionToolingLimitationFindings(findings)
+}
+
+// ApplyToolingLimitationPartitionForTest exposes partitionToolingLimitations for external tests.
+func ApplyToolingLimitationPartitionForTest(report *LintReport) int {
+	return partitionToolingLimitations(*report)
 }
 
 func (backend *GovardLintBackend) containerRequest(request LintRequest, plan govardLintTarget, resolved ResolvedToolchain, toolchainDigest, cacheDir string) ContainerRunRequest {

--- a/internal/cmd/audit_output.go
+++ b/internal/cmd/audit_output.go
@@ -188,6 +188,9 @@ func (r auditTextRenderer) phpResult(php auditLintPHPView) {
 	}
 	parts = append(parts, cacheText, fmt.Sprintf("%d findings", len(php.Findings)))
 	r.printf("      %s", strings.Join(parts, " | "))
+	if php.LimitedFindings > 0 {
+		r.printf("      ... and %d tooling-limitation findings excluded (analyzer crashes and test fixtures, not project code)", php.LimitedFindings)
+	}
 	limit := auditMaxDisplayedFindings
 	if r.color {
 		// On an interactive terminal the operator is actively fixing code;
@@ -396,12 +399,13 @@ func (r auditTextRenderer) removedSessions(payload map[string]any) {
 const auditMaxDisplayedFindings = 10
 
 type auditLintPHPView struct {
-	Version     string
-	Outcome     string
-	DurationMS  int64
-	CacheState  string
-	CacheReason string
-	Findings    []auditLintFindingView
+	Version         string
+	Outcome         string
+	DurationMS      int64
+	CacheState      string
+	CacheReason     string
+	Findings        []auditLintFindingView
+	LimitedFindings int
 }
 
 type auditLintFindingView struct {
@@ -460,12 +464,13 @@ func auditLintPHPViews(evidence map[string]any) []auditLintPHPView {
 				})
 			}
 			views = append(views, auditLintPHPView{
-				Version:     result.PHPVersion,
-				Outcome:     result.Outcome,
-				DurationMS:  result.DurationMS,
-				CacheState:  result.Cache.State,
-				CacheReason: result.Cache.Reason,
-				Findings:    findings,
+				Version:         result.PHPVersion,
+				Outcome:         result.Outcome,
+				DurationMS:      result.DurationMS,
+				CacheState:      result.Cache.State,
+				CacheReason:     result.Cache.Reason,
+				Findings:        findings,
+				LimitedFindings: result.LimitedFindings,
 			})
 		}
 		return views
@@ -481,9 +486,10 @@ func auditLintPHPViews(evidence map[string]any) []auditLintPHPView {
 			continue
 		}
 		view := auditLintPHPView{
-			Version:    auditMapString(item, "php_version"),
-			Outcome:    auditMapString(item, "outcome"),
-			DurationMS: auditMapInt64(item, "duration_ms"),
+			Version:         auditMapString(item, "php_version"),
+			Outcome:         auditMapString(item, "outcome"),
+			DurationMS:      auditMapInt64(item, "duration_ms"),
+			LimitedFindings: int(auditMapInt64(item, "limited_findings")),
 		}
 		if cache, ok := item["cache"].(map[string]any); ok {
 			view.CacheState = auditMapString(cache, "state")

--- a/tests/audit_lint_govard_test.go
+++ b/tests/audit_lint_govard_test.go
@@ -1151,3 +1151,43 @@ func writeLintReportFileForTest(t *testing.T, runDir string, report audit.LintRe
 		t.Fatal(err)
 	}
 }
+
+func TestPartitionToolingLimitationFindings(t *testing.T) {
+	report := audit.LintReport{PHPResults: []audit.LintPHPResult{{
+		PHPVersion: "8.4",
+		Findings: []audit.LintFinding{
+			{Tool: "M2-LINT-COMPAT", Path: "dev/tests/integration/testsuite/Magento/Framework/Jwt/JwtManagerTest.php", Message: "Function openssl_free_key() is deprecated since PHP 8.0"},
+			{Tool: "M2-LINT-COMPAT", Message: "Internal error: Magento\\TestModuleExtensionAttributes\\Api\\Data\\FakeRegionInterface does not exist and has no extension interface while analysing file /source/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/Data/FakeRegion.php"},
+			{Tool: "M2-LINT-PHPCS", Rule: "Generic.Files.LineLength.TooLong", Path: "app/code/Acme/Elist/Controller/Submit/Create.php", Message: "Line exceeds 120 characters"},
+		},
+	}}}
+	actionable, limited := audit.PartitionToolingLimitationsForTest(report.PHPResults[0].Findings)
+	if len(actionable) != 1 || len(limited) != 2 {
+		t.Fatalf("got %d actionable, %d limited; want 1, 2", len(actionable), len(limited))
+	}
+}
+
+func TestPartitionedLimitationsRecomputeOutcome(t *testing.T) {
+	// Partitioning tooling limitations out of a PHP result must leave the
+	// actionable findings in place and recompute the outcome: failed while
+	// actionable findings remain, passed when only limitations were present.
+	report := audit.LintReport{Status: "failed", PHPResults: []audit.LintPHPResult{{
+		PHPVersion: "8.4",
+		Outcome:    "failed",
+		Findings: []audit.LintFinding{
+			{Tool: "M2-LINT-COMPAT", Message: "Internal error: FakeRegionInterface does not exist and has no extension interface while analysing file /source/dev/tests/integration/_files/FakeRegion.php"},
+			{Tool: "M2-LINT-PHPSTAN", Rule: "method.notFound", Path: "app/code/Acme/Contact/ViewModel/ContactViewModel.php", Line: 56, Message: "Call to an undefined method Magento\\Framework\\View\\Element\\BlockInterface::setData()."},
+		},
+	}}}
+	limited := audit.ApplyToolingLimitationPartitionForTest(&report)
+	if limited != 1 {
+		t.Fatalf("partitioned %d limited findings; want 1", limited)
+	}
+	kept := report.PHPResults[0].Findings
+	if len(kept) != 1 || kept[0].Rule != "method.notFound" {
+		t.Fatalf("kept findings = %+v; want only the actionable method.notFound", kept)
+	}
+	if report.PHPResults[0].Outcome != "failed" {
+		t.Fatalf("outcome = %q; want failed while actionable findings remain", report.PHPResults[0].Outcome)
+	}
+}

--- a/tests/audit_output_test.go
+++ b/tests/audit_output_test.go
@@ -36,6 +36,25 @@ func failingLintReportWithFindings(projectID string) audit.LintReport {
 	return report
 }
 
+func TestAuditRunTextSurfacesToolingLimitationBucket(t *testing.T) {
+	project := auditCommandProject(t, "magento2")
+	report := failingLintReportWithFindings("audit-shop")
+	php := report.PHPResults[0]
+	php.LimitedFindings = 10
+	report.PHPResults[0] = php
+	backend := &textLintBackend{report: report}
+	installAuditCommandDependencies(t, backend)
+
+	output, err := executeAuditCommand(t, project, []string{"audit", "run"})
+	if err == nil {
+		t.Fatalf("a failed lint must fail the process; output=%s", output)
+	}
+	rendered := string(output)
+	if !strings.Contains(rendered, "10 tooling-limitation findings excluded") {
+		t.Fatalf("failed-run text output hides the tooling-limitation bucket:\n%s", rendered)
+	}
+}
+
 func TestAuditRunDefaultTextShowsReadableSummary(t *testing.T) {
 	project := auditCommandProject(t, "magento2")
 	backend := &textLintBackend{report: passingLintReport("audit-shop")}


### PR DESCRIPTION
## Summary

Project-scope PHPStan analysis aborts on `dev/tests` fixture crashes, discarding all per-file findings while diff scope shows 53. This change partitions analyzer tooling noise into a counted bucket and stops PHPStan from analyzing fixture trees.

Closes #220.

## Changes

- `internal/audit/lint_govard.go`: `isToolingLimitationFinding` (`Internal error:` prefix or `dev/tests/` path) + `partitionToolingLimitations` wired into `acceptReport` beside `filterGeneratedFindings`, with status recompute.
- `internal/audit/lint.go`: new `LintPHPResult.LimitedFindings` (`omitempty`; host-set, container never writes it).
- `internal/cmd/audit_output.go`: renders `... and N tooling-limitation findings excluded (analyzer crashes and test fixtures, not project code)` for fresh and stored evidence.
- `docker/audit/bin/glint`: `write_phpstan_config` excludes `dev/tests/**/*`.
- Tests: 2 bucket unit tests + 1 renderer test (Go), 1 new contract case (`case_phpstan_excludes_test_fixtures`).

## Validation

- All new tests watched fail first (Go undefined-symbol; contract `[dev/tests/**/*] not found`), then pass.
- `gofmt -s -l` clean on changed files; `go vet ./...` + `go build ./...` clean.
- Full `go test ./tests/` matches master: the only 6 failures reproduce identically on clean master (environmental — no Docker user info / compose fixtures in the container).
- Drop point confirmed against stored sessions, not guessed: project `20260904T075743Z-26ad337c` (phpstan 32.7s, 28MB, incomplete-result) vs diff `20260904T075631Z-b44c624d` (53 findings).

## Live validation (done 2026-09-04)

Branch binary + project-scope audit on the reference project (old pinned image, so the container-side exclude is not yet active — pure host-bucket path): session `20260904T090301Z-568b29de` renders `PHP 8.4 | FAILED | 3417 findings` plus `... and 1434 tooling-limitation findings excluded`; zero limitation findings leak into actionable (`limited_findings: 1434` persisted). A third of the old 4860 total was fixture noise. The container exclude ships with the next glint image build.