### PR TITLE
chore(release): bump to 1.70.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.2] - 2026-09-04
+
+### 🐛 Bug Fixes
+
+- **`doctor --fix --dry-run` no longer deadlocks:** `confirmAction` now returns a non-interactive decline under `--dry-run` before reaching `pterm.DefaultInteractiveConfirm.Show`, which previously parked forever on `/dev/tty` (`fatal error: all goroutines are asleep - deadlock!`) when no TTY was present — piping stdin could never answer it. `pullRuntimeImages` gains the same missing dry-run short-circuit. Both prompts now print a `[dry-run] ...` message and exit cleanly instead of blocking. (#222, closes #219)
+- **Config drift: `cache_version` and `services.search` now reconciled:** `CollectConfigDrift` / `SyncConfigDriftForTest` now detect and sync `stack.cache_version` drift and rename `stack.services.search` to the profile's search backend (e.g. `elasticsearch → opensearch`), matching the existing `search_version` handling — closes the secondary gap from #219 where a successful drift fix still left the profile partly un-converged. (#222)
+
 ## [1.70.1] - 2026-09-02
 
 ### 🐛 Bug Fixes

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.70.1",
+  "version": "1.70.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.70.1"
+    "productVersion": "1.70.2"
   }
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.70.1"
+var Version = "1.70.2"
 
 var verbose bool
 

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.70.1"
+var Version = "1.70.2"
 
 type App struct {
 	ctx context.Context


### PR DESCRIPTION
## Summary
Release version bump for #222 (fix(doctor): make --dry-run non-interactive; sync cache_version/services.search drift — closes #219).

- `internal/cmd/root.go`, `internal/desktop/app.go`, `desktop/frontend/package.json`, `desktop/wails.json`: `1.70.1` → `1.70.2`
- `CHANGELOG.md`: add `[1.70.2]` section

### Validation
- `make test` (lint + fmt-check + vet + unit + integration): PASS
- `make build && ./bin/govard version`: OK (dev build shows `git describe` version, hardcoded `Version` var is the tag source of truth)

Refs: #222, #219