### PR TITLE
chore(release): bump to 1.70.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.3] - 2026-09-08
+
+### 🐛 Bug Fixes
+
+- **Proxy dnsmasq answers `*.test` locally:** the proxy `dnsmasq` command gains `--local=/test/` so `.test` is never forwarded upstream. Previously `-A` only synthesized A records while AAAA queries looped (container docker DNS → host resolved stub → back into the same dnsmasq) until timeout, stalling every dual-stack `*.test` lookup ~6s (`curl namelookup` 6.1s → 0.001s). `.test` is RFC 2606 reserved so never forwarding it is always safe. (#226, closes #225)
+
 ## [1.70.2] - 2026-09-04
 
 ### 🐛 Bug Fixes

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.70.2",
+  "version": "1.70.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.70.2"
+    "productVersion": "1.70.3"
   }
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.70.2"
+var Version = "1.70.3"
 
 var verbose bool
 

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.70.2"
+var Version = "1.70.3"
 
 type App struct {
 	ctx context.Context


### PR DESCRIPTION
Release 1.70.3 — version bumps (root.go, desktop app.go, frontend package.json, wails.json) + CHANGELOG entry.

Contains #226 (proxy dnsmasq `--local=/test/` fix for the ~6s AAAA stall on `*.test`).

Verification: `make test` green, `make build` OK.