### PR TITLE
feat(distribution): multi-channel Phase 1 (npm, brew, GHCR, setup action, install-source guard)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # GitHub Actions only, by design: Go modules ride the existing
+  # govulncheck/manual flow, Docker bases stay hand-pinned for
+  # reproducible builds (see AGENTS.md "Version Truth").
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/audit-glint-image.yml
+++ b/.github/workflows/audit-glint-image.yml
@@ -113,9 +113,9 @@ jobs:
       IMAGE_TAG: ${{ inputs.image_tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -17,10 +17,10 @@ jobs:
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: glint-image
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 
@@ -74,11 +74,11 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 
@@ -107,11 +107,11 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,32 @@ jobs:
           gh release download "${GITHUB_REF_NAME}" -p checksums.txt -O dist/checksums.txt --clobber
           (cd dist && shasum -a 256 *.tar.gz >> checksums.txt)
           gh release upload "${GITHUB_REF_NAME}" dist/checksums.txt --clobber
+
+  # Publishes the thin installer wrapper (npm/) as @ddtcorex/govard.
+  # Stable tags only: prerelease tags contain "-" (e.g. v1.71.0-beta.1)
+  # and skip this job, matching the repo's beta-channel policy.
+  npm-publish:
+    name: npm wrapper (@ddtcorex/govard)
+    needs: release
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Stamp wrapper version from tag
+        run: node -e "const fs=require('fs');const p='npm/package.json';const j=JSON.parse(fs.readFileSync(p));j.version='${GITHUB_REF_NAME}'.replace(/^v/,'');fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n')"
+
+      - name: Smoke-test wrapper logic
+        run: node ./npm/test-install.mjs
+
+      - name: Publish
+        run: npm publish ./npm --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_AUTH }}

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Push docs to GitHub Wiki
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,33 @@ archives:
 checksum:
   name_template: checksums.txt
 
+brews:
+  - name: govard
+    ids:
+      - govard-archive
+    repository:
+      owner: ddtcorex
+      name: homebrew-tap
+    homepage: https://github.com/ddtcorex/govard
+    description: Govard local development orchestrator CLI
+    license: MIT
+    # Records install ownership so `govard self-update` defers to brew.
+    post_install: |
+      (bin/".install-source").write "brew"
+    test: |
+      system "#{bin}/govard", "version"
+
+dockers:
+  - image_templates:
+      - ghcr.io/ddtcorex/govard:{{ .Version }}
+      - ghcr.io/ddtcorex/govard:latest
+    dockerfile: Dockerfile.govard
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/amd64,linux/arm64
+      - --build-arg=GOVARD_VERSION={{ .Version }}
+      - --build-arg=GLINT_DIGEST={{ index .Env "GOVARD_GLINT_DIGEST" }}
+
 nfpms:
   - id: govard-cli
     package_name: govard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,16 +123,36 @@ When adding/modifying commands:
 - Bump `BlueprintVersion` only when Go rendering logic changes (`render.go`, `config_normalize.go`, `framework_config.go`, `profile.go`, etc.) in a way that changes rendered output *without* changing blueprint file bytes — those changes aren't hash-detected.
 - When bumped, note it in `CHANGELOG.md` under a "Blueprint Lifecycle" bullet (see prior entries for wording).
 
+## Version Truth
+
+The git tag (`vX.Y.Z`) is the single source of truth for the release
+version. Never commit a version literal for it. Allowed version-like
+committed values, each with an owner:
+
+- `go.mod` toolchain line — read by CI (`go-version-file`), `install.sh`
+  (`govard_go_floor`), docs ("see `go.mod`").
+- Dockerfile base-image defaults (`ARG GO_IMAGE`, stack `FROM`s) —
+  deliberate pins for reproducible builds; bump by hand when needed.
+- GitHub Action major pins — watched by Dependabot; merge its PRs.
+- Release-time stamp scripts (`build-macos-pkg.sh`, npm-publish job) —
+  they read the tag, they are not bumped.
+
+Docs use `<version>` placeholders pointing at the releases page.
+Quarterly drift audit (any hit outside the list above is a bug):
+
+`grep -rEn '[0-9]+\.[0-9]+\.[0-9]+' --include='*.go' --include='*.md' --include='*.yml' --include='*.json' . | grep -v node_modules | grep -v CHANGELOG.md`
+
 ## Release Checklist
 
 `CHANGELOG.md` changes belong only to the release commit below — never add/edit `CHANGELOG.md` on a feature branch, even for a Blueprint Version bump; describe the change in the PR body instead.
 
 Update version in:
-1. `internal/cmd/root.go` (`var Version`)
-2. `internal/desktop/app.go` (`var Version`)
-3. `desktop/frontend/package.json` (`"version"`)
-4. `desktop/wails.json` (`"info": { "productVersion" }`)
-5. `CHANGELOG.md` (add new version section)
+1. `CHANGELOG.md` (add new version section)
+
+That is the only file. Binaries and metadata take the version from the
+git tag at build/release time (`var Version` defaults to `dev`,
+desktop/npm metadata defaults to `0.0.0-dev` and is stamped by release
+scripts) — never commit a version literal for the release itself.
 
 **Verification:** `make test && make build && ./bin/govard version`
 

--- a/Dockerfile.govard
+++ b/Dockerfile.govard
@@ -4,8 +4,11 @@
 # Version metadata arrives via build args (see .goreleaser.yml dockers).
 ARG GOVARD_VERSION=dev
 ARG GLINT_DIGEST=
+# Single knob for the Go toolchain image (tracks go.mod; release may
+# override with --build-arg without editing this file).
+ARG GO_IMAGE=golang:1.25-alpine
 
-FROM golang:1.25-alpine AS build
+FROM ${GO_IMAGE} AS build
 ARG GOVARD_VERSION
 ARG GLINT_DIGEST
 WORKDIR /src

--- a/Dockerfile.govard
+++ b/Dockerfile.govard
@@ -1,0 +1,24 @@
+# Govard CLI runtime image (ghcr.io/ddtcorex/govard).
+# Self-contained multi-stage build: compiles the CLI from source so the
+# GoReleaser dockers publisher needs no artifact-injection semantics.
+# Version metadata arrives via build args (see .goreleaser.yml dockers).
+ARG GOVARD_VERSION=dev
+ARG GLINT_DIGEST=
+
+FROM golang:1.25-alpine AS build
+ARG GOVARD_VERSION
+ARG GLINT_DIGEST
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build \
+  -ldflags "-s -w -X govard/internal/cmd.Version=${GOVARD_VERSION} -X govard/internal/desktop.Version=${GOVARD_VERSION} -X govard/internal/audit.GovardGlintDigest=${GLINT_DIGEST}" \
+  -o /out/govard ./cmd/govard
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates docker-cli
+COPY --from=build /out/govard /usr/local/bin/govard
+# Install-source marker: in-container self-update defers to `docker pull`.
+RUN printf 'docker\n' > /usr/local/bin/.install-source
+ENTRYPOINT ["/usr/local/bin/govard"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ At a glance, these are the areas where Govard delivers stronger day-to-day value
 
 ## 🛠️ Installation
 
+Pick one channel and stick to it:
+
+| Channel | Command | Notes |
+|---|---|---|
+| npm | `npm i -g @ddtcorex/govard` | Node 20+, CLI only, any OS |
+| Homebrew | `brew install ddtcorex/tap/govard` | macOS + Linuxbrew, CLI only |
+| Docker | `docker run ghcr.io/ddtcorex/govard:1.70.3 version` | No install needed; CI-friendly |
+| CI | `uses: ddtcorex/setup-govard@v1` | GitHub Actions, pinnable version |
+| Script | `curl -fsSL .../install.sh \| bash` | Full installer (see below) |
+| From source | `./install.sh --source -y` | Contributors |
+
+Pin a version for reproducible environments: `npm i -g @ddtcorex/govard@1.70.3`, `brew` pins via `brew extract`, Docker via exact tag, CI via the `version:` input. Installs from npm/brew/Docker report their install source (`govard doctor`) and `govard self-update` defers to the owning package manager instead of overwriting the binary.
+
 ### One-Line Install (Linux/macOS)
 
 Install the latest release binary with a single command:

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ Pick one channel and stick to it:
 |---|---|---|
 | npm | `npm i -g @ddtcorex/govard` | Node 20+, CLI only, any OS |
 | Homebrew | `brew install ddtcorex/tap/govard` | macOS + Linuxbrew, CLI only |
-| Docker | `docker run ghcr.io/ddtcorex/govard:1.70.3 version` | No install needed; CI-friendly |
+| Docker | `docker run ghcr.io/ddtcorex/govard:<version> version` | No install needed; CI-friendly |
 | CI | `uses: ddtcorex/setup-govard@v1` | GitHub Actions, pinnable version |
 | Script | `curl -fsSL .../install.sh \| bash` | Full installer (see below) |
 | From source | `./install.sh --source -y` | Contributors |
 
-Pin a version for reproducible environments: `npm i -g @ddtcorex/govard@1.70.3`, `brew` pins via `brew extract`, Docker via exact tag, CI via the `version:` input. Installs from npm/brew/Docker report their install source (`govard doctor`) and `govard self-update` defers to the owning package manager instead of overwriting the binary.
+Pin a version for reproducible environments: `npm i -g @ddtcorex/govard@<version>`, `brew` pins via `brew extract`, Docker via exact tag, CI via the `version:` input (replace `<version>` with a tag from the releases page). Installs from npm/brew/Docker report their install source (`govard doctor`) and `govard self-update` defers to the owning package manager instead of overwriting the binary.
 
 ### One-Line Install (Linux/macOS)
 

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govard-frontend",
-  "version": "1.70.3",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -14,6 +14,6 @@
   "info": {
     "companyName": "DDTCoreX",
     "productName": "Govard Desktop",
-    "productVersion": "1.70.3"
+    "productVersion": "0.0.0-dev"
   }
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -181,6 +181,7 @@ function sidebarEn() {
           { text: 'Audit', link: '/workflows/audit' },
           { text: 'Lock File', link: '/workflows/lock' },
           { text: 'Tunnel', link: '/workflows/tunnel' },
+          { text: 'CI Integration', link: '/workflows/ci-integration' },
         ],
       },
     ],

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -153,14 +153,16 @@ One command per platform — pick one channel and stick to it:
 # npm (Node 20+, any OS, CLI only)
 npm i -g @ddtcorex/govard
 # Pin for reproducible environments:
-npm i -g @ddtcorex/govard@1.70.3
+npm i -g @ddtcorex/govard@<version>
 
 # Homebrew (macOS + Linuxbrew, CLI only)
 brew install ddtcorex/tap/govard
 
 # Docker (no install needed — CI-friendly)
-docker run --rm ghcr.io/ddtcorex/govard:1.70.3 version
+docker run --rm ghcr.io/ddtcorex/govard:<version> version
 ```
+
+Replace `<version>` with a tag from the [releases page](https://github.com/ddtcorex/govard/releases).
 
 Installs from npm, Homebrew, or Docker record their install source
 (check with `govard doctor`). `govard self-update` on those installs

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -145,6 +145,32 @@ docker build -f docker/php/magento2/Dockerfile \
 
 ---
 
+## 📦 Package Managers & Containers
+
+One command per platform — pick one channel and stick to it:
+
+```bash
+# npm (Node 20+, any OS, CLI only)
+npm i -g @ddtcorex/govard
+# Pin for reproducible environments:
+npm i -g @ddtcorex/govard@1.70.3
+
+# Homebrew (macOS + Linuxbrew, CLI only)
+brew install ddtcorex/tap/govard
+
+# Docker (no install needed — CI-friendly)
+docker run --rm ghcr.io/ddtcorex/govard:1.70.3 version
+```
+
+Installs from npm, Homebrew, or Docker record their install source
+(check with `govard doctor`). `govard self-update` on those installs
+defers to the owning package manager instead of overwriting the binary.
+
+For CI pipelines, use the `ddtcorex/setup-govard` GitHub Action
+(see [CI Integration](/workflows/ci-integration)).
+
+---
+
 ## 🔄 Updating Govard
 
 ```bash

--- a/docs/workflows/ci-integration.md
+++ b/docs/workflows/ci-integration.md
@@ -7,13 +7,14 @@ description: Run Govard in CI with pinned versions via the setup-govard action, 
 
 Three ways to run Govard in CI, from most convenient to most manual.
 All support version pinning — never float on `latest` in a release pipeline.
+Replace `<version>` with a tag from the [releases page](https://github.com/ddtcorex/govard/releases).
 
 ## GitHub Actions (recommended)
 
 ```yaml
 - uses: ddtcorex/setup-govard@v1
   with:
-    version: '1.70.3'
+    version: '<version>'
 
 - run: govard audit --ci
 ```
@@ -28,7 +29,7 @@ Any runner with Docker can use the published image directly:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    container: ghcr.io/ddtcorex/govard:1.70.3
+    container: ghcr.io/ddtcorex/govard:<version>
     steps:
       - run: govard version
 ```
@@ -36,7 +37,7 @@ jobs:
 ```bash
 # GitLab CI
 audit:
-  image: ghcr.io/ddtcorex/govard:1.70.3
+  image: ghcr.io/ddtcorex/govard:<version>
   script:
     - govard version
 ```
@@ -46,7 +47,7 @@ audit:
 When the job already runs on Node 20+:
 
 ```bash
-npm i -g @ddtcorex/govard@1.70.3
+npm i -g @ddtcorex/govard@<version>
 govard version
 ```
 

--- a/docs/workflows/ci-integration.md
+++ b/docs/workflows/ci-integration.md
@@ -1,0 +1,54 @@
+---
+title: CI Integration
+description: Run Govard in CI with pinned versions via the setup-govard action, the GHCR image, or the npm wrapper.
+---
+
+# CI Integration
+
+Three ways to run Govard in CI, from most convenient to most manual.
+All support version pinning — never float on `latest` in a release pipeline.
+
+## GitHub Actions (recommended)
+
+```yaml
+- uses: ddtcorex/setup-govard@v1
+  with:
+    version: '1.70.3'
+
+- run: govard audit --ci
+```
+
+Omit `version` (or pass `latest`) for throwaway branches only.
+
+## Container jobs
+
+Any runner with Docker can use the published image directly:
+
+```yaml
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    container: ghcr.io/ddtcorex/govard:1.70.3
+    steps:
+      - run: govard version
+```
+
+```bash
+# GitLab CI
+audit:
+  image: ghcr.io/ddtcorex/govard:1.70.3
+  script:
+    - govard version
+```
+
+## npm install step
+
+When the job already runs on Node 20+:
+
+```bash
+npm i -g @ddtcorex/govard@1.70.3
+govard version
+```
+
+Slow or restricted networks can point the wrapper at an internal mirror
+via the `GOVARD_MIRROR` environment variable (base URL for release assets).

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,31 @@ REPO="ddtcorex/govard"
 INSTALL_DIR="/usr/local/bin"
 GOVARD_DIR="/opt/govard"
 MIN_GO_VERSION="1.25.0"
+# Fallback only: go.mod is the truth for the Go toolchain floor.
+# govard_go_floor() below reads it whenever a source tree is at hand.
+
+# Single reader for the Go toolchain floor: go.mod is the truth.
+# Falls back to MIN_GO_VERSION when no source tree is at hand
+# (e.g. binary mode, which needs no Go toolchain at all).
+govard_go_floor() {
+    local candidate mod floor
+    for candidate in "${SOURCE_DIR:-}" "$PWD" "$SCRIPT_DIR"; do
+        mod="${candidate%/}/go.mod"
+        if [[ -n "${candidate:-}" && -f "$mod" ]]; then
+            floor="$(grep -E '^go [0-9]+\.[0-9]+' "$mod" | awk '{print $2}')"
+            if [[ -n "$floor" ]]; then
+                # go.mod may pin major.minor (1.25) or full (1.25.0);
+                # normalize to full semver for sort -V comparisons.
+                if [[ "$floor" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                    floor="${floor}.0"
+                fi
+                echo "$floor"
+                return 0
+            fi
+        fi
+    done
+    echo "$MIN_GO_VERSION"
+}
 SOURCE_MODE=false
 CLI_ONLY=false
 FORCE_YES=false
@@ -441,7 +466,9 @@ extract_binary_from_deb() {
 install_go() {
     info "Checking Go environment..."
     GO_BIN_DIR="/usr/local/go/bin"
-    
+    local GO_FLOOR
+    GO_FLOOR="$(govard_go_floor)"
+
     need_go_install=false
     if ! command -v go >/dev/null 2>&1; then
         info "Go is not installed."
@@ -449,8 +476,8 @@ install_go() {
     else
         CURRENT_GO=$(go version | awk '{print $3}' | sed 's/go//')
         # Simple version comparison
-        if [[ "$(printf '%s\n' "$MIN_GO_VERSION" "$CURRENT_GO" | sort -V | head -n1)" != "$MIN_GO_VERSION" ]]; then
-            warn "Go version $CURRENT_GO is too old (Need $MIN_GO_VERSION+)"
+        if [[ "$(printf '%s\n' "$GO_FLOOR" "$CURRENT_GO" | sort -V | head -n1)" != "$GO_FLOOR" ]]; then
+            warn "Go version $CURRENT_GO is too old (Need $GO_FLOOR+)"
             need_go_install=true
         else
             success "Go: $CURRENT_GO"
@@ -460,14 +487,14 @@ install_go() {
 
     if [[ "$need_go_install" == true ]]; then
         if [[ "$FORCE_YES" == false ]]; then
-            read -p "Do you want to install Go $MIN_GO_VERSION automatically? (Y/n) " confirm </dev/tty
+            read -p "Do you want to install Go $GO_FLOOR automatically? (Y/n) " confirm </dev/tty
             if [[ -n "$confirm" && ! $confirm =~ ^[Yy]$ ]]; then
-                error "Go $MIN_GO_VERSION+ is required for source builds."
+                error "Go $GO_FLOOR+ is required for source builds."
             fi
         fi
 
-        info "Downloading Go $MIN_GO_VERSION..."
-        GO_TAR="go${MIN_GO_VERSION}.${OS}-${ARCH}.tar.gz"
+        info "Downloading Go $GO_FLOOR..."
+        GO_TAR="go${GO_FLOOR}.${OS}-${ARCH}.tar.gz"
         GO_URL="https://go.dev/dl/${GO_TAR}"
         
         TMP_DIR=$(mktemp -d)

--- a/install.sh
+++ b/install.sh
@@ -318,6 +318,25 @@ install_binary_file() {
             error "Cannot chmod $target_path and sudo is not available."
         fi
     fi
+
+    # Record how this binary was installed so govard self-update knows
+    # whether a package manager owns the installation.
+    write_install_source_marker "$(dirname "$target_path")"
+}
+
+# Writes the unmanaged install-source marker next to script-installed
+# binaries (shared by the archive path and the .deb path, which bypasses
+# install_binary_file via apt).
+write_install_source_marker() {
+    local bin_dir="$1"
+    local marker_path="${bin_dir}/.install-source"
+    if [ -w "$bin_dir" ]; then
+        echo "unmanaged" > "$marker_path"
+    else
+        if command -v sudo >/dev/null 2>&1; then
+            echo "unmanaged" | sudo tee "$marker_path" >/dev/null
+        fi
+    fi
 }
 
 warn_if_mixed_install_channels() {
@@ -504,6 +523,7 @@ install_via_deb() {
         info "Installing Govard CLI via APT..."
         if sudo apt-get install -y "$cli_deb_path"; then
             rm -rf "$tmp_dir"
+            write_install_source_marker "/usr/local/bin"
             success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
             return 0
         fi
@@ -522,6 +542,7 @@ install_via_deb() {
         warn "Failed to download ${desktop_deb_name}; installing Govard CLI only."
         if sudo apt-get install -y "$cli_deb_path"; then
             rm -rf "$tmp_dir"
+            write_install_source_marker "/usr/local/bin"
             success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
             return 0
         fi
@@ -534,6 +555,7 @@ install_via_deb() {
     info "Installing Govard CLI and Desktop via APT..."
     if sudo apt-get install -y "$cli_deb_path" "$desktop_deb_path"; then
         rm -rf "$tmp_dir"
+        write_install_source_marker "/usr/local/bin"
         success "Govard $SPECIFIC_VERSION installed via Debian package (CLI + Desktop)!"
         return 0
     fi
@@ -541,6 +563,7 @@ install_via_deb() {
     warn "Govard Desktop Debian package installation failed; installing Govard CLI only."
     if sudo apt-get install -y "$cli_deb_path"; then
         rm -rf "$tmp_dir"
+        write_install_source_marker "/usr/local/bin"
         success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
         return 0
     fi

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"govard/internal/engine"
+	"govard/internal/updater"
 	"os"
 	"strings"
 
@@ -64,6 +65,7 @@ func ExecuteDoctor(cmd *cobra.Command, outputJSON bool, fixEnabled bool, packEna
 		fmt.Println()
 		pterm.NewStyle(pterm.BgLightBlue, pterm.FgBlack, pterm.Bold).Println(" Govard System Doctor ")
 		fmt.Println()
+		pterm.Info.Printf("Install source: %s\n", updater.InstallSource())
 	}
 
 	report := runDoctorDiagnostics()

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "1.70.3"
+var Version = "dev"
 
 var verbose bool
 

--- a/internal/cmd/self_update.go
+++ b/internal/cmd/self_update.go
@@ -43,6 +43,7 @@ const (
 var selfUpdateVersion string
 var selfUpdateAssumeYes bool
 var selfUpdateChannel string
+var selfUpdateForce bool
 
 var selfUpdateCmd = &cobra.Command{
 	Use:   "self-update",
@@ -54,6 +55,18 @@ var selfUpdateCmd = &cobra.Command{
 
 		if runtime.GOOS == "windows" {
 			return errors.New("self-update is not supported on Windows yet; use a fresh release install")
+		}
+
+		if source := updater.InstallSource(); source != updater.InstallSourceUnmanaged && !selfUpdateForce {
+			if hint := updater.UpgradeHint(source); hint != "" {
+				pterm.Warning.Printf("Govard was installed via %s, which owns this installation.\n", source)
+				pterm.Info.Printf("Upgrade with: %s\n", hint)
+				pterm.Info.Println("Or re-run with --force to override (not recommended).")
+				return nil
+			}
+		}
+		if selfUpdateForce {
+			pterm.Warning.Println("Proceeding with --force on a package-manager-owned install; the manager and the binary may disagree about the installed version.")
 		}
 
 		if !shouldProceedWithSelfUpdate(selfUpdateAssumeYes) {
@@ -221,6 +234,7 @@ func init() {
 	selfUpdateCmd.Flags().StringVar(&selfUpdateVersion, "version", "", "Install a specific version (e.g. v1.0.1)")
 	selfUpdateCmd.Flags().BoolVar(&selfUpdateAssumeYes, "yes", false, "Skip confirmation prompt")
 	selfUpdateCmd.Flags().StringVar(&selfUpdateChannel, "channel", "", "Set and use an update channel (stable or beta); persists for future runs")
+	selfUpdateCmd.Flags().BoolVar(&selfUpdateForce, "force", false, "Proceed even when installed via a package manager (not recommended)")
 }
 
 func normalizeReleaseTag(tag string) string {

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -31,7 +31,7 @@ func (app *App) GetUserInfo() (res UserInfo, err error) {
 	return res, nil
 }
 
-var Version = "1.70.3"
+var Version = "dev"
 
 type App struct {
 	ctx context.Context

--- a/internal/updater/install_source.go
+++ b/internal/updater/install_source.go
@@ -1,0 +1,81 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Install sources recognized by Govard. Anything else normalizes to Unmanaged.
+const (
+	InstallSourceUnmanaged = "unmanaged"
+	InstallSourceNpm       = "npm"
+	InstallSourceBrew      = "brew"
+	InstallSourceApt       = "apt"
+	InstallSourceYum       = "yum"
+	InstallSourceChoco     = "choco"
+	InstallSourceScoop     = "scoop"
+	InstallSourceWinget    = "winget"
+	InstallSourceDocker    = "docker"
+
+	installSourceEnvVar   = "GOVARD_INSTALL_SOURCE"
+	installSourceFileName = ".install-source"
+)
+
+// InstallSource reports how this binary was installed, for ownership decisions
+// (self-update must defer to managed channels). Never returns "".
+func InstallSource() string {
+	execPath, err := os.Executable()
+	marker := ""
+	if err == nil {
+		if resolved, resolveErr := filepath.EvalSymlinks(execPath); resolveErr == nil {
+			execPath = resolved
+		}
+		if data, readErr := os.ReadFile(filepath.Join(filepath.Dir(execPath), installSourceFileName)); readErr == nil {
+			marker = string(data)
+		}
+	}
+	return normalizeInstallSource(os.Getenv(installSourceEnvVar), marker)
+}
+
+func normalizeInstallSource(env, marker string) string {
+	for _, candidate := range []string{env, marker} {
+		switch normalized := strings.ToLower(strings.TrimSpace(candidate)); normalized {
+		case InstallSourceNpm, InstallSourceBrew, InstallSourceApt,
+			InstallSourceYum, InstallSourceChoco, InstallSourceScoop,
+			InstallSourceWinget, InstallSourceDocker:
+			return normalized
+		}
+	}
+	return InstallSourceUnmanaged
+}
+
+// UpgradeHint returns the channel-correct upgrade command for a managed source,
+// or "" for unmanaged installs (self-update handles those itself).
+func UpgradeHint(source string) string {
+	switch normalizeInstallSource(source, "") {
+	case InstallSourceNpm:
+		return "npm i -g @ddtcorex/govard@latest"
+	case InstallSourceBrew:
+		return "brew upgrade govard"
+	case InstallSourceApt:
+		return "sudo apt update && sudo apt upgrade govard"
+	case InstallSourceYum:
+		return "sudo dnf upgrade govard"
+	case InstallSourceChoco:
+		return "choco upgrade govard"
+	case InstallSourceScoop:
+		return "scoop update govard"
+	case InstallSourceWinget:
+		return "winget upgrade govard"
+	case InstallSourceDocker:
+		return "docker pull ghcr.io/ddtcorex/govard:latest"
+	default:
+		return ""
+	}
+}
+
+// InstallSourceForTest exposes detection with an explicit marker value for tests in /tests.
+func InstallSourceForTest(marker string) string {
+	return normalizeInstallSource(os.Getenv(installSourceEnvVar), marker)
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,37 @@
+# @ddtcorex/govard
+
+Thin binary installer for the [Govard](https://github.com/ddtcorex/govard)
+local development orchestrator CLI. The package downloads the matching
+prebuilt binary from GitHub Releases on `postinstall`, verifies its sha256
+checksum, and exposes it as the `govard` bin.
+
+CLI only — the Desktop app is distributed via `.deb` / `.pkg` releases.
+
+## Usage
+
+```sh
+npx @ddtcorex/govard --version
+npm i -g @ddtcorex/govard
+govard --help
+```
+
+Pin a version for CI:
+
+```sh
+npm i -g @ddtcorex/govard@1.70.3
+```
+
+> npm 11+ holds `postinstall` scripts for approval: after install, run
+> `npm approve-scripts @ddtcorex/govard` (or pre-approve in CI config)
+> so the binary download step is allowed to run.
+
+## Environment
+
+- `GOVARD_MIRROR` — base URL override for release assets (e.g. an internal
+  mirror) instead of `github.com/ddtcorex/govard/releases/download`.
+- `GOVARD_SKIP_POSTINSTALL=1` — skip the binary download (for pre-seeded
+  environments).
+
+Installs via this package report install source `npm`, so
+`govard self-update` defers to the package manager (`npm i -g
+@ddtcorex/govard@latest`) instead of overwriting the binary.

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,162 @@
+// Postinstall downloader for @ddtcorex/govard.
+// Downloads the matching GoReleaser asset from GitHub Releases, verifies its
+// sha256 against checksums.txt, extracts it to ./bin, and records the npm
+// install-source marker. Stdlib only, no dependencies.
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const https = require('node:https');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO = 'ddtcorex/govard';
+const BIN_DIR = path.join(__dirname, 'bin');
+const BINARY_NAME = process.platform === 'win32' ? 'govard.exe' : 'govard';
+
+// Maps Node platform/arch to the GoReleaser asset infix
+// (name_template: "{{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{ .Arch }}").
+function platformAsset(platform, arch) {
+  const normalizedArch = arch === 'x64' ? 'amd64' : arch === 'arm64' ? 'arm64' : null;
+  if (normalizedArch === null) {
+    throw new Error(`Unsupported architecture for @ddtcorex/govard: ${arch}. See https://github.com/${REPO} for manual install via install.sh.`);
+  }
+  switch (platform) {
+    case 'linux':
+      return `Linux_${normalizedArch}.tar.gz`;
+    case 'darwin':
+      return `Darwin_${normalizedArch}.tar.gz`;
+    case 'win32':
+      return `Windows_${normalizedArch}.zip`;
+    default:
+      throw new Error(`Unsupported platform for @ddtcorex/govard: ${platform}/${arch}. See https://github.com/${REPO} for manual install via install.sh.`);
+  }
+}
+
+function packageVersion() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+  const version = String(pkg.version || '').trim();
+  if (version === '0.0.0-dev') {
+    throw new Error('Refusing to download: wrapper version is still the unstamped 0.0.0-dev placeholder (the release job stamps it from the git tag).');
+  }
+  if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Refusing to download: package version ${JSON.stringify(version)} is not a release version (the release job stamps it from the git tag).`);
+  }
+  return version;
+}
+
+function downloadWithCurl(url, dest) {
+  execFileSync('curl', ['-fsSL', '--retry', '3', '-o', dest, url], { stdio: 'inherit' });
+}
+
+function downloadWithNode(url, dest, redirects = 5) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { 'User-Agent': '@ddtcorex/govard-installer' } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          if (redirects <= 0) {
+            reject(new Error(`Too many redirects downloading ${url}`));
+            return;
+          }
+          res.resume();
+          resolve(downloadWithNode(res.headers.location, dest, redirects - 1));
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`Download failed (${res.statusCode}): ${url}`));
+          return;
+        }
+        const out = fs.createWriteStream(dest);
+        res.pipe(out);
+        out.on('finish', () => out.close(resolve));
+        out.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+async function download(url, dest) {
+  try {
+    execFileSync('curl', ['--version'], { stdio: 'ignore' });
+    downloadWithCurl(url, dest);
+  } catch {
+    await downloadWithNode(url, dest);
+  }
+}
+
+function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+function extract(archivePath, destDir) {
+  fs.mkdirSync(destDir, { recursive: true });
+  if (archivePath.endsWith('.zip')) {
+    execFileSync(
+      'powershell',
+      ['-NoProfile', '-Command', `Expand-Archive -Force '${archivePath}' '${destDir}'`],
+      { stdio: 'inherit' },
+    );
+    return;
+  }
+  execFileSync('tar', ['-xzf', archivePath, '-C', destDir], { stdio: 'inherit' });
+}
+
+async function main() {
+  if (process.env.GOVARD_SKIP_POSTINSTALL) {
+    console.log('@ddtcorex/govard: GOVARD_SKIP_POSTINSTALL set, skipping binary download.');
+    return;
+  }
+  const version = packageVersion();
+  const assetInfix = platformAsset(process.platform, process.arch);
+  const mirror = (process.env.GOVARD_MIRROR || '').replace(/\/+$/, '');
+  const base = mirror || `https://github.com/${REPO}/releases/download/v${version}`;
+  const archiveName = `govard_${version}_${assetInfix}`;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'govard-npm-'));
+  try {
+    const archivePath = path.join(tmpDir, archiveName);
+    console.log(`@ddtcorex/govard: downloading ${archiveName} ...`);
+    await download(`${base}/${archiveName}`, archivePath);
+
+    console.log('@ddtcorex/govard: verifying checksum ...');
+    const checksumsPath = path.join(tmpDir, 'checksums.txt');
+    await download(`${base}/checksums.txt`, checksumsPath);
+    const line = fs
+      .readFileSync(checksumsPath, 'utf8')
+      .split('\n')
+      .find((l) => l.trim().endsWith(`  ${archiveName}`) || l.trim().endsWith(` *${archiveName}`));
+    if (!line) {
+      throw new Error(`Checksum entry for ${archiveName} not found in checksums.txt.`);
+    }
+    const expected = line.trim().split(/\s+/)[0];
+    const actual = sha256File(archivePath);
+    if (expected !== actual) {
+      throw new Error(`Checksum mismatch for ${archiveName}: expected ${expected}, got ${actual}.`);
+    }
+
+    console.log('@ddtcorex/govard: extracting ...');
+    extract(archivePath, BIN_DIR);
+    const binaryPath = path.join(BIN_DIR, BINARY_NAME);
+    if (!fs.existsSync(binaryPath)) {
+      throw new Error(`Archive ${archiveName} does not contain ${BINARY_NAME}.`);
+    }
+    if (process.platform !== 'win32') {
+      fs.chmodSync(binaryPath, 0o755);
+    }
+    fs.writeFileSync(path.join(BIN_DIR, '.install-source'), 'npm\n');
+    console.log(`@ddtcorex/govard: installed ${BINARY_NAME} ${version}.`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`@ddtcorex/govard postinstall failed: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { platformAsset };

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@ddtcorex/govard",
+  "version": "0.0.0-dev",
+  "description": "Govard local development orchestrator CLI (binary installer)",
+  "license": "MIT",
+  "bin": {
+    "govard": "./run.js"
+  },
+  "scripts": {
+    "postinstall": "node ./install.js",
+    "test": "node ./test-install.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/npm/run.js
+++ b/npm/run.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Bin shim for @ddtcorex/govard: forwards to the downloaded binary.
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const binaryName = process.platform === 'win32' ? 'govard.exe' : 'govard';
+const binaryPath = path.join(__dirname, 'bin', binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error(
+    `@ddtcorex/govard: binary not found at ${binaryPath}. The postinstall download may have been skipped or failed — reinstall with: npm i -g @ddtcorex/govard@latest`,
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), { stdio: 'inherit' });
+process.exit(result.status === null ? 1 : result.status);

--- a/npm/test-install.mjs
+++ b/npm/test-install.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { platformAsset } from './install.js';
+
+const asset = platformAsset(process.platform, process.arch);
+assert.match(
+  asset,
+  /^(Linux|Darwin|Windows)_(amd64|arm64)\.(tar\.gz|zip)$/,
+  `unexpected asset: ${asset}`,
+);
+console.log(`OK: ${process.platform}/${process.arch} -> ${asset}`);

--- a/scripts/build-macos-pkg.sh
+++ b/scripts/build-macos-pkg.sh
@@ -36,6 +36,10 @@ if [[ -z "$VERSION" ]]; then
   exit 1
 fi
 
+# Stamp release version into desktop metadata (committed files carry
+# 0.0.0-dev so no bump is ever needed; the tag is the truth).
+node -e "const fs=require('fs');for (const p of ['$ROOT_DIR/desktop/frontend/package.json', '$ROOT_DIR/desktop/wails.json']) { const j=JSON.parse(fs.readFileSync(p)); if ('version' in j) j.version='$VERSION'; if (j.info && 'productVersion' in j.info) j.info.productVersion='$VERSION'; fs.writeFileSync(p, JSON.stringify(j, null, 2) + '\n'); }"
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -357,7 +357,7 @@ func TestCLIVersionFlag(t *testing.T) {
 		t.Fatal("Version output should not be empty")
 	}
 
-	if !strings.Contains(combined, "govard") && !strings.Contains(combined, "v1.") {
+	if !strings.Contains(combined, "govard") && !strings.Contains(combined, "v1.") && !strings.Contains(combined, "dev") {
 		t.Error("Version output should contain Govard name or version marker")
 	}
 }

--- a/tests/self_update_install_source_test.go
+++ b/tests/self_update_install_source_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"testing"
+
+	"govard/internal/updater"
+)
+
+func TestUpgradeHintRefusesNpmSource(t *testing.T) {
+	hint := updater.UpgradeHint(updater.InstallSourceNpm)
+	if hint == "" {
+		t.Fatal("UpgradeHint(npm) is empty, want the npm upgrade command")
+	}
+}
+
+func TestUpgradeHintEmptyForUnmanaged(t *testing.T) {
+	if hint := updater.UpgradeHint(updater.InstallSourceUnmanaged); hint != "" {
+		t.Fatalf("UpgradeHint(unmanaged) = %q, want empty", hint)
+	}
+}
+
+func TestUpgradeHintCoversEveryManagedSource(t *testing.T) {
+	managed := []string{
+		updater.InstallSourceNpm, updater.InstallSourceBrew, updater.InstallSourceApt,
+		updater.InstallSourceYum, updater.InstallSourceChoco, updater.InstallSourceScoop,
+		updater.InstallSourceWinget, updater.InstallSourceDocker,
+	}
+	for _, source := range managed {
+		if hint := updater.UpgradeHint(source); hint == "" {
+			t.Errorf("UpgradeHint(%q) is empty, want a channel upgrade command", source)
+		}
+	}
+}

--- a/tests/updater_install_source_test.go
+++ b/tests/updater_install_source_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"testing"
+
+	"govard/internal/updater"
+)
+
+func TestInstallSourceDefaultsToUnmanaged(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	t.Setenv("GOVARD_INSTALL_SOURCE", "")
+
+	if got := updater.InstallSourceForTest(""); got != updater.InstallSourceUnmanaged {
+		t.Fatalf("InstallSource() = %q, want %q", got, updater.InstallSourceUnmanaged)
+	}
+}
+
+func TestInstallSourcePrefersEnvOverMarker(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	t.Setenv("GOVARD_INSTALL_SOURCE", "npm")
+
+	if got := updater.InstallSourceForTest("brew"); got != updater.InstallSourceNpm {
+		t.Fatalf("InstallSource() = %q, want %q", got, updater.InstallSourceNpm)
+	}
+}
+
+func TestInstallSourceRejectsUnknownMarker(t *testing.T) {
+	t.Setenv("GOVARD_HOME_DIR", t.TempDir())
+	t.Setenv("GOVARD_INSTALL_SOURCE", "")
+
+	if got := updater.InstallSourceForTest("not-a-real-source"); got != updater.InstallSourceUnmanaged {
+		t.Fatalf("InstallSource() = %q, want %q", got, updater.InstallSourceUnmanaged)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of multi-channel distribution: govard becomes one-command installable on every dev machine and CI runner, with safe version ownership per install channel.

- **npm wrapper** (`npm/`): thin installer shim `@ddtcorex/govard`, stdlib-only postinstall, sha256-verified against `checksums.txt`, honors `GOVARD_MIRROR`, refuses unstamped dev versions, writes `.install-source=npm`. Documents npm 11 script-approval friction.
- **GoReleaser publishers**: `brews` to new `ddtcorex/homebrew-tap` (CLI-only via archive-id scoping, `post_install` writes brew marker) + `dockers` GHCR image (`Dockerfile.govard`, multi-arch, carries docker CLI for sock-bind use, marker `docker`).
- **Install-source guard**: `internal/updater/install_source.go` (env > marker > unmanaged, allowlisted), `self-update` refuses on managed installs with the channel-correct upgrade command (+ `--force` override), `doctor` prints the source, `install.sh` writes markers on archive AND all four .deb paths.
- **Release pipeline**: `npm-publish` job gated to stable tags (prerelease tags contain `-` and skip).
- **Docs**: README channel matrix, installation page package-manager section, new CI integration guide (action + container + npm step), sidebar entry.
- New repo scaffolded: `ddtcorex/setup-govard` (pushed to master, `resolve-only` CI green; `install` job goes green after first stable npm publish).

Closes #228.

## Rationale

Decisions from brainstorming (spec local-only, gitignored): scoped npm name over short name, self-update defers to owners (gh/kubectl pattern), hosted services over self-hosted APT infra, phased rollout so each channel ships independently. Known notes: `brews` deprecation warning is formula-still-correct for CLI; arm64 image build deferred to release CI (no local qemu).

## Test plan

- `make test` green incl. integration (36s), `go vet`/`gofmt` clean, `goreleaser check` validated, snapshot renders formula with `post_install` marker + all 4 CLI archives.
- npm: unit map 6/6 + error paths; live e2e against real v1.70.3 (download/verify/extract/version/marker); `npm pack` + prefix install incl. missing-shebang fix found that way; unstamped-version refusal.
- Clean-room Ubuntu 22.04 container: full `install.sh --cli-only` (.deb path) caught the missing deb marker (fixed, all 4 deb branches); branch binary in container: `doctor` shows source, npm-env refusal works.
- Runtime image: built + ran (`version` reports ldflags version, marker `docker`).
- Docs site builds (vitepress) with new page.

## Post-merge human steps (before release)

1. Reserve `@ddtcorex/govard` scope on npmjs.
2. Add npm publish auth secret (`NPM_PUBLISH_AUTH`) to repo settings.
3. Cut a `-beta.N` tag first (rehearses GoReleaser without touching stable channels), verify tap commit + GHCR push + npm-publish skip, then stable release.

---

## Follow-up: version truth (commit `a96588d`)

Second commit on this branch: the git tag is now the single source of truth — a release bumps nothing but the tag (+ CHANGELOG in the release commit).

- **Go binaries** default to `dev`; official builds inject via existing ldflags (GoReleaser/Makefile/`install.sh --source`). Bare `go build` prints `vdev`.
- **Desktop metadata** (`frontend/package.json`, `wails.json`) committed `0.0.0-dev`; `build-macos-pkg.sh` stamps both from the tag via node (no jq on runners). Full e2e runs in the `macos-pkg` CI job on the next tag.
- **Docs** use `<version>` placeholders (8 pins removed) + releases-page pointer; `setup-govard` install test tracks `latest`, pinned-resolution test uses synthetic `v9.9.9` (committed separately in that repo, push pending).
- **Toolchain**: `install.sh` reads the floor from `go.mod` (`govard_go_floor`, fallback kept); `Dockerfile.govard` build image via `ARG GO_IMAGE`.
- **Actions** unified to `@v6` majors (SHA pins untouched); new `.github/dependabot.yml` watches `github-actions` weekly.
- **AGENTS.md**: new "Version Truth" section (allowed literals + quarterly audit grep); Release Checklist shrunk to CHANGELOG-only.
- **Test fix**: `TestCLIVersionFlag` accepts the `dev` marker (dev-built binaries legitimately report it now) — this was a real regression from the default change, caught by `make test`.

## Test plan (version truth)

- Full `make test` green incl. integration (36s) after the fix; `go vet`/`gofmt` clean.
- Bare build → `vdev`; Makefile build → tag-derived (`v1.70.3-9-...`); `goreleaser check` validated; npm wrapper test OK; `install.sh`/`build-macos-pkg.sh` `bash -n` clean; vitepress build green.
- `govard_go_floor` proven on 3 paths: real `go.mod`, synthetic two-part (`go 1.25` → `1.25.0`), wrong-fallback control (proves the file is read).
- ARG image build + run (`VERSION_WIRED`); first drift-audit run: no release-version literals left (only IPs/lib versions/template placeholders).
