### PR TITLE
fix(release): grant GHCR push auth to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,11 @@ jobs:
   # The lint image must be published before anything is linked, because
   # the release binaries carry its manifest digest in
   # internal/audit.GovardGlintDigest and only ever reference the official image
-  # pinned to that digest. packages: write is granted here and nowhere else: a
-  # reusable workflow cannot escalate beyond its calling job's token, so the grant
-  # has to live on this job, while the workflow-level block above stays
-  # contents: write only and neither `release` nor `macos-pkg` ever sees it.
+  # pinned to that digest. packages: write is granted to `glint-image` (a
+  # reusable workflow cannot escalate beyond its calling job's token, so the
+  # grant has to live on that job) and to `release` (the GoReleaser dockers
+  # publisher pushes GHCR images); the workflow-level block above stays
+  # contents: write only and `macos-pkg` never sees it.
   glint-image:
     permissions:
       contents: read
@@ -27,6 +28,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: glint-image
+    permissions:
+      contents: write
+      packages: write # GoReleaser dockers publisher pushes GHCR images
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,6 +39,13 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Unblocks GHCR image publishing: the `release` job gets `packages: write` plus a GHCR login step (`docker/login-action@v3`) before GoReleaser runs, and the stale least-privilege comment (written before the dockers publisher existed) is corrected.

Closes #234.

## Rationale

Beta rehearsal `v1.71.0-beta.1` proved the failure mode: without registry auth, buildx cannot push the multi-arch manifest and dies on local export (`docker exporter does not currently support exporting manifest lists`). One permission + one login step restore the push path; nothing else changes.

## Test plan

- Workflow YAML parses; diff is 15 insertions in `release.yml` only.
- Full verification happens on the next beta tag (`v1.71.0-beta.2` after merge): release job green, GHCR beta image present, `macos-pkg` + desktop-stamp e2e runs, `npm-publish` still skips.