### PR TITLE
fix(release): log in to GHCR via CLI instead of login-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      # NOTE: docker/login-action is deliberately NOT used here — its v3
+      # ref is currently unresolvable by GitHub's action fetcher (proven by
+      # probe runs: any workflow containing it dies at startup with zero
+      # jobs). CLI login needs no external action fetch on this path.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Replaces the `docker/login-action@v3` step with an equivalent CLI login (`docker login ghcr.io` via `GITHUB_TOKEN`). Follow-up to #234 (whose #235 added the action-based login).

## Rationale

Beta.2/beta.3 rehearsal runs died at startup with zero jobs — three tags, identical tree. Bisect via throwaway probe workflows (since removed) proved it: any workflow containing `docker/login-action@v3` fails at startup, while the identical workflow with a CLI login step runs green (probe verified a real GHCR login). GitHub's action fetcher currently cannot resolve that ref, even though the tag lists via API. The CLI form needs no external action fetch on the critical release path, and the note in the workflow records why.

## Test plan

- Throwaway probe (branch push, since deleted): permissions-only variant green; CLI-login variant green **including a real `docker login ghcr.io`**.
- Next beta tag exercises the full release path: GoReleaser dockers push, `macos-pkg` + desktop-stamp e2e, `npm-publish` skip.