### PR TITLE
fix(release): publish GHCR image via CLI buildx instead of GoReleaser dockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,32 @@ jobs:
           # context locally instead.
           GOVARD_GLINT_DIGEST: ${{ needs.glint-image.outputs.image_digest }}
 
+      # GHCR runtime image: built and pushed here (not via GoReleaser
+      # dockers — its buildx flow exports multi-arch manifests locally
+      # instead of pushing). Mirrors the proven audit-glint-image
+      # pipeline: binfmt first (the builder learns platforms at bootstrap),
+      # then an explicit --push build. :latest only for stable tags.
+      - name: Enable arm64 emulation
+        run: docker run --privileged --rm "tonistiigi/binfmt@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f" --install arm64
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Publish GHCR runtime image
+        run: |
+          IMAGE="ghcr.io/ddtcorex/govard"
+          TAGS=(--tag "${IMAGE}:${GITHUB_REF_NAME}")
+          if [[ "${GITHUB_REF_NAME}" != *-* ]]; then
+            TAGS+=(--tag "${IMAGE}:latest")
+          fi
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            "${TAGS[@]}" \
+            --build-arg "GOVARD_VERSION=${GITHUB_REF_NAME#v}" \
+            --build-arg "GLINT_DIGEST=${{ needs.glint-image.outputs.image_digest }}" \
+            --file Dockerfile.govard \
+            .
+
   macos-pkg:
     name: macOS Installer (${{ matrix.arch }})
     needs: release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,16 +82,11 @@ brews:
     test: |
       system "#{bin}/govard", "version"
 
-dockers:
-  - image_templates:
-      - ghcr.io/ddtcorex/govard:{{ .Version }}
-      - ghcr.io/ddtcorex/govard:latest
-    dockerfile: Dockerfile.govard
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/amd64,linux/arm64
-      - --build-arg=GOVARD_VERSION={{ .Version }}
-      - --build-arg=GLINT_DIGEST={{ index .Env "GOVARD_GLINT_DIGEST" }}
+# NOTE: no dockers publisher here by design. GoReleaser's buildx flow
+# exports multi-arch manifests locally instead of pushing them (proven by
+# two failed beta rehearsals), so the GHCR runtime image is built and
+# pushed by explicit workflow steps below (release.yml "Publish GHCR
+# runtime image"), mirroring the proven audit-glint-image pipeline.
 
 nfpms:
   - id: govard-cli


### PR DESCRIPTION
## Summary

Removes the GoReleaser `dockers` publisher and publishes the GHCR runtime image with explicit workflow steps (binfmt + container-driver buildx + `--push`), mirroring the proven audit-glint-image pipeline.

Closes #234 (follow-up; #235/#236 fixed auth and login-action).

## Rationale

Beta.4 proved the auth/login fixes were necessary but not sufficient: GoReleaser's buildx flow still exports multi-arch manifests locally (`docker exporter does not currently support exporting manifest lists`) instead of pushing, regardless of registry auth. Rather than debugging GoReleaser's internal push/load decision, this uses the exact pattern that already publishes multi-arch images to GHCR in this repo every release. `:latest` is tagged for stable refs only (explicit shell condition — deterministic, unlike template behavior). The `v` prefix is stripped from the version build-arg, matching the Makefile convention.

## Test plan

- `goreleaser check` validated (dockers removal is schema-clean); actionlint reports only the one pre-existing shellcheck info.
- Full verification on the next beta tag after merge: GHCR beta image present for both arches, `macos-pkg` + desktop-stamp e2e, `npm-publish` skip. NOTE: `brews` still never ran end-to-end (every beta died before it) — watch the tap commit on the next green run.
