### PR TITLE
fix(release): push Homebrew formula via PAT step instead of GoReleaser brews

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,30 @@ jobs:
             --file Dockerfile.govard \
             .
 
+      # Homebrew formula: pushed here, not by GoReleaser brews
+      # (skip_upload — GITHUB_TOKEN cannot write cross-repo, so this uses
+      # the dedicated HOMEBREW_TAP_TOKEN PAT).
+      - name: Checkout tap
+        uses: actions/checkout@v6
+        with:
+          repository: ddtcorex/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Publish Homebrew formula
+        run: |
+          cp dist/homebrew/govard.rb tap/govard.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add govard.rb
+          if git diff --cached --quiet; then
+            echo "formula unchanged"
+          else
+            git commit -m "chore: bump govard to ${GITHUB_REF_NAME}"
+            git push origin HEAD:master
+          fi
+
   macos-pkg:
     name: macOS Installer (${{ matrix.arch }})
     needs: release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,6 +70,10 @@ brews:
   - name: govard
     ids:
       - govard-archive
+    # Rendered only: GITHUB_TOKEN cannot push cross-repo, so the workflow
+    # pushes dist/homebrew/govard.rb to the tap with a dedicated PAT
+    # (release.yml "Publish Homebrew formula").
+    skip_upload: true
     repository:
       owner: ddtcorex
       name: homebrew-tap


### PR DESCRIPTION
## Summary

GoReleaser `brews` goes `skip_upload: true` (render-only); the workflow pushes `dist/homebrew/govard.rb` to `ddtcorex/homebrew-tap` with a dedicated fine-grained PAT (`HOMEBREW_TAP_TOKEN`). Companion: tap repo seeded with a README so checkout/push have a base commit.

Closes #234 (final piece; #235/#236/#237 fixed auth, login, image publish).

## Rationale

Beta.5 error, confirmed against the publisher schema (no `token` field on brews — it always uses `GITHUB_TOKEN`): `PUT .../homebrew-tap/contents/govard.rb: 403 Resource not accessible by integration`. `GITHUB_TOKEN` is repo-scoped to govard and can never write cross-repo, so no config tweak fixes it — the push must happen under a PAT. Explicit checkout+commit+push also keeps the tap history readable (one commit per release).

## Test plan

- Snapshot renders `dist/homebrew/govard.rb` (`ruby -c` OK, `post_install` brew marker intact).
- Full verification on the next beta tag after merge **once `HOMEBREW_TAP_TOKEN` exists**: formula commit lands in the tap, then `macos-pkg` + desktop-stamp e2e, `npm-publish` skip.
- BLOCKED on secret: the tap-push step fails without `HOMEBREW_TAP_TOKEN` (fine-grained PAT, Contents RW on `homebrew-tap` only).