### PR TITLE
fix(release): revert goreleaser-action to v6 pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ jobs:
           echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        # Pinned v6: the v7 SHA (f06c13b) breaks GitHub's startup fetch
+        # (proven by probe + beta.7) though valid via API. Revisit only
+        # with a branch-level probe run first. See #230.
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,11 @@ committed values, each with an owner:
 - Dockerfile base-image defaults (`ARG GO_IMAGE`, stack `FROM`s) —
   deliberate pins for reproducible builds; bump by hand when needed.
 - GitHub Action major pins — watched by Dependabot; merge its PRs.
+  A ref that is valid via API can still break GitHub's startup fetch
+  (zero-job runs; seen with docker/* and goreleaser/* refs). Any NEW
+  third-party ref in a tag-only workflow (release.yml) must first run
+  green in a throwaway branch probe workflow before merging — PR CI
+  never executes tag-only files, so green checks prove nothing there.
 - Release-time stamp scripts (`build-macos-pkg.sh`, npm-publish job) —
   they read the tag, they are not bumped.
 


### PR DESCRIPTION
## Summary

Reverts the GoReleaser wrapper to the proven v6 SHA pin and records the probe-verification rule in AGENTS.md.

Closes #239 (follow-up to #230, which stays open for a future retry).

## Rationale

Beta.7 + an isolated single-step probe workflow both die at startup with zero jobs when referencing `goreleaser-action@f06c13b` (v7.2.3) — valid via API, unfetchable by GitHub Actions. Fourth instance in 24h of the same class (docker/* refs earlier). The v6 pin ran the full beta.6 release green, so this restores a known-good path; v7 gets another chance only after a green branch probe.

## Test plan

- actionlint clean (only the pre-existing shellcheck info); YAML parses.
- Proof happens on the next beta tag: release job starts (past startup) and completes.