### PR TITLE
fix(release): grant id-token write to npm-publish for provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,9 @@ jobs:
     needs: release
     if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm --provenance attestation
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Grants `contents: read` + `id-token: write` to the `npm-publish` job so `npm publish --provenance` can mint its attestation.

## Rationale

Stable v1.71.0: everything green except npm-publish — `npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission`. Notably auth and the npm org both proved fine (publish got all the way to attestation). After merge, re-run the failed npm job on the v1.71.0 run to complete the release.

## Test plan

- YAML parses; actionlint clean (only the pre-existing shellcheck info).
- Proof is the re-run of the failed job on tag v1.71.0 after merge.