### PR TITLE
fix(npm): add repository field for provenance validation

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.0-dev",
   "description": "Govard local development orchestrator CLI (binary installer)",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ddtcorex/govard",
+    "directory": "npm"
+  },
   "bin": {
     "govard": "./run.js"
   },


### PR DESCRIPTION
## Summary

Adds the `repository` pointer to the npm wrapper manifest so Sigstore provenance validation accepts the publish.

## Rationale

v1.71.1: provenance attestation now signs and publishes fine, but the registry rejects with `E422 ... package.json: repository.url is "", expected to match https://github.com/ddtcorex/govard`. One static field, no version literal, no behavior change. Next patch tag completes the npm publish.