### PR TITLE
Distribution Phase 2A: completions, install.sh hardening, install-e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,3 +205,36 @@ jobs:
         run: npm publish ./npm --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_AUTH }}
+
+  # Proves both install channels work on a fresh machine for every tag
+  # (stable and beta). Beta tags exercise this job without touching
+  # stable channels — that is the rehearsal path for install changes.
+  # NOTE: the npm leg installs the published wrapper, which only exists
+  # for stable tags (npm-publish skips prereleases), so it is gated to
+  # non-prerelease tags; install.sh covers beta rehearsals.
+  install-e2e:
+    name: install e2e (${{ matrix.channel }} on ${{ matrix.ubuntu }})
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [install-sh, npm]
+        ubuntu: ["22.04", "24.04"]
+    container:
+      image: ubuntu:${{ matrix.ubuntu }}
+    steps:
+      - name: Install prerequisites
+        run: |
+          apt-get update
+          apt-get install -y curl sudo ca-certificates nodejs npm
+      - name: Install via install.sh
+        if: matrix.channel == 'install-sh'
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --cli-only -y
+          test "$(govard version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | head -n1)" = "${GITHUB_REF_NAME#v}"
+      - name: Install via npm
+        if: ${{ matrix.channel == 'npm' && !contains(github.ref_name, '-') }}
+        run: |
+          npm install -g "@ddtcorex/govard@${GITHUB_REF_NAME#v}"
+          test "$(govard version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | head -n1)" = "${GITHUB_REF_NAME#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,18 @@ jobs:
             | head -n1)
           echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Generate shell completions
+        run: |
+          mkdir -p completion dist
+          for sh in bash zsh fish powershell; do
+            go run ./cmd/govard completion "$sh" > "completion/govard.$sh"
+          done
+          mv completion/govard.powershell completion/govard.ps1
+          test -s completion/govard.bash
+          test -s completion/govard.zsh
+          test -s completion/govard.fish
+          test -s completion/govard.ps1
+
       - name: Run GoReleaser
         # Pinned v6: the v7 SHA (f06c13b) breaks GitHub's startup fetch
         # (proven by probe + beta.7) though valid via API. Revisit only

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,13 @@ archives:
       - govard
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{ .Arch }}
+    files:
+      - README.md
+      - LICENSE
+      - completion/govard.bash
+      - completion/govard.zsh
+      - completion/govard.fish
+      - completion/govard.ps1
     formats:
       - tar.gz
     format_overrides:
@@ -111,6 +118,13 @@ nfpms:
     dependencies:
       - ca-certificates
       - libnss3-tools
+    contents:
+      - src: ./completion/govard.bash
+        dst: /etc/bash_completion.d/govard
+      - src: ./completion/govard.fish
+        dst: /usr/share/fish/vendor_completions.d/govard.fish
+      - src: ./completion/govard.zsh
+        dst: /usr/local/share/zsh/site-functions/_govard
 
   - id: govard-desktop
     package_name: govard-desktop

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -173,6 +173,21 @@ For CI pipelines, use the `ddtcorex/setup-govard` GitHub Action
 
 ---
 
+## 🖥️ Shell Completions
+
+Release archives bundle completion scripts under `completion/`, and the
+`.deb` package installs them automatically (bash, fish, zsh). For
+other install channels, generate them from the binary:
+
+```bash
+govard completion bash > /etc/bash_completion.d/govard   # root
+govard completion zsh > "${fpath[1]}/_govard"
+govard completion fish > ~/.config/fish/completions/govard.fish
+govard completion powershell | Out-String | Invoke-Expression
+```
+
+---
+
 ## 🔄 Updating Govard
 
 ```bash
@@ -191,6 +206,10 @@ govard doctor
 ```
 
 `govard doctor` runs system diagnostics including Docker, DNS, ports, and SSL trust checks.
+
+Release downloads (`install.sh` and npm) are sha256-verified against
+`checksums.txt` before anything is installed; on mismatch the install
+aborts. There is no bypass flag for this check by design.
 
 ---
 

--- a/docs/vi/getting-started/installation.md
+++ b/docs/vi/getting-started/installation.md
@@ -145,6 +145,19 @@ docker build -f docker/php/magento2/Dockerfile \
 
 ---
 
+## 🖥️ Shell Completions
+
+Release archives đóng gói sẵn scripts completion trong thư mục `completion/`, và package `.deb` tự cài chúng (bash, fish, zsh). Với các kênh cài khác, sinh từ binary:
+
+```bash
+govard completion bash > /etc/bash_completion.d/govard   # root
+govard completion zsh > "${fpath[1]}/_govard"
+govard completion fish > ~/.config/fish/completions/govard.fish
+govard completion powershell | Out-String | Invoke-Expression
+```
+
+---
+
 ## 🔄 Cập nhật Govard
 
 ```bash
@@ -163,6 +176,8 @@ govard doctor
 ```
 
 Lệnh `govard doctor` chạy các chẩn đoán hệ thống (system diagnostics) bao gồm kiểm tra Docker, DNS, ports và SSL trust store.
+
+Các bản tải release (`install.sh` và npm) đều được xác minh sha256 với `checksums.txt` trước khi cài đặt; nếu hash không khớp, quá trình cài đặt dừng ngay. Không có flag bỏ qua bước kiểm tra này theo thiết kế.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,47 @@ success() { echo -e "${GREEN}success:${NC} $1"; }
 warn()    { echo -e "${YELLOW}warning:${NC} $1"; }
 error()   { echo -e "${RED}error:${NC} $1"; exit 1; }
 
+CHECKSUMS_FILE=""
+
+fetch_checksums() {
+    # Downloads checksums.txt for SPECIFIC_VERSION into a directory once per run.
+    local dest_dir="$1"
+    CHECKSUMS_FILE="${dest_dir}/checksums.txt"
+    if [[ -f "$CHECKSUMS_FILE" ]]; then
+        return 0
+    fi
+    local url="https://github.com/${REPO}/releases/download/${SPECIFIC_VERSION}/checksums.txt"
+    info "Downloading checksums.txt..."
+    if ! curl -fsSL "$url" -o "$CHECKSUMS_FILE"; then
+        error "Failed to download checksums.txt for ${SPECIFIC_VERSION}; refusing to install unverified binaries."
+    fi
+}
+
+sha256_file() {
+    # Portable sha256: sha256sum (Linux) or shasum -a 256 (macOS).
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+verify_asset() {
+    # verify_asset <file_path> <asset_name>: sha256-checks file against CHECKSUMS_FILE.
+    local file_path="$1"
+    local asset_name="$2"
+    local expected actual
+    expected="$(grep -E "[[:space:]](\\*?)${asset_name}\$" "$CHECKSUMS_FILE" | awk '{print $1}' | head -n1)"
+    if [[ -z "$expected" ]]; then
+        error "Checksum entry for ${asset_name} not found in checksums.txt; refusing to install."
+    fi
+    actual="$(sha256_file "$file_path")"
+    if [[ "$expected" != "$actual" ]]; then
+        error "Checksum mismatch for ${asset_name}: expected ${expected}, got ${actual}."
+    fi
+    info "Checksum OK: ${asset_name}"
+}
+
 run_as_user() {
     if [[ -n "${SUDO_USER:-}" && "$USER" == "root" ]]; then
         sudo -u "$SUDO_USER" "$@"
@@ -545,6 +586,8 @@ install_via_deb() {
         rm -rf "$tmp_dir"
         return 1
     fi
+    fetch_checksums "$tmp_dir"
+    verify_asset "$cli_deb_path" "$cli_deb_name"
 
     if [[ "$CLI_ONLY" == true ]]; then
         info "Installing Govard CLI via APT..."
@@ -578,6 +621,7 @@ install_via_deb() {
         rm -rf "$tmp_dir"
         return 1
     fi
+    verify_asset "$desktop_deb_path" "$desktop_deb_name"
 
     info "Installing Govard CLI and Desktop via APT..."
     if sudo apt-get install -y "$cli_deb_path" "$desktop_deb_path"; then
@@ -617,6 +661,7 @@ install_binary() {
     OS_CAP="$(echo "${OS:0:1}" | tr '[:lower:]' '[:upper:]')${OS:1}"
 
     TMP_DIR=$(mktemp -d)
+    fetch_checksums "$TMP_DIR"
     binaries=("$CLI_BINARY_NAME")
     if [[ "$CLI_ONLY" == false ]]; then
         binaries+=("$DESKTOP_BINARY_NAME")
@@ -630,6 +675,7 @@ install_binary() {
 
         info "Downloading $download_url..."
         if curl -fsSL "$download_url" -o "$archive_path"; then
+            verify_asset "$archive_path" "$archive_name"
             tar -xzf "$archive_path" -C "$TMP_DIR"
             extracted_path="${TMP_DIR}/${binary_name}"
             if [[ ! -f "$extracted_path" ]]; then
@@ -648,6 +694,7 @@ install_binary() {
             if ! curl -fsSL "$deb_url" -o "$deb_path"; then
                 error "Failed to download ${deb_name} for desktop fallback."
             fi
+            verify_asset "$deb_path" "$deb_name"
 
             extracted_path="${TMP_DIR}/${binary_name}"
             if ! extract_binary_from_deb "$deb_path" "$binary_name" "$extracted_path"; then

--- a/install.sh
+++ b/install.sh
@@ -138,6 +138,20 @@ verify_asset() {
     info "Checksum OK: ${asset_name}"
 }
 
+assert_installed_version() {
+    # assert_installed_version <binary_path>: fails loudly on version mismatch.
+    local bin_path="$1"
+    local got expected="${SPECIFIC_VERSION#v}"
+    if [[ ! -x "$bin_path" ]]; then
+        error "Installed binary not found or not executable: ${bin_path}"
+    fi
+    got="$("$bin_path" version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | head -n1)"
+    if [[ "$got" != "$expected" ]]; then
+        error "Installed version '${got}' does not match requested '${expected}'."
+    fi
+    info "Version OK: ${got}"
+}
+
 run_as_user() {
     if [[ -n "${SUDO_USER:-}" && "$USER" == "root" ]]; then
         sudo -u "$SUDO_USER" "$@"
@@ -594,6 +608,7 @@ install_via_deb() {
         if sudo apt-get install -y "$cli_deb_path"; then
             rm -rf "$tmp_dir"
             write_install_source_marker "/usr/local/bin"
+            assert_installed_version "/usr/local/bin/govard"
             success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
             return 0
         fi
@@ -613,6 +628,7 @@ install_via_deb() {
         if sudo apt-get install -y "$cli_deb_path"; then
             rm -rf "$tmp_dir"
             write_install_source_marker "/usr/local/bin"
+            assert_installed_version "/usr/local/bin/govard"
             success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
             return 0
         fi
@@ -627,6 +643,7 @@ install_via_deb() {
     if sudo apt-get install -y "$cli_deb_path" "$desktop_deb_path"; then
         rm -rf "$tmp_dir"
         write_install_source_marker "/usr/local/bin"
+        assert_installed_version "/usr/local/bin/govard"
         success "Govard $SPECIFIC_VERSION installed via Debian package (CLI + Desktop)!"
         return 0
     fi
@@ -635,6 +652,7 @@ install_via_deb() {
     if sudo apt-get install -y "$cli_deb_path"; then
         rm -rf "$tmp_dir"
         write_install_source_marker "/usr/local/bin"
+        assert_installed_version "/usr/local/bin/govard"
         success "Govard $SPECIFIC_VERSION installed via Debian package (CLI only)!"
         return 0
     fi
@@ -714,6 +732,7 @@ install_binary() {
     done
 
     rm -rf "$TMP_DIR"
+    assert_installed_version "${INSTALL_DIR%/}/govard"
     if [[ "$CLI_ONLY" == true ]]; then
         success "Govard $SPECIFIC_VERSION installed (CLI only)!"
     else

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"govard/internal/engine"
 	_ "govard/internal/frameworks" // registers framework detection/config data via init()
@@ -85,6 +86,29 @@ func versionChannelNotice(channel string) string {
 // VersionChannelNoticeForTest exposes versionChannelNotice for tests in /tests.
 func VersionChannelNoticeForTest(channel string) string {
 	return versionChannelNotice(channel)
+}
+
+// GenCompletionForTest exposes cobra completion generation for tests
+// and release packaging.
+func GenCompletionForTest(shell string) (string, error) {
+	var buf strings.Builder
+	var err error
+	switch shell {
+	case "bash":
+		err = rootCmd.GenBashCompletion(&buf)
+	case "zsh":
+		err = rootCmd.GenZshCompletion(&buf)
+	case "fish":
+		err = rootCmd.GenFishCompletion(&buf, true)
+	case "powershell":
+		err = rootCmd.GenPowerShellCompletion(&buf)
+	default:
+		return "", fmt.Errorf("unsupported shell: %s", shell)
+	}
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 func Execute() {

--- a/tests/completion_test.go
+++ b/tests/completion_test.go
@@ -1,0 +1,27 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"govard/internal/cmd"
+)
+
+func TestGenCompletionForTest(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		script, err := cmd.GenCompletionForTest(shell)
+		if err != nil {
+			t.Fatalf("GenCompletionForTest(%q) returned error: %v", shell, err)
+		}
+		if len(strings.TrimSpace(script)) == 0 {
+			t.Fatalf("GenCompletionForTest(%q) returned an empty script", shell)
+		}
+		if !strings.Contains(script, "govard") {
+			t.Fatalf("GenCompletionForTest(%q) does not mention govard", shell)
+		}
+	}
+
+	if _, err := cmd.GenCompletionForTest("tcsh"); err == nil {
+		t.Fatal("GenCompletionForTest(tcsh) should return an error for unsupported shells")
+	}
+}

--- a/tests/linux_package_layout_test.go
+++ b/tests/linux_package_layout_test.go
@@ -49,8 +49,24 @@ func TestLinuxPackageLayout(t *testing.T) {
 	if slices.Contains(cli.Dependencies, "libwebkit2gtk-4.1-0") {
 		t.Errorf("CLI dependencies unexpectedly include WebKitGTK: %v", cli.Dependencies)
 	}
-	if len(cli.Contents) != 0 {
-		t.Errorf("CLI package unexpectedly contains Desktop assets: %v", cli.Contents)
+	// The CLI package carries shell completions only — no Desktop assets.
+	completionContents := [][2]string{
+		{"./completion/govard.bash", "/etc/bash_completion.d/govard"},
+		{"./completion/govard.fish", "/usr/share/fish/vendor_completions.d/govard.fish"},
+		{"./completion/govard.zsh", "/usr/local/share/zsh/site-functions/_govard"},
+	}
+	if len(cli.Contents) != len(completionContents) {
+		t.Errorf("CLI package contents = %v, want exactly the shell completion files", cli.Contents)
+	}
+	for _, want := range completionContents {
+		if !releaseNFPMHasContent(cli, want[0], want[1]) {
+			t.Errorf("CLI package is missing completion file %q -> %q", want[0], want[1])
+		}
+	}
+	for _, content := range cli.Contents {
+		if strings.HasPrefix(content.Source, "./packaging/") {
+			t.Errorf("CLI package unexpectedly contains Desktop asset: %v", content)
+		}
 	}
 
 	desktop := findReleaseNFPM(t, config.NFPMS, "govard-desktop")


### PR DESCRIPTION
Closes #247.

## Summary
First shippable batch of the Phase 2 full-auto distribution plan (spec: docs/superpowers/specs/2026-09-08-govard-distribution-phase2-design.md — local-only; plan: docs/superpowers/plans/2026-09-08-govard-distribution-phase2a.md — local-only). No third-party accounts needed; nothing touches stable channels until a tag is cut.

- Completions: generated from cobra at release time (new release.yml step), shipped in archives and the CLI .deb (bash/fish/zsh standard paths). New hermetic test + CLI-deb contract test update.
- install.sh: sha256-verifies every downloaded asset against checksums.txt (closes the gap vs the npm wrapper) and asserts the installed version matches the requested tag on all success paths. Portable hash (sha256sum/shasum).
- install-e2e CI job on every tag: install.sh x npm on fresh Ubuntu 22.04/24.04 containers, asserting installed version equals the tag. Beta tags exercise it without touching stable channels (npm leg gated to stable).
- Docs: checksums + completions sections, EN + VI.

## Rationale
Learned from go-task/task: completions ride free with the release artifacts, and the install script must verify what it downloads. The e2e job turns the manual Ubuntu rehearsal into a regression gate.

## Test plan
- make test green (lint + fmt + vet + unit + integration), gofmt clean.
- GoReleaser snapshot: archives contain completion/ (explicit file list — the completion/** glob matches nothing for release-generated untracked files), .deb carries all three completion paths; no-config warnings.
- Local docker rehearsal on fresh ubuntu:24.04: install.sh --cli-only -y installs v1.71.2, govard version correct, exit 0.
- actionlint: only the pre-existing SC2035 (macos-pkg glob, on master too).
- Real gate after merge: first -beta.N tag must show install-e2e green before any stable release relies on it.
