### PR TITLE
Distribution Phase 2B: Scoop bucket + WinGet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,3 +241,72 @@ jobs:
         run: |
           npm install -g "@ddtcorex/govard@${GITHUB_REF_NAME#v}"
           test "$(govard version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | head -n1)" = "${GITHUB_REF_NAME#v}"
+
+  # Renders bucket/govard.json from the tag's checksums and pushes it
+  # to ddtcorex/scoop-bucket (owned bucket: no community review gate,
+  # fully automated). Stable tags only.
+  scoop-bucket:
+    name: Scoop bucket (ddtcorex/scoop-bucket)
+    needs: release
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout bucket
+        uses: actions/checkout@v6
+        with:
+          repository: ddtcorex/scoop-bucket
+          token: ${{ secrets.DISTRIBUTION_PAT }}
+          path: bucket
+
+      - name: Render manifest from release checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          gh release download "${GITHUB_REF_NAME}" -p checksums.txt -O checksums.txt
+          AMD64_URL="https://github.com/ddtcorex/govard/releases/download/${GITHUB_REF_NAME}/govard_${VER}_Windows_amd64.zip"
+          ARM64_URL="https://github.com/ddtcorex/govard/releases/download/${GITHUB_REF_NAME}/govard_${VER}_Windows_arm64.zip"
+          AMD64_HASH="$(grep -E "[[:space:]]govard_${VER}_Windows_amd64.zip$" checksums.txt | awk '{print $1}')"
+          ARM64_HASH="$(grep -E "[[:space:]]govard_${VER}_Windows_arm64.zip$" checksums.txt | awk '{print $1}')"
+          test -n "$AMD64_HASH" && test -n "$ARM64_HASH"
+          python3 - "$VER" "$AMD64_URL" "$AMD64_HASH" "$ARM64_URL" "$ARM64_HASH" <<'EOF'
+          import json, sys
+          ver, a64url, a64hash, armurl, armhash = sys.argv[1:6]
+          manifest = {
+              "version": ver,
+              "description": "Govard local development orchestrator CLI",
+              "homepage": "https://github.com/ddtcorex/govard",
+              "license": "MIT",
+              "architecture": {
+                  "64bit": {"url": a64url, "hash": a64hash},
+                  "arm64": {"url": armurl, "hash": armhash},
+              },
+              "bin": "govard.exe",
+              "checkver": "github",
+              "autoupdate": {
+                  "architecture": {
+                      "64bit": {"url": "https://github.com/ddtcorex/govard/releases/download/v$version/govard_$version_Windows_amd64.zip"},
+                      "arm64": {"url": "https://github.com/ddtcorex/govard/releases/download/v$version/govard_$version_Windows_arm64.zip"},
+                  }
+              },
+          }
+          with open("bucket/bucket/govard.json", "w") as f:
+              json.dump(manifest, f, indent=4)
+              f.write("\n")
+          EOF
+          cat bucket/bucket/govard.json
+
+      - name: Push manifest
+        run: |
+          cd bucket
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/govard.json
+          if git diff --cached --quiet; then
+            echo "manifest unchanged"
+          else
+            git commit -m "chore: bump govard to ${GITHUB_REF_NAME}"
+            git push origin HEAD:master
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev_tag.outputs.tag }}
+          # Feeds the winget publisher (fork PR). A missing secret fails
+          # the release loudly instead of skipping WinGet silently.
+          DISTRIBUTION_PAT: ${{ secrets.DISTRIBUTION_PAT }}
           # Linked into internal/audit.GovardGlintDigest by .goreleaser.yml. An empty value is a valid,
           # degraded state rather than a build failure: ToolchainManager treats
           # it as "no official image pinned" and builds the embedded lint

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -191,3 +191,41 @@ release:
   prerelease: auto
   footer: |
     Automated release by GoReleaser.
+
+# WinGet (Windows): committed to the ddtcorex/winget-pkgs fork and
+# auto-raised as a PR to microsoft/winget-pkgs, mirroring go-task/task.
+# Auth uses DISTRIBUTION_PAT (fine-grained PAT, Contents RW on the
+# fork), passed in by release.yml — a missing secret fails the release
+# loudly instead of skipping WinGet silently.
+winget:
+  - name: Govard
+    publisher: DDTCoreX
+    short_description: Govard local development orchestrator CLI.
+    description: Govard local development orchestrator for PHP and web projects (Magento, Laravel, Symfony, WordPress, and more).
+    license: MIT
+    homepage: https://github.com/ddtcorex/govard
+    publisher_url: https://github.com/ddtcorex
+    publisher_support_url: https://github.com/ddtcorex/govard/issues
+    package_identifier: DDTCoreX.Govard
+    commit_author:
+      name: github-actions[bot]
+      email: github-actions[bot]@users.noreply.github.com
+    release_notes_url: https://github.com/ddtcorex/govard/releases/tag/{{.Tag}}
+    tags:
+      - cli
+      - development
+      - devops
+      - docker
+      - php
+    repository:
+      owner: ddtcorex
+      name: winget-pkgs
+      branch: 'govard-{{.Version}}'
+      token: "{{.Env.DISTRIBUTION_PAT}}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -160,6 +160,13 @@ brew install ddtcorex/tap/govard
 
 # Docker (no install needed — CI-friendly)
 docker run --rm ghcr.io/ddtcorex/govard:<version> version
+
+# Windows (WinGet — auto-updated every release)
+winget install DDTCoreX.Govard
+
+# Windows (Scoop — owned bucket, auto-updated every release)
+scoop bucket add ddtcorex https://github.com/ddtcorex/scoop-bucket
+scoop install govard
 ```
 
 Replace `<version>` with a tag from the [releases page](https://github.com/ddtcorex/govard/releases).

--- a/docs/vi/getting-started/installation.md
+++ b/docs/vi/getting-started/installation.md
@@ -78,6 +78,32 @@ sudo installer -pkg govard_<version>_Darwin_arm64.pkg -target /
 
 ---
 
+## 📦 Package Managers
+
+Mỗi nền tảng một lệnh duy nhất — chọn một kênh và dùng cố định:
+
+```bash
+# npm (Node 20+, mọi OS, chỉ CLI)
+npm i -g @ddtcorex/govard
+
+# Homebrew (macOS + Linuxbrew, chỉ CLI)
+brew install ddtcorex/tap/govard
+
+# Docker (không cần cài — thân thiện CI)
+docker run --rm ghcr.io/ddtcorex/govard:<version> version
+
+# Windows (WinGet — tự cập nhật mỗi release)
+winget install DDTCoreX.Govard
+
+# Windows (Scoop — bucket riêng, tự cập nhật mỗi release)
+scoop bucket add ddtcorex https://github.com/ddtcorex/scoop-bucket
+scoop install govard
+```
+
+Thay `<version>` bằng tag từ [trang releases](https://github.com/ddtcorex/govard/releases).
+
+---
+
 ## 🔧 Build từ Source
 
 ### Điều kiện tiên quyết


### PR DESCRIPTION
Closes #249.

## Summary
Second shippable batch of the Phase 2 plan (spec + Plan B are local-only under docs/superpowers/). Windows coverage, no per-release manual steps.

- New repo ddtcorex/scoop-bucket (master branch, manifest-only): release.yml scoop-bucket job renders bucket/govard.json from the tag's checksums.txt on stable tags and pushes via DISTRIBUTION_PAT.
- GoReleaser winget publisher (package_identifier DDTCoreX.Govard): commits to the ddtcorex/winget-pkgs fork and opens the microsoft/winget-pkgs PR automatically. PAT passed as DISTRIBUTION_PAT; missing secret fails loudly.
- One-time (done in this batch except the secret value): fork + bucket repo created, both on master; DISTRIBUTION_PAT must be pasted by the repo owner before the first rehearsal tag.
- Docs EN + VI.

## Rationale
go-task/task pattern: WinGet automated via GoReleaser fork-PR; Scoop via owned bucket (no community review gate per version).

## Test plan
- make test green, gofmt clean.
- goreleaser check passes (pre-existing brews deprecation note only).
- scoop render dry-run against v1.71.2 checksums: both Windows zip hashes resolve.
- actionlint: only the pre-existing SC2035 (macos-pkg glob, also on master).
- Post-merge gate: -beta.N tag must show the scoop commit + winget rehearsal PR (closed by hand after verify) before stable relies on it. Watch item: whether winget fires on beta tags determines if a stable-only disable gate is needed before the first stable release with this config.
