### PR TITLE
fix(release): ignore generated completion dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /govard-desktop
 /bin/
 /dist/
+/completion/
 *.exe
 *.out
 


### PR DESCRIPTION
Closes #251.

## Summary
Beta rehearsal v1.72.0-beta.1 failed at GoReleaser with 'git is in a dirty state ?? completion/'. The Phase 2A generation step creates that dir untracked right before GoReleaser validates the tree. One-line fix: /completion/ in .gitignore (generated at release time, never committed — same class as /dist/).

## Test plan
- Local repro of the CI condition: generate completion/ then git status --porcelain shows only the .gitignore modification (no ?? completion/).
- CI on this PR must be green; the real proof is the next -beta.N tag run.
