### PR TITLE
fix(ci): install-e2e pins the exact tag for install.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,9 @@ jobs:
       - name: Install via install.sh
         if: matrix.channel == 'install-sh'
         run: |
-          curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --cli-only -y
+          # --version pins the exact tag: without it install.sh resolves
+          # releases/latest (stable only), which can never equal a beta tag.
+          curl -fsSL https://raw.githubusercontent.com/ddtcorex/govard/master/install.sh | bash -s -- --cli-only -y --version "${GITHUB_REF_NAME}"
           test "$(govard version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | head -n1)" = "${GITHUB_REF_NAME#v}"
       - name: Install via npm
         if: ${{ matrix.channel == 'npm' && !contains(github.ref_name, '-') }}


### PR DESCRIPTION
Closes #255.

## Summary
Beta rehearsal v1.72.0-beta.3 proved the e2e job's worth: both install-sh legs failed because install.sh without --version resolves releases/latest (stable-only), installing 1.71.2 while asserting the beta tag. One-line fix: pass --version with the exact tag ref so stable and beta tags both install what the assertion expects.

## Test plan
- YAML parses, actionlint shows only the pre-existing SC2035.
- Real proof is the next -beta.N tag run (both install-sh legs must go green).
