### PR TITLE
fix(wordpress): define WP_INSTALLING so fresh install actually installs

### DIFF
--- a/internal/frameworks/wordpress/bootstrap.go
+++ b/internal/frameworks/wordpress/bootstrap.go
@@ -225,17 +225,7 @@ func (w *WordPressBootstrap) installWordPressSite(projectDir, siteURL string) er
 		httpsValue = "on"
 	}
 
-	code := strings.Join([]string{
-		"$_SERVER['HTTP_HOST'] = " + strconv.Quote(host) + ";",
-		"$_SERVER['SERVER_NAME'] = " + strconv.Quote(host) + ";",
-		"$_SERVER['REQUEST_URI'] = '/';",
-		"$_SERVER['HTTPS'] = " + strconv.Quote(httpsValue) + ";",
-		"require " + strconv.Quote(loadPath) + ";",
-		"require " + strconv.Quote(upgradePath) + ";",
-		"if (!is_blog_installed()) {",
-		"    wp_install(" + strconv.Quote("WordPress Site") + ", " + strconv.Quote(conventions.DefaultAdminUser) + ", " + strconv.Quote(conventions.DefaultAdminEmail) + ", true, '', " + strconv.Quote(conventions.DefaultAdminPassword) + ");",
-		"}",
-	}, "\n")
+	code := buildWordPressInstallCode(host, httpsValue, loadPath, upgradePath)
 
 	if err := bootstrap.RunPHPOneLiner(projectDir, w.Options.Runner, code); err != nil {
 		pterm.Warning.Printf("PHP one-liner install failed (%v), trying wp-cli fallback...\n", err)
@@ -260,6 +250,31 @@ func (w *WordPressBootstrap) installWordPressSite(projectDir, siteURL string) er
 	}
 
 	return nil
+}
+
+func BuildWordPressInstallCodeForTest(host, httpsValue, loadPath, upgradePath string) string {
+	return buildWordPressInstallCode(host, httpsValue, loadPath, upgradePath)
+}
+
+// buildWordPressInstallCode renders the php -r one-liner that installs the
+// site on a fresh database. WP_INSTALLING must be defined before wp-load.php:
+// wp-settings.php unconditionally calls wp_not_installed(), which
+// wp_redirect()s to install.php and dies when the DB is empty and the
+// constant is absent. Without it the one-liner exits 0 having installed
+// nothing while the caller reports success (issue #246).
+func buildWordPressInstallCode(host, httpsValue, loadPath, upgradePath string) string {
+	return strings.Join([]string{
+		"if (!defined('WP_INSTALLING')) { define('WP_INSTALLING', true); }",
+		"$_SERVER['HTTP_HOST'] = " + strconv.Quote(host) + ";",
+		"$_SERVER['SERVER_NAME'] = " + strconv.Quote(host) + ";",
+		"$_SERVER['REQUEST_URI'] = '/';",
+		"$_SERVER['HTTPS'] = " + strconv.Quote(httpsValue) + ";",
+		"require " + strconv.Quote(loadPath) + ";",
+		"require " + strconv.Quote(upgradePath) + ";",
+		"if (!is_blog_installed()) {",
+		"    wp_install(" + strconv.Quote("WordPress Site") + ", " + strconv.Quote(conventions.DefaultAdminUser) + ", " + strconv.Quote(conventions.DefaultAdminEmail) + ", true, '', " + strconv.Quote(conventions.DefaultAdminPassword) + ");",
+		"}",
+	}, "\n")
 }
 
 func (w *WordPressBootstrap) updateWordPressSiteURL(projectDir, siteURL string) error {

--- a/tests/bootstrap_wordpress_test.go
+++ b/tests/bootstrap_wordpress_test.go
@@ -107,3 +107,19 @@ require_once ABSPATH . 'wp-settings.php';
 		t.Fatalf("expected default admin password in runner commands, got:\n%s", joined)
 	}
 }
+
+func TestWordPressInstallCodeDefinesInstallingBeforeLoad(t *testing.T) {
+	code := wordpress.BuildWordPressInstallCodeForTest("wp-repro-246.test", "", "/var/www/html/wp-load.php", "/var/www/html/wp-admin/includes/upgrade.php")
+
+	defIdx := strings.Index(code, "WP_INSTALLING")
+	loadIdx := strings.Index(code, "wp-load.php")
+	if defIdx < 0 {
+		t.Fatalf("install code must define WP_INSTALLING (issue #246), got:\n%s", code)
+	}
+	if loadIdx < 0 || defIdx > loadIdx {
+		t.Fatalf("WP_INSTALLING must be defined before wp-load.php is required, got:\n%s", code)
+	}
+	if !strings.Contains(code, "wp_install(") || !strings.Contains(code, "is_blog_installed()") {
+		t.Fatalf("install code must keep the guarded wp_install call, got:\n%s", code)
+	}
+}


### PR DESCRIPTION
Closes #246.

## Summary
Fresh WP bootstrap printed 'WordPress installation completed' with zero tables. Root cause (proven live): the php -r one-liner requires wp-load.php on an empty DB without defining WP_INSTALLING, so wp-settings.php's unconditional wp_not_installed() call wp_redirect()s to install.php and dies — exit code 0, nothing installed. The fix mirrors wp-admin/install.php:32: define WP_INSTALLING before loading. Extracted the one-liner into a tested builder.

## Rationale
One-line semantic fix at the exact failure point instead of restructuring the install flow (PHP one-liner + wp-cli fallback stay as-is).

## Test plan
- New hermetic test: install code defines WP_INSTALLING before wp-load.php (fails before, passes after).
- make test green, gofmt clean.
- Live end-to-end on scratch project (binary from this branch): fresh bootstrap from empty volume → 12 wp_ tables, siteurl correct, homepage HTTP 200 (was: 0 tables + redirect to install.php).
