### PR TITLE
fix(ci): rename verify gate to Verify

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -129,7 +129,7 @@ jobs:
           path: bin/
 
   verify:
-    name: verify / verify
+    name: Verify
     runs-on: ubuntu-latest
     needs: [quality_checks, fast_tests, integration_tests, build_binaries]
     if: always()


### PR DESCRIPTION
Renames the CI gate job display name from 'verify / verify' to 'Verify' so it reads consistently with the other pipeline checks. Closes #259. NOTE: branch protection on master still requires the old 'verify / verify' context — update it to 'Verify' once this PR's checks run green, before merge.