### PR TITLE
feat(distribution): add Snap and CloudSmith channels (Phase 2C)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,14 @@ jobs:
           test -s completion/govard.fish
           test -s completion/govard.ps1
 
+      - name: Log in to Snap Store
+        # GoReleaser's snapcrafts publisher reads SNAPCRAFT_STORE_CREDENTIALS.
+        run: |
+          sudo snap install snapcraft --classic
+          snapcraft login --with <(echo "${{ secrets.SNAPCRAFT_TOKEN }}")
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
       - name: Run GoReleaser
         # Pinned v6: the v7 SHA (f06c13b) breaks GitHub's startup fetch
         # (proven by probe + beta.7) though valid via API. Revisit only
@@ -89,6 +97,28 @@ jobs:
           # it as "no official image pinned" and builds the embedded lint
           # context locally instead.
           GOVARD_GLINT_DIGEST: ${{ needs.glint-image.outputs.image_digest }}
+
+      # CloudSmith (apt/dnf/apk): GoReleaser OSS has no cloudsmiths publisher
+      # (Pro-only), so the workflow pushes the nfpms artifacts with
+      # CloudSmith CLI — same rendered-then-pushed pattern as the Homebrew
+      # formula below. Runs on every tag incl. betas; per-repo retention
+      # (keep last 5) bounds the free-tier storage.
+      - name: Push packages to Cloudsmith
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        run: |
+          pip install --quiet cloudsmith-cli
+          DEB=(dist/govard_*.deb)
+          RPM=(dist/govard_*.rpm)
+          APK=(dist/govard_*.apk)
+          test -f "${DEB[0]}" && test -f "${RPM[0]}" && test -f "${APK[0]}"
+          for d in ubuntu/22.04 ubuntu/24.04 debian/12; do
+            cloudsmith push deb "ddtcorex/govard-deb/${d}" "${DEB[0]}" --republish
+          done
+          for d in el/9 fedora/41; do
+            cloudsmith push rpm "ddtcorex/govard-rpm/${d}" "${RPM[0]}" --republish
+          done
+          cloudsmith push alpine "ddtcorex/govard-apk/alpine/3.20" "${APK[0]}" --republish
 
       # GHCR runtime image: built and pushed here (not via GoReleaser
       # dockers — its buildx flow exports multi-arch manifests locally

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,6 +106,8 @@ nfpms:
       - govard
     formats:
       - deb
+      - rpm
+      - apk
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     bindir: /usr/local/bin
     maintainer: DDTCoreX <kaido4492@gmail.com>
@@ -186,6 +188,22 @@ changelog:
     - title: 📦 Others
       order: 99
   format: "{{ .Message }}"
+
+# Snap Store: classic confinement (Govard orchestrates Docker and writes
+# system paths). Name `govard` claimed by the maintainer; publish:true from
+# day one — if the Store holds the first revision for classic review the
+# release goes red once, which is the accepted rehearsal signal.
+snapcrafts:
+  - id: govard
+    name: govard
+    ids:
+      - govard
+    summary: Govard local development orchestrator CLI
+    description: Govard local development orchestrator CLI
+    license: MIT
+    grade: stable
+    confinement: classic
+    publish: true
 
 release:
   prerelease: auto

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -160,6 +160,22 @@ brew install ddtcorex/tap/govard
 
 # Docker (no install needed — CI-friendly)
 docker run --rm ghcr.io/ddtcorex/govard:<version> version
+
+# Snap (Linux, CLI only — classic confinement is required:
+# Govard orchestrates Docker and writes system paths)
+sudo snap install govard --classic
+
+# Debian/Ubuntu via CloudSmith (one-time repo setup, then install)
+curl -1sLf https://dl.cloudsmith.io/public/ddtcorex/govard-deb/setup.deb.sh | sudo -E bash
+sudo apt install govard
+
+# Fedora/RHEL via CloudSmith (one-time repo setup, then install)
+curl -1sLf https://dl.cloudsmith.io/public/ddtcorex/govard-rpm/setup.rpm.sh | sudo -E bash
+sudo dnf install govard
+
+# Alpine via CloudSmith (one-time repo setup, then install)
+curl -1sLf https://dl.cloudsmith.io/public/ddtcorex/govard-apk/setup.alpine.sh | sudo -E bash
+sudo apk add govard
 ```
 
 Replace `<version>` with a tag from the [releases page](https://github.com/ddtcorex/govard/releases).

--- a/docs/vi/getting-started/installation.md
+++ b/docs/vi/getting-started/installation.md
@@ -70,6 +70,26 @@ CLI + Desktop (WebKitGTK 4.1 / Ubuntu 22.04+):
 sudo apt install ./govard_<version>_linux_<arch>.deb ./govard-desktop_<version>_linux_<arch>.deb
 ```
 
+### Kênh package (Snap / CloudSmith)
+
+```bash
+# Snap (Linux, chỉ CLI — bắt buộc classic confinement vì
+# Govard điều khiển Docker và ghi system paths)
+sudo snap install govard --classic
+
+# Debian/Ubuntu qua CloudSmith (setup repo một lần, rồi cài)
+curl -1sLf https://dl.cloudsmith.io/public/ddtcorex/govard-deb/setup.deb.sh | sudo -E bash
+sudo apt install govard
+
+# Fedora/RHEL qua CloudSmith (setup repo một lần, rồi cài)
+curl -1sLf https://dl.cloudsmith.io/public/ddtcorex/govard-rpm/setup.rpm.sh | sudo -E bash
+sudo dnf install govard
+
+# Alpine qua CloudSmith (setup repo một lần, rồi cài)
+curl -1sLf https://dl.cloudsmith.io/public/ddtcorex/govard-apk/setup.alpine.sh | sudo -E bash
+sudo apk add govard
+```
+
 ### macOS (`.pkg`)
 
 ```bash


### PR DESCRIPTION
Implements Plan C (option B: CloudSmith CLI in workflow — GoReleaser OSS has no cloudsmiths publisher, verified against its JSON schema).

## Summary
- nfpms govard-cli: build rpm + apk alongside deb.
- snapcrafts: publish govard snap (classic confinement, publish:true) to the Store. First release may go red if the Store holds the revision for classic review — accepted rehearsal signal.
- release.yml: Snap Store login before GoReleaser; CloudSmith CLI push after (deb x3 distros, rpm x2, apk x1, --republish for idempotent reruns). Runs on every tag incl. betas.
- Docs (en+vi): snap + apt/dnf/apk install instructions.

## Rationale
Option B over GoReleaser Pro: free, same rendered-then-pushed pattern already proven by the Homebrew tap.

## Test plan
- goreleaser check green (twice, incl. after snapcrafts fix: Snapcraft has no homepage field).
- actionlint: only pre-existing SC2035 (also on master), no new findings.
- make test green, gofmt clean.
- Beta rehearsal after merge: deb/rpm/apk attached, CloudSmith repos populated, snap outcome documented.

Maintainer one-time: CloudSmith per-repo retention keep-last-5 (free-tier 500MB storage ~7 releases). Please verify the dl.cloudsmith.io setup-script URLs match the repos' visibility in the CloudSmith UI.
