### PR TITLE
fix(distribution): authenticate snapcraft via env only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,9 @@ jobs:
 
       - name: Log in to Snap Store
         # GoReleaser's snapcrafts publisher reads SNAPCRAFT_STORE_CREDENTIALS.
-        run: |
-          sudo snap install snapcraft --classic
-          snapcraft login --with <(echo "${{ secrets.SNAPCRAFT_TOKEN }}")
+        # snapcraft 9.x removed `login --with`: the env var alone authenticates
+        # both the CLI and GoReleaser (proven by beta.5 rehearsal).
+        run: sudo snap install snapcraft --classic
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
 


### PR DESCRIPTION
Beta.5 rehearsal found it: snapcraft 9.x removed `login --with` (exit 64). The SNAPCRAFT_STORE_CREDENTIALS env var alone authenticates both the CLI and GoReleaser. Drops the login line, keeps the install.

Test plan: actionlint (only pre-existing SC2035); proof comes from the next beta rehearsal tag after merge.
