### PR TITLE
fix(distribution): pin snapcraft to 8.x channel

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -156,7 +156,7 @@ jobs:
           mv completion/govard.powershell completion/govard.ps1
 
       - name: Install snapcraft for snap packs
-        run: sudo snap install snapcraft --channel=8.x/stable
+        run: sudo snap install snapcraft --classic --channel=8.x/stable
 
       - name: Run GoReleaser snapshot
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -147,6 +147,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - name: Install desktop build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+
       - name: Generate shell completions
         run: |
           mkdir -p completion dist

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -128,14 +128,52 @@ jobs:
           name: govard-binaries
           path: bin/
 
+  # Validates the tag-only release config on every PR: GoReleaser --snapshot
+  # builds everything release.yml builds (archives, nfpms deb/rpm/apk, snap
+  # packs) without publishing anything. Added after beta.5-8 burned four tags
+  # on snap-login issues PR CI could never see. Store-upload auth remains
+  # beta-rehearsal-only (it needs real secrets).
+  release_snapshot:
+    name: Release Snapshot (GoReleaser --snapshot)
+    runs-on: ubuntu-latest
+    needs: [quality_checks, fast_tests]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Generate shell completions
+        run: |
+          mkdir -p completion dist
+          for sh in bash zsh fish powershell; do
+            go run ./cmd/govard completion "$sh" > "completion/govard.$sh"
+          done
+          mv completion/govard.powershell completion/govard.ps1
+
+      - name: Install snapcraft for snap packs
+        run: sudo snap install snapcraft --channel=8.x/stable
+
+      - name: Run GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   verify:
     name: Verify
     runs-on: ubuntu-latest
-    needs: [quality_checks, fast_tests, integration_tests, build_binaries]
+    needs: [quality_checks, fast_tests, integration_tests, build_binaries, release_snapshot]
     if: always()
     steps:
       - name: Gate
         run: |
-          for r in "${{ needs.quality_checks.result }}" "${{ needs.fast_tests.result }}" "${{ needs.integration_tests.result }}" "${{ needs.build_binaries.result }}"; do
+          for r in "${{ needs.quality_checks.result }}" "${{ needs.fast_tests.result }}" "${{ needs.integration_tests.result }}" "${{ needs.build_binaries.result }}" "${{ needs.release_snapshot.result }}"; do
             [ "$r" = "success" ] || [ "$r" = "skipped" ] || exit 1
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,17 +74,15 @@ jobs:
           test -s completion/govard.ps1
 
       - name: Log in to Snap Store
-        # GoReleaser's snapcrafts publisher reads SNAPCRAFT_STORE_CREDENTIALS.
-        # snapcraft 9.x removed `login --with`: the env var alone carries the
-        # exported credentials (beta.5). The snapcraft SNAP is strictly
-        # confined and cannot reach any keyring on headless CI (beta.6: empty
-        # unlock; beta.7: still "No keyring found"), so install the unconfined
-        # PyPI build and point keyring at a file backend instead.
+        # GoReleaser's snapcrafts publisher shells out to the `snapcraft`
+        # binary for pack+upload. Pinned to the 8.x channel: 9.x removed
+        # `login --with` (beta.5, exit 64) and enforces a keyring the
+        # strictly-confined snap cannot reach headless (beta.6/7); the PyPI
+        # build is uninstallable (its backend demands git metadata, beta.8).
+        # 8.x keeps `login --with` with the pre-9.x lenient credential store.
         run: |
-          sudo apt-get install -y squashfs-tools
-          pip install --quiet --break-system-packages snapcraft keyrings.alt
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-          echo "PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring" >> "${GITHUB_ENV}"
+          sudo snap install snapcraft --channel=8.x/stable
+          snapcraft login --with <(echo "${{ secrets.SNAPCRAFT_TOKEN }}")
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         # build is uninstallable (its backend demands git metadata, beta.8).
         # 8.x keeps `login --with` with the pre-9.x lenient credential store.
         run: |
-          sudo snap install snapcraft --channel=8.x/stable
+          sudo snap install snapcraft --classic --channel=8.x/stable
           snapcraft login --with <(echo "${{ secrets.SNAPCRAFT_TOKEN }}")
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}


### PR DESCRIPTION
Beta.8: PyPI snapcraft is uninstallable (build backend demands git metadata, exit 128). Pin the snap to the 8.x channel instead: 8.x keeps login --with with the pre-9.x lenient credential store, dodging both the 9.x keyring enforcement (beta.6/7) and the PyPI dead end.

Test plan: actionlint (only pre-existing SC2035); proof comes from the next beta rehearsal tag after merge.
