### PR TITLE
chore(distribution): disable snap to prove CloudSmith in isolation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -193,8 +193,12 @@ changelog:
 # system paths). Name `govard` claimed by the maintainer; publish:true from
 # day one — if the Store holds the first revision for classic review the
 # release goes red once, which is the accepted rehearsal signal.
+# TEMPORARILY DISABLED (beta.11): headless Store auth unsolved after
+# beta.5-10. Disabled to prove the CloudSmith half green in isolation;
+# re-enable with the working auth on beta.12. Tracked in Plan C Task 5.
 snapcrafts:
   - id: govard
+    disable: "true"
     name: govard
     ids:
       - govard


### PR DESCRIPTION
Beta.11 setup: temporarily disable snapcrafts (headless Store auth unsolved after beta.5-10) so the release can proceed to the CloudSmith push step and prove apt/dnf/apk green in isolation. Re-enable with working auth on beta.12.

Test plan: goreleaser check green; snapshot job on this PR; proof comes from the beta.11 rehearsal tag after merge.
