### PR TITLE
fix(distribution): devmode snapcraft to reach CI keyring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,16 @@ jobs:
         # it expects an INI session file and chokes on the raw exported
         # token (beta.9: "File contains no section headers") — the env var
         # alone carries auth for both the CLI and GoReleaser.
-        run: sudo snap install snapcraft --classic --channel=8.x/stable
+        # --devmode (beta.12): devmode lifts confinement so snapcraft can
+        # reach the session keyring; strict mode could not (beta.6/7/10).
+        # PyPI is dead (4.8.1 from 2021, beta.8) — Canonical ships new
+        # snapcraft as snaps only.
+        run: |
+          sudo snap install snapcraft --classic --channel=8.x/stable --devmode
+          sudo apt-get install -y gnome-keyring
+          eval "$(dbus-launch --sh-syntax)"
+          echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}" >> "${GITHUB_ENV}"
+          echo -n "" | gnome-keyring-daemon --unlock
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -193,12 +193,10 @@ changelog:
 # system paths). Name `govard` claimed by the maintainer; publish:true from
 # day one — if the Store holds the first revision for classic review the
 # release goes red once, which is the accepted rehearsal signal.
-# TEMPORARILY DISABLED (beta.11): headless Store auth unsolved after
-# beta.5-10. Disabled to prove the CloudSmith half green in isolation;
-# re-enable with the working auth on beta.12. Tracked in Plan C Task 5.
+# Re-enabled (beta.12): CloudSmith proven green on beta.11; snap returns
+# with a devmode install so the binary can reach the CI keyring.
 snapcrafts:
   - id: govard
-    disable: "true"
     name: govard
     ids:
       - govard


### PR DESCRIPTION
Beta.12 setup: re-enable snap (CloudSmith proven green on beta.11) with snapcraft installed --devmode so the binary can reach the unlocked session keyring — strict confinement blocked every attempt (beta.6/7/10). PyPI ruled out (4.8.1 from 2021, beta.8). Added gnome-keyring unlock back alongside.

Test plan: goreleaser check green; actionlint (only pre-existing SC2035); snapshot job on this PR; proof of upload comes from the beta.12 rehearsal tag after merge.
