### PR TITLE
fix(distribution): create login keyring collection explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,9 +91,13 @@ jobs:
         run: |
           sudo snap install snapcraft --classic --channel=8.x/stable
           sudo apt-get install -y gnome-keyring libsecret-1-0 dbus-x11 libsecret-tools
+          pip install --quiet secretstorage
           eval "$(dbus-launch --sh-syntax)"
           echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}" >> "${GITHUB_ENV}"
           echo -n "" | gnome-keyring-daemon --daemonize --components=secrets --unlock
+          # --unlock cannot CREATE the login collection (beta.17: Secret
+          # Service up but /collection/login missing) — create it explicitly.
+          python3 -c "import secretstorage; b=secretstorage.dbus_init(); secretstorage.create_collection(b,'login','') if 'login' not in [c.get_label() for c in secretstorage.get_all_collections(b)] else None"
           secret-tool store --label=ci-keyring-probe probe-key probe-value
           [ "$(secret-tool lookup probe-key probe-value)" = "probe-value" ]
         env:


### PR DESCRIPTION
Beta.17 probe diagnosed precisely: Secret Service runs but /collection/login does not exist — --unlock cannot create it. Creates the login collection explicitly via secretstorage before the round-trip probe.

Test plan: snapshot job on this PR; proof of upload comes from the beta.18 rehearsal tag after merge.
