### PR TITLE
fix(distribution): pipe secret into secret-tool probe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,10 @@ jobs:
           # appears in logs, never the value.
           KEYRING_PASS="$(openssl rand -hex 16)"
           printf '%s' "${KEYRING_PASS}" | gnome-keyring-daemon --daemonize --components=secrets --login
-          secret-tool store --label=ci-keyring-probe probe-key probe-value
-          [ "$(secret-tool lookup probe-key probe-value)" = "probe-value" ]
+          # secret-tool reads the SECRET from stdin (beta.20: bare call
+          # stored empty, lookup mismatch failed silently under bash -e).
+          printf '%s' 'probe-secret' | secret-tool store --label=ci-keyring-probe probe-key probe-attr
+          [ "$(secret-tool lookup probe-key probe-attr)" = "probe-secret" ]
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
 


### PR DESCRIPTION
Beta.20: the probe itself was broken — secret-tool reads the secret from stdin, so the bare call stored empty and the lookup mismatch failed silently. Pipe the secret in. The keyring (--login + random password) may have been fine all along.

Test plan: snapshot job on this PR; proof of upload comes from the beta.21 rehearsal tag after merge.
