### PR TITLE
fix(distribution): declare Store token on GoReleaser step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev_tag.outputs.tag }}
+          # Step env does NOT cross step boundaries (beta.21: snapcraft
+          # upload ran credential-less and fell back to an interactive
+          # login prompt) — the Store token must be re-declared here.
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           # Linked into internal/audit.GovardGlintDigest by .goreleaser.yml. An empty value is a valid,
           # degraded state rather than a build failure: ToolchainManager treats
           # it as "no official image pinned" and builds the embedded lint


### PR DESCRIPTION
Beta.21 (keyring now works, probe green): snapcraft upload fell back to interactive login — step env does not cross step boundaries, so GoReleaser never saw SNAPCRAFT_STORE_CREDENTIALS. Re-declare it on the GoReleaser step.

Test plan: actionlint (only pre-existing SC2035); snapshot job on this PR; proof of upload comes from the beta.22 rehearsal tag after merge.
