### PR TITLE
fix(distribution): tolerate distro suffix in retention sort

### DIFF
--- a/.github/workflows/cloudsmith-retention.yml
+++ b/.github/workflows/cloudsmith-retention.yml
@@ -51,12 +51,16 @@ jobs:
               cloudsmith_api.ApiClient(config)
           )
 
+          import re
+
           def version_key(version):
               # "1.72.0-beta.11" -> ((1,72,0),(0,11)); "1.72.0" -> ((1,72,0),(1,))
+              # Tolerates distro suffixes (dry-run found "beta.11-0~beta").
               base, _, pre = version.partition("-")
               nums = tuple(int(p) for p in base.split("."))
-              if pre.startswith("beta."):
-                  return (nums, (0, int(pre[len("beta."):])))
+              m = re.match(r"beta\.(\d+)", pre)
+              if m:
+                  return (nums, (0, int(m.group(1))))
               return (nums, (1,))
 
           deleted = 0


### PR DESCRIPTION
Dry-run found it: nfpms appends distro revisions (1.72.0-beta.11-0~beta) that crashed the strict beta.N parse. Match the leading beta.N with regex and ignore the suffix.

Test plan: sort logic unit-proven incl. suffixed versions; next dry-run on merge confirms against live inventory.
