### PR TITLE
fix(distribution): parse tilde-style deb versions

### DIFF
--- a/.github/workflows/cloudsmith-retention.yml
+++ b/.github/workflows/cloudsmith-retention.yml
@@ -55,10 +55,13 @@ jobs:
 
           def version_key(version):
               # "1.72.0-beta.11" -> ((1,72,0),(0,11)); "1.72.0" -> ((1,72,0),(1,))
-              # Tolerates distro suffixes (dry-run found "beta.11-0~beta").
-              base, _, pre = version.partition("-")
-              nums = tuple(int(p) for p in base.split("."))
-              m = re.match(r"beta\.(\d+)", pre)
+              # Debian revisions rewrite the separator (dry-runs found
+              # "beta.11-0~beta" and tilde-style "1.72.0~beta11"), so parse
+              # leading numerics + first beta marker anywhere in the string.
+              nums = tuple(
+                  int(p) for p in re.match(r"^(\d+(?:\.\d+)*)", version).group(1).split(".")
+              )
+              m = re.search(r"beta\.?(\d+)", version)
               if m:
                   return (nums, (0, int(m.group(1))))
               return (nums, (1,))


### PR DESCRIPTION
Second dry-run found it: nfpms also emits tilde-style deb versions (1.72.0~beta11, no hyphen at all). Parse leading numerics + first beta marker anywhere instead of splitting on hyphen.

Test plan: sort logic proven over hyphen, suffixed, tilde, and stable+revision forms; next dry-run on merge confirms against live inventory.
