### PR TITLE
feat(core): declare the Docker-free contract and add container-free analysis

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -171,14 +171,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  core_sans_docker:
+    name: Core Contract (no Docker)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build CLI
+        run: go build -o /tmp/govard ./cmd/govard
+
+      - name: Run the Docker-free contract
+        run: |
+          docker run --rm \
+            -v /tmp/govard:/govard:ro \
+            -v "$PWD/scripts/core-contract.sh:/core-contract.sh:ro" \
+            debian:bookworm-slim /core-contract.sh /govard
+
   verify:
     name: Verify
     runs-on: ubuntu-latest
-    needs: [quality_checks, fast_tests, integration_tests, build_binaries, release_snapshot]
+    needs: [quality_checks, fast_tests, integration_tests, build_binaries, release_snapshot, core_sans_docker]
     if: always()
     steps:
       - name: Gate
         run: |
-          for r in "${{ needs.quality_checks.result }}" "${{ needs.fast_tests.result }}" "${{ needs.integration_tests.result }}" "${{ needs.build_binaries.result }}" "${{ needs.release_snapshot.result }}"; do
+          for r in "${{ needs.quality_checks.result }}" "${{ needs.fast_tests.result }}" "${{ needs.integration_tests.result }}" "${{ needs.build_binaries.result }}" "${{ needs.release_snapshot.result }}" "${{ needs.core_sans_docker.result }}"; do
             [ "$r" = "success" ] || [ "$r" = "skipped" ] || exit 1
           done

--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ The installer automatically handles required system dependencies, starts global 
 Do not mix install channels on the same machine (for example: `.deb` + `make install` + `self-update` across different paths).  
 Use one channel only, otherwise you can end up with conflicting binaries in `/usr/bin` and `/usr/local/bin`.
 
+### Runs without Docker
+
+Govard installs and runs without Docker. Commands that never touch a container
+declare that requirement in the manifest, and the resulting set is listed by:
+
+```bash
+govard capabilities          # every command, its requirements, and host status
+govard capabilities --json   # same, machine-readable
+```
+
+Docker is required only for stack commands. When it is missing, those commands
+exit `3` with `CAPABILITY_MISSING` instead of failing midway through their
+workflow, and `--error-json` prints the failure as a machine-readable envelope.
+`govard doctor` reports Docker as an optional capability (exit `0`); use
+`govard doctor --strict` when a script needs the old hard gate.
+
+Note: commands that forward their arguments to a tool (`govard tool php ...`,
+`govard redis cli ...`) cannot parse the `--error-json` flag; their failures
+still carry the documented exit codes.
+
 ### Release Installers
 
 Every tagged release publishes these Linux packages:
@@ -149,7 +169,7 @@ Ensure you have the following prerequisites installed:
 - **Node.js 20+**
 - **Yarn (v1.x)**
 - **golangci-lint (v2.11+)**
-- **Docker & Docker Compose**
+- **Docker & Docker Compose** — required for stack commands (`env`, `svc`, `db`, `shell`, `test`, `audit`)
 - **Wails v2.11+** (required for desktop app development)
 
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -90,7 +90,7 @@ Ensure you have the following installed:
 | Node.js | `20+` |
 | Yarn | v1.x |
 | golangci-lint | v2.11+ |
-| Docker + Docker Compose | latest |
+| Docker + Docker Compose | latest (stack commands only — the CLI itself has no Docker dependency) |
 | Wails | `v2.11+` (desktop development only) |
 
 ### Source Install
@@ -124,6 +124,21 @@ cd govard
 No `sudo` required — install everything locally and update your `PATH`.
 
 ---
+
+## Runs Without Docker
+
+The CLI installs and runs with no Docker at all. The commands that never touch a
+container are declared in the binary's manifest and listed by:
+
+```bash
+govard capabilities          # command, requirement, and whether this host meets it
+govard capabilities --json   # machine-readable
+```
+
+Stack commands (`govard env up`, `svc`, `db`, `shell`, `test`, `audit`) need
+Docker; without it they exit `3` with `CAPABILITY_MISSING` before doing any work.
+`govard doctor` treats Docker as optional and exits `0`; `govard doctor --strict`
+restores the hard gate for bootstrap scripts.
 
 ## 🐳 Docker Images
 

--- a/docs/vi/getting-started/installation.md
+++ b/docs/vi/getting-started/installation.md
@@ -110,7 +110,7 @@ sudo installer -pkg govard_<version>_Darwin_arm64.pkg -target /
 | Node.js | `20+` |
 | Yarn | v1.x |
 | golangci-lint | v2.11+ |
-| Docker + Docker Compose | Bản mới nhất |
+| Docker + Docker Compose | Bản mới nhất (chỉ cho lệnh stack — bản thân CLI không phụ thuộc Docker) |
 | Wails | `v2.11+` (chỉ khi phát triển desktop app) |
 
 ### Cài đặt từ Source

--- a/install.sh
+++ b/install.sh
@@ -259,7 +259,7 @@ check_dependencies() {
     if command -v docker >/dev/null 2>&1; then
         success "  Docker: $(docker --version | awk '{print $3}' | tr -d ',')"
     else
-        warn "  Docker: Not found (Required to run Govard stacks)"
+        info "  Docker: not found - core commands work without it; stack commands need it"
     fi
 
     # Docker Compose
@@ -269,7 +269,7 @@ check_dependencies() {
         success "  Docker Compose (v1): $(docker-compose --version | awk '{print $3}')"
         warn "  Docker Compose V2 (plugin) is recommended."
     else
-        warn "  Docker Compose: Not found (Required to run Govard stacks)"
+        info "  Docker Compose: not found - stack commands need the Compose v2 plugin"
     fi
     # Git (for source mode)
     if command -v git >/dev/null 2>&1; then
@@ -821,8 +821,13 @@ main() {
     # Post-installation automation
     local govard_bin="${INSTALL_DIR%/}/${CLI_BINARY_NAME}"
     if [[ -x "$govard_bin" ]]; then
-        info "Initializing global services..."
-        run_as_user "$govard_bin" svc up -d --remove-orphans || warn "Failed to start global services automatically."
+        if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+            info "Initializing global services..."
+            run_as_user "$govard_bin" svc up -d --remove-orphans || warn "Failed to start global services automatically."
+        else
+            info "Skipping global services: Docker/Compose is not available on this host."
+            info "Core commands are ready - run '$govard_bin capabilities' to list them."
+        fi
         echo ""
     fi
 

--- a/internal/audit/integrity.go
+++ b/internal/audit/integrity.go
@@ -1,0 +1,68 @@
+package audit
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// IntegrityCheck is the audit check id for container-free host analysis. It runs
+// Go analyzers directly on the host, so it needs no container runtime and no PHP
+// toolchain (unlike the lint and profiler checks).
+const IntegrityCheck = "integrity"
+
+// IntegrityRequest carries the host-visible inputs an analyzer may read. It
+// deliberately has no container or PHP-version fields: analyzers are expected to
+// be deterministic over the checked-out source plus the resolved project config.
+type IntegrityRequest struct {
+	ProjectRoot     string
+	TargetPath      string
+	Framework       string
+	StackPHPVersion string
+}
+
+// IntegrityAnalyzer is one framework-declared host analyzer. Implementations
+// self-register by ID; a framework opts in by listing IDs in its
+// AuditIntegrityProfile, so no framework name is hardcoded here.
+type IntegrityAnalyzer interface {
+	ID() string
+	Analyze(IntegrityRequest) ([]LintFinding, error)
+}
+
+var integrityAnalyzers = map[string]IntegrityAnalyzer{}
+
+// RegisterIntegrityAnalyzer adds an analyzer to the process registry. It is
+// called from analyzer init functions, mirroring the framework capability
+// registry pattern.
+func RegisterIntegrityAnalyzer(analyzer IntegrityAnalyzer) {
+	if analyzer == nil || strings.TrimSpace(analyzer.ID()) == "" {
+		return
+	}
+	integrityAnalyzers[analyzer.ID()] = analyzer
+}
+
+// RegisteredIntegrityAnalyzerIDs lists the available analyzer IDs in stable
+// order for error messages.
+func RegisteredIntegrityAnalyzerIDs() []string {
+	ids := make([]string, 0, len(integrityAnalyzers))
+	for id := range integrityAnalyzers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// IntegrityAnalyzers resolves the analyzer IDs declared by a framework profile.
+// An unknown ID is an error naming the available analyzers, never a silent skip.
+func IntegrityAnalyzers(ids []string) ([]IntegrityAnalyzer, error) {
+	analyzers := make([]IntegrityAnalyzer, 0, len(ids))
+	for _, id := range ids {
+		analyzer, ok := integrityAnalyzers[id]
+		if !ok {
+			return nil, fmt.Errorf("integrity analyzer %q is not registered (available: %s)",
+				id, strings.Join(RegisteredIntegrityAnalyzerIDs(), ", "))
+		}
+		analyzers = append(analyzers, analyzer)
+	}
+	return analyzers, nil
+}

--- a/internal/audit/integrity_composer.go
+++ b/internal/audit/integrity_composer.go
@@ -1,0 +1,198 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// composerIntegrityAnalyzer checks the project manifest against its lock file and
+// the configured stack runtime. It needs neither PHP nor a container.
+type composerIntegrityAnalyzer struct{}
+
+func init() { RegisterIntegrityAnalyzer(composerIntegrityAnalyzer{}) }
+
+func (composerIntegrityAnalyzer) ID() string { return "composer" }
+
+const integrityToolName = "govard-integrity"
+
+type composerManifest struct {
+	Name       string            `json:"name"`
+	Require    map[string]string `json:"require"`
+	RequireDev map[string]string `json:"require-dev"`
+}
+
+type composerLockedPackage struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type composerLockFile struct {
+	ContentHash string                  `json:"content-hash"`
+	Packages    []composerLockedPackage `json:"packages"`
+	PackagesDev []composerLockedPackage `json:"packages-dev"`
+}
+
+// platformRequirements are satisfied by the runtime itself, never by a locked
+// package, so they are excluded from the lock consistency check.
+var composerPlatformRequirement = regexp.MustCompile(`^(php(-64bit)?|hhvm|ext-[a-z0-9_-]+|lib-[a-z0-9_-]+|composer-(plugin|runtime)-api)$`)
+
+var composerPHPVersionToken = regexp.MustCompile(`(\d+)\.\d+`)
+
+func (composerIntegrityAnalyzer) Analyze(request IntegrityRequest) ([]LintFinding, error) {
+	root := strings.TrimSpace(request.TargetPath)
+	if root == "" {
+		root = request.ProjectRoot
+	}
+	if root == "" {
+		return nil, nil
+	}
+
+	manifestPath := filepath.Join(root, "composer.json")
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // not a Composer project: nothing to check
+		}
+		return nil, fmt.Errorf("read composer.json: %w", err)
+	}
+
+	var manifest composerManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return []LintFinding{integrityFinding("COMPOSER_JSON_INVALID", "composer.json",
+			fmt.Sprintf("composer.json is not valid JSON: %v", err))}, nil
+	}
+
+	findings := []LintFinding{}
+
+	lockPath := filepath.Join(root, "composer.lock")
+	lockRaw, lockErr := os.ReadFile(lockPath)
+	if lockErr != nil {
+		if os.IsNotExist(lockErr) {
+			findings = append(findings, integrityFinding("COMPOSER_LOCK_MISSING", "composer.lock",
+				"composer.json is present but composer.lock is missing; dependencies are not pinned"))
+			return findings, nil
+		}
+		return nil, fmt.Errorf("read composer.lock: %w", lockErr)
+	}
+
+	var lock composerLockFile
+	if err := json.Unmarshal(lockRaw, &lock); err != nil {
+		findings = append(findings, integrityFinding("COMPOSER_LOCK_INVALID", "composer.lock",
+			fmt.Sprintf("composer.lock is not valid JSON: %v", err)))
+		return findings, nil
+	}
+
+	locked := map[string]string{}
+	duplicates := map[string]bool{}
+	for _, pkg := range append(append([]composerLockedPackage{}, lock.Packages...), lock.PackagesDev...) {
+		name := strings.TrimSpace(strings.ToLower(pkg.Name))
+		if name == "" {
+			continue
+		}
+		if _, seen := locked[name]; seen {
+			duplicates[name] = true
+			continue
+		}
+		locked[name] = pkg.Version
+	}
+	for _, name := range sortedKeys(duplicates) {
+		findings = append(findings, integrityFinding("COMPOSER_DUPLICATE_PACKAGE", "composer.lock",
+			fmt.Sprintf("package %q is locked more than once", name)))
+	}
+
+	for _, requirement := range append(requiredNames(manifest.Require), requiredNames(manifest.RequireDev)...) {
+		if composerPlatformRequirement.MatchString(requirement) {
+			continue
+		}
+		if _, ok := locked[strings.ToLower(requirement)]; !ok {
+			findings = append(findings, integrityFinding("COMPOSER_REQUIREMENT_NOT_LOCKED", "composer.lock",
+				fmt.Sprintf("%q is required in composer.json but absent from composer.lock", requirement)))
+		}
+	}
+
+	if finding, ok := composerPHPConstraintFinding(manifest.Require["php"], request.StackPHPVersion); ok {
+		findings = append(findings, finding)
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Rule != findings[j].Rule {
+			return findings[i].Rule < findings[j].Rule
+		}
+		return findings[i].Message < findings[j].Message
+	})
+	return findings, nil
+}
+
+// composerPHPConstraintFinding compares the manifest's PHP constraint against the
+// configured stack runtime at major-version granularity. That level is
+// deliberately conservative: composer constraint semantics (^, ~, ranges) cannot
+// be reproduced exactly without the PHP implementation, and a false positive
+// here would be worse than a missed warning.
+func composerPHPConstraintFinding(constraint string, stackPHP string) (LintFinding, bool) {
+	constraint = strings.TrimSpace(constraint)
+	stackPHP = strings.TrimSpace(stackPHP)
+	if constraint == "" || stackPHP == "" {
+		return LintFinding{}, false
+	}
+	stackMajor := majorVersion(stackPHP)
+	if stackMajor < 0 {
+		return LintFinding{}, false
+	}
+	majors := map[int]bool{}
+	for _, match := range composerPHPVersionToken.FindAllStringSubmatch(constraint, -1) {
+		if major, err := strconv.Atoi(match[1]); err == nil {
+			majors[major] = true
+		}
+	}
+	if len(majors) == 0 || majors[stackMajor] {
+		return LintFinding{}, false
+	}
+	allowed := make([]string, 0, len(majors))
+	for major := range majors {
+		allowed = append(allowed, strconv.Itoa(major))
+	}
+	sort.Strings(allowed)
+	return integrityFinding("COMPOSER_PHP_CONSTRAINT_MISMATCH", "composer.json",
+		fmt.Sprintf("composer.json requires PHP %s but the project stack runs PHP %s",
+			strings.Join(allowed, "/"), stackPHP)), true
+}
+
+func majorVersion(version string) int {
+	match := composerPHPVersionToken.FindStringSubmatch(version)
+	if match == nil {
+		return -1
+	}
+	major, err := strconv.Atoi(match[1])
+	if err != nil {
+		return -1
+	}
+	return major
+}
+
+func requiredNames(requirements map[string]string) []string {
+	names := make([]string, 0, len(requirements))
+	for name := range requirements {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func integrityFinding(rule string, path string, message string) LintFinding {
+	return LintFinding{Tool: integrityToolName, Rule: rule, Path: path, Message: message}
+}

--- a/internal/audit/integrity_job.go
+++ b/internal/audit/integrity_job.go
@@ -1,0 +1,152 @@
+package audit
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"govard/internal/frameworks/types"
+)
+
+// IntegrityReport is the persisted evidence of one container-free analysis run.
+// Findings reuse LintFinding so downstream consumers need no second parser.
+type IntegrityReport struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Provider      string                `json:"provider"`
+	Analyzers     []string              `json:"analyzers"`
+	TargetMode    types.AuditTargetMode `json:"target_mode"`
+	TargetPath    string                `json:"target_path"`
+	Status        string                `json:"status"`
+	Findings      []LintFinding         `json:"findings"`
+}
+
+// integrityReportSchemaVersion versions the persisted report.
+const integrityReportSchemaVersion = 1
+
+// integrityReportFilename is the artifact name inside the run directory.
+const integrityReportFilename = "integrity.json"
+
+// savedIntegritySettings are persisted with the job so a rerun can rebuild the
+// same analysis without the caller repeating the framework profile.
+type savedIntegritySettings struct {
+	Profile         types.AuditIntegrityProfile `json:"profile"`
+	StackPHPVersion string                      `json:"stack_php_version,omitempty"`
+	Target          types.AuditTarget           `json:"target"`
+}
+
+type integrityFailureError struct{}
+
+func (integrityFailureError) Error() string { return "integrity analysis reported findings" }
+
+// integrityJob builds the container-free analysis job. It never touches a
+// container runtime or a PHP toolchain: analyzers read the checked-out source
+// and the resolved project config only.
+func (runner *Runner) integrityJob(request RunRequest, manifest SessionManifest, runID string) (Job, error) {
+	analyzers, err := IntegrityAnalyzers(request.IntegrityProfile.Analyzers)
+	if err != nil {
+		return Job{}, err
+	}
+	if len(analyzers) == 0 {
+		return Job{}, fmt.Errorf("integrity check requires at least one analyzer in the framework profile")
+	}
+
+	targetPath := strings.TrimSpace(request.Target.TargetPath)
+	if targetPath == "" {
+		targetPath = request.ProjectRoot
+	}
+	framework := request.Environment.Framework
+	stackPHP := request.StackPHPVersion
+	projectRoot := request.ProjectRoot
+
+	run := func(ctx context.Context) (map[string]any, error) {
+		if ctx != nil && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		analyzerIDs := make([]string, 0, len(analyzers))
+		findings := []LintFinding{}
+		for _, analyzer := range analyzers {
+			analyzerIDs = append(analyzerIDs, analyzer.ID())
+			analyzerFindings, analyzeErr := analyzer.Analyze(IntegrityRequest{
+				ProjectRoot:     projectRoot,
+				TargetPath:      targetPath,
+				Framework:       framework,
+				StackPHPVersion: stackPHP,
+			})
+			if analyzeErr != nil {
+				return nil, fmt.Errorf("integrity analyzer %s: %w", analyzer.ID(), analyzeErr)
+			}
+			findings = append(findings, analyzerFindings...)
+		}
+
+		status := "passed"
+		if len(findings) > 0 {
+			status = "failed"
+		}
+		report := IntegrityReport{
+			SchemaVersion: integrityReportSchemaVersion,
+			Provider:      integrityToolName,
+			Analyzers:     analyzerIDs,
+			TargetMode:    request.Target.Mode,
+			TargetPath:    targetPath,
+			Status:        status,
+			Findings:      findings,
+		}
+
+		artifactPath, pathErr := runner.store.RunArtifactPath(manifest.ProjectID, manifest.SessionID, runID, integrityReportFilename)
+		if pathErr != nil {
+			return nil, fmt.Errorf("resolve integrity artifact path: %w", pathErr)
+		}
+		payload, marshalErr := json.MarshalIndent(report, "", "  ")
+		if marshalErr != nil {
+			return nil, fmt.Errorf("marshal integrity report: %w", marshalErr)
+		}
+		payload = append(payload, '\n')
+		if writeErr := os.WriteFile(artifactPath, payload, 0o600); writeErr != nil {
+			return nil, fmt.Errorf("write integrity report: %w", writeErr)
+		}
+		sum := sha256.Sum256(payload)
+
+		evidence := map[string]any{
+			"analyzers": analyzerIDs,
+			"integrity_settings": savedIntegritySettings{
+				Profile:         request.IntegrityProfile,
+				StackPHPVersion: request.StackPHPVersion,
+				Target:          request.Target,
+			},
+			"findings": findings,
+			"status":   status,
+			"artifact": Artifact{
+				Kind:   "integrity-report",
+				Path:   artifactPath,
+				SHA256: hex.EncodeToString(sum[:]),
+			},
+		}
+		if len(findings) > 0 {
+			return evidence, integrityFailureError{}
+		}
+		return evidence, nil
+	}
+
+	return Job{
+		ID:        IntegrityCheck,
+		Kind:      "host-analysis",
+		Resources: Resources{CPU: 1, MemoryMB: 256},
+		Run:       run,
+	}, nil
+}
+
+func integrityArtifacts(jobs []JobResult) []Artifact {
+	for _, job := range jobs {
+		if job.ID != IntegrityCheck {
+			continue
+		}
+		if artifact, ok := job.Evidence["artifact"].(Artifact); ok {
+			return []Artifact{artifact}
+		}
+	}
+	return nil
+}

--- a/internal/audit/integrity_magento.go
+++ b/internal/audit/integrity_magento.go
@@ -1,0 +1,243 @@
+package audit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// magentoModuleDIAnalyzer checks Magento module registration and dependency
+// injection wiring. It parses XML and PHP registration files directly, so it
+// runs without PHP, Composer, or a container.
+type magentoModuleDIAnalyzer struct{}
+
+func init() { RegisterIntegrityAnalyzer(magentoModuleDIAnalyzer{}) }
+
+func (magentoModuleDIAnalyzer) ID() string { return "magento-module-di" }
+
+// Directories that never carry first-party module sources.
+var magentoScanSkipDirs = map[string]bool{
+	"vendor": true, "generated": true, "var": true, "node_modules": true,
+	".git": true, "pub": true, "setup": true,
+}
+
+var magentoRegistrationComponent = regexp.MustCompile(`(?i)ComponentRegistrar::MODULE\s*,\s*['"]([A-Za-z0-9_]+)['"]`)
+
+// magentoModuleXML mirrors etc/module.xml: the document root is <config> and the
+// module identity lives on the <module> child.
+type magentoModuleXML struct {
+	XMLName xml.Name `xml:"config"`
+	Module  struct {
+		Name     string `xml:"name,attr"`
+		Sequence []struct {
+			Name string `xml:"name,attr"`
+		} `xml:"sequence>module"`
+	} `xml:"module"`
+}
+
+type magentoConfigXML struct {
+	XMLName     xml.Name `xml:"config"`
+	Preferences []struct {
+		For string `xml:"for,attr"`
+	} `xml:"preference"`
+	Types []struct {
+		Name string `xml:"name,attr"`
+	} `xml:"type"`
+	VirtualTypes []struct {
+		Name string `xml:"name,attr"`
+	} `xml:"virtualType"`
+}
+
+type magentoModuleFile struct {
+	moduleXMLPath string
+	registration  string
+	name          string
+	sequence      []string
+}
+
+func (magentoModuleDIAnalyzer) Analyze(request IntegrityRequest) ([]LintFinding, error) {
+	root := strings.TrimSpace(request.TargetPath)
+	if root == "" {
+		root = request.ProjectRoot
+	}
+	if root == "" {
+		return nil, nil
+	}
+	info, err := os.Stat(root)
+	if err != nil || !info.IsDir() {
+		return nil, nil
+	}
+
+	findings := []LintFinding{}
+	modules := []magentoModuleFile{}
+	diFiles := []string{}
+
+	walkErr := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable subtrees are reported by the walk root, not here
+		}
+		if entry.IsDir() {
+			if path != root && magentoScanSkipDirs[entry.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		base := strings.ToLower(entry.Name())
+		if base != "module.xml" && base != "di.xml" && base != "webapi.xml" && base != "routes.xml" {
+			return nil
+		}
+		if strings.ToLower(filepath.Base(filepath.Dir(path))) != "etc" {
+			return nil
+		}
+		switch base {
+		case "module.xml":
+			modules = append(modules, magentoModuleFile{moduleXMLPath: path})
+		case "di.xml":
+			diFiles = append(diFiles, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("scan Magento modules: %w", walkErr)
+	}
+	if len(modules) == 0 && len(diFiles) == 0 {
+		return nil, nil // not a Magento module tree
+	}
+
+	sort.Slice(modules, func(i, j int) bool { return modules[i].moduleXMLPath < modules[j].moduleXMLPath })
+	sort.Strings(diFiles)
+
+	for index := range modules {
+		module := &modules[index]
+		raw, readErr := os.ReadFile(module.moduleXMLPath)
+		relative := relativeTo(root, module.moduleXMLPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s: %w", relative, readErr)
+		}
+		var parsed magentoModuleXML
+		if err := xml.Unmarshal(raw, &parsed); err != nil {
+			findings = append(findings, integrityFinding("MAGENTO_XML_INVALID", relative,
+				fmt.Sprintf("%s is not valid XML: %v", filepath.Base(module.moduleXMLPath), err)))
+			continue
+		}
+		module.name = strings.TrimSpace(parsed.Module.Name)
+		for _, entry := range parsed.Module.Sequence {
+			if name := strings.TrimSpace(entry.Name); name != "" {
+				module.sequence = append(module.sequence, name)
+			}
+		}
+		module.registration = readRegistrationComponent(filepath.Join(filepath.Dir(filepath.Dir(module.moduleXMLPath)), "registration.php"))
+	}
+
+	for _, module := range modules {
+		relative := relativeTo(root, module.moduleXMLPath)
+		if module.registration != "" && module.name != "" && module.registration != module.name {
+			findings = append(findings, integrityFinding("MAGENTO_MODULE_NAME_MISMATCH", relative,
+				fmt.Sprintf("registration.php registers %q but module.xml declares %q", module.registration, module.name)))
+		}
+	}
+
+	known := map[string]bool{}
+	for _, module := range modules {
+		if module.name != "" {
+			known[module.name] = true
+		}
+	}
+	for _, module := range modules {
+		for _, dependency := range module.sequence {
+			if known[dependency] {
+				continue
+			}
+			findings = append(findings, integrityFinding("MAGENTO_SEQUENCE_UNKNOWN_MODULE", relativeTo(root, module.moduleXMLPath),
+				fmt.Sprintf("%s depends on module %q, which is not present in this tree", module.name, dependency)))
+		}
+	}
+
+	for _, path := range diFiles {
+		relative := relativeTo(root, path)
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s: %w", relative, readErr)
+		}
+		var parsed magentoConfigXML
+		if err := xml.Unmarshal(raw, &parsed); err != nil {
+			findings = append(findings, integrityFinding("MAGENTO_XML_INVALID", relative,
+				fmt.Sprintf("%s is not valid XML: %v", filepath.Base(path), err)))
+			continue
+		}
+		findings = append(findings, duplicateDITargets(relative, parsed)...)
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Rule != findings[j].Rule {
+			return findings[i].Rule < findings[j].Rule
+		}
+		if findings[i].Path != findings[j].Path {
+			return findings[i].Path < findings[j].Path
+		}
+		return findings[i].Message < findings[j].Message
+	})
+	return findings, nil
+}
+
+func duplicateDITargets(relative string, config magentoConfigXML) []LintFinding {
+	findings := []LintFinding{}
+	preferences := map[string]int{}
+	for _, preference := range config.Preferences {
+		preferences[strings.TrimSpace(preference.For)]++
+	}
+	types := map[string]int{}
+	for _, declared := range config.Types {
+		types[strings.TrimSpace(declared.Name)]++
+	}
+	virtualTypes := map[string]int{}
+	for _, declared := range config.VirtualTypes {
+		virtualTypes[strings.TrimSpace(declared.Name)]++
+	}
+	duplicated := make([]string, 0, len(preferences))
+	for target, count := range preferences {
+		if target != "" && count > 1 {
+			duplicated = append(duplicated, fmt.Sprintf("preference for %q is declared %d times", target, count))
+		}
+	}
+	for target, count := range types {
+		if target != "" && count > 1 {
+			duplicated = append(duplicated, fmt.Sprintf("type %q is declared %d times", target, count))
+		}
+	}
+	for target, count := range virtualTypes {
+		if target != "" && count > 1 {
+			duplicated = append(duplicated, fmt.Sprintf("virtualType %q is declared %d times", target, count))
+		}
+	}
+	sort.Strings(duplicated)
+	for _, message := range duplicated {
+		findings = append(findings, integrityFinding("MAGENTO_DI_DUPLICATE_TARGET", relative, message))
+	}
+	return findings
+}
+
+func readRegistrationComponent(path string) string {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	match := magentoRegistrationComponent.FindSubmatch(raw)
+	if match == nil {
+		return ""
+	}
+	return string(match[1])
+}
+
+func relativeTo(root string, path string) string {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(relative)
+}

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -19,15 +19,21 @@ import (
 // RunRequest describes one explicit audit execution. The session manifest
 // captures the immutable project/source/scope inputs before work starts.
 type RunRequest struct {
-	ProjectRoot         string
-	ProjectID           string
-	Scope               Scope
-	BaseRef             string
-	Checks              []string
-	LintJobs            int
-	Environment         EnvironmentFingerprint
-	Source              SourceFingerprint
-	LintProfile         types.AuditLintProfile
+	ProjectRoot string
+	ProjectID   string
+	Scope       Scope
+	BaseRef     string
+	Checks      []string
+	LintJobs    int
+	Environment EnvironmentFingerprint
+	Source      SourceFingerprint
+	LintProfile types.AuditLintProfile
+	// IntegrityProfile declares the container-free analyzers to run when the
+	// integrity check is selected. It is ignored when the check is not requested.
+	IntegrityProfile types.AuditIntegrityProfile
+	// StackPHPVersion is the configured runtime PHP version, used by analyzers
+	// that cross-check the manifest against the project config.
+	StackPHPVersion     string
 	Target              types.AuditTarget
 	ProfilerURL         string
 	SelectedPHPVersions []string
@@ -155,6 +161,16 @@ func (runner *Runner) Rerun(ctx context.Context, sessionID, projectID string, ch
 		}
 		target = savedLintTarget(settings.Target, manifest)
 	}
+	integritySettings := savedIntegritySettings{}
+	if includesCheck(checks, IntegrityCheck) {
+		integritySettings, err = runner.latestIntegritySettings(projectID, sessionID, manifest.Runs)
+		if err != nil {
+			return RunResult{}, err
+		}
+		if target == (types.AuditTarget{}) {
+			target = savedLintTarget(integritySettings.Target, manifest)
+		}
+	}
 	if includesCheck(checks, "profiler") {
 		profilerSettings, err := runner.latestProfilerSettings(projectID, sessionID, manifest.Runs)
 		if err != nil {
@@ -175,6 +191,8 @@ func (runner *Runner) Rerun(ctx context.Context, sessionID, projectID string, ch
 		Environment:         manifest.Environment,
 		Source:              manifest.Source,
 		LintProfile:         settings.Profile,
+		IntegrityProfile:    integritySettings.Profile,
+		StackPHPVersion:     integritySettings.StackPHPVersion,
 		Target:              target,
 		ProfilerURL:         requestURL,
 		SelectedPHPVersions: settings.SelectedPHPVersions,
@@ -210,7 +228,7 @@ func (runner *Runner) latestRunChecks(projectID, sessionID string, runs []RunRef
 		}
 		checks := make([]string, 0, 2)
 		for _, job := range result.Jobs {
-			if job.ID == "lint" || job.ID == "profiler" {
+			if job.ID == "lint" || job.ID == "profiler" || job.ID == IntegrityCheck {
 				checks = append(checks, job.ID)
 			}
 		}
@@ -278,6 +296,7 @@ func (runner *Runner) runInSession(ctx context.Context, manifest SessionManifest
 		jobsResult, scheduleErr := NewScheduler(runner.resources).Run(ctx, jobs)
 		result.Jobs = jobsResult
 		result.Artifacts = append(result.Artifacts, profilerArtifacts(jobsResult)...)
+		result.Artifacts = append(result.Artifacts, integrityArtifacts(jobsResult)...)
 		err = scheduleErr
 		if err == nil {
 			err = infrastructureError(jobsResult)
@@ -311,6 +330,12 @@ func (runner *Runner) jobsFor(request RunRequest, manifest SessionManifest, runI
 				return nil, err
 			}
 			jobs = append(jobs, lintJob)
+		case IntegrityCheck:
+			integrityJob, err := runner.integrityJob(request, manifest, runID)
+			if err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, integrityJob)
 		case "profiler":
 			if runner.profilerRuntime == nil {
 				return nil, errors.New("audit runner profiler runtime is not configured")
@@ -551,7 +576,7 @@ func NormalizeChecks(checks []string) ([]string, error) {
 	normalized := make([]string, 0, len(checks))
 	for _, check := range checks {
 		check = strings.TrimSpace(check)
-		if check != "lint" && check != "profiler" {
+		if check != "lint" && check != "profiler" && check != IntegrityCheck {
 			return nil, fmt.Errorf("audit check %q is not implemented", check)
 		}
 		if !seen[check] {
@@ -597,8 +622,9 @@ type savedProfilerSettings struct {
 }
 
 var (
-	errNoPersistedLintSettings     = errors.New("audit session has no persisted lint settings")
-	errNoPersistedProfilerSettings = errors.New("audit session has no persisted profiler settings")
+	errNoPersistedIntegritySettings = errors.New("audit session has no persisted integrity settings")
+	errNoPersistedLintSettings      = errors.New("audit session has no persisted lint settings")
+	errNoPersistedProfilerSettings  = errors.New("audit session has no persisted profiler settings")
 )
 
 type legacySavedLintSettings struct {
@@ -724,4 +750,40 @@ func (runner *Runner) latestProfilerSettings(projectID, sessionID string, runs [
 		return settings, err
 	}
 	return savedProfilerSettings{}, errNoPersistedProfilerSettings
+}
+
+func persistedIntegritySettings(result RunResult) (savedIntegritySettings, error) {
+	for _, job := range result.Jobs {
+		if job.ID != IntegrityCheck {
+			continue
+		}
+		value, ok := job.Evidence["integrity_settings"]
+		if !ok {
+			continue
+		}
+		raw, marshalErr := json.Marshal(value)
+		if marshalErr != nil {
+			return savedIntegritySettings{}, marshalErr
+		}
+		var settings savedIntegritySettings
+		if unmarshalErr := json.Unmarshal(raw, &settings); unmarshalErr != nil {
+			return savedIntegritySettings{}, fmt.Errorf("decode saved integrity settings: %w", unmarshalErr)
+		}
+		return settings, nil
+	}
+	return savedIntegritySettings{}, errNoPersistedIntegritySettings
+}
+
+func (runner *Runner) latestIntegritySettings(projectID, sessionID string, runs []RunReference) (savedIntegritySettings, error) {
+	for index := len(runs) - 1; index >= 0; index-- {
+		result, err := runner.store.ReadResult(projectID, sessionID, runs[index].RunID)
+		if err != nil {
+			return savedIntegritySettings{}, err
+		}
+		settings, settingsErr := persistedIntegritySettings(result)
+		if settingsErr == nil {
+			return settings, nil
+		}
+	}
+	return savedIntegritySettings{}, errNoPersistedIntegritySettings
 }

--- a/internal/cli/envelope.go
+++ b/internal/cli/envelope.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// EnvelopeSchemaVersion versions the machine-readable error envelope; it must
+// never change without a documented migration.
+const EnvelopeSchemaVersion = 1
+
+const (
+	CodeCapabilityMissingName = "CAPABILITY_MISSING"
+	CodeUsageName             = "USAGE"
+	CodeConfigName            = "CONFIG"
+	CodeErrorName             = "ERROR"
+)
+
+// capabilityError is implemented by errors that carry a missing-capability
+// payload (see runtime.MissingError).
+type capabilityError interface {
+	MissingCapability() string
+	MissingCapabilityHint() string
+}
+
+type EnvelopeError struct {
+	Code       string `json:"code"`
+	Capability string `json:"capability,omitempty"`
+	Command    string `json:"command,omitempty"`
+	Message    string `json:"message"`
+	Hint       string `json:"hint,omitempty"`
+}
+
+type ErrorEnvelope struct {
+	SchemaVersion int           `json:"schema_version"`
+	OK            bool          `json:"ok"`
+	Error         EnvelopeError `json:"error"`
+}
+
+// NewErrorEnvelope classifies err by type, never by message text.
+func NewErrorEnvelope(command string, err error) ErrorEnvelope {
+	entry := EnvelopeError{Code: CodeErrorName, Command: command, Message: err.Error()}
+	var capability capabilityError
+	var usage *UsageError
+	var coded interface{ ExitCode() int }
+	switch {
+	case errors.As(err, &capability):
+		entry.Code = CodeCapabilityMissingName
+		entry.Capability = capability.MissingCapability()
+		entry.Hint = capability.MissingCapabilityHint()
+	case errors.As(err, &usage):
+		entry.Code = CodeUsageName
+	case errors.As(err, &coded) && coded.ExitCode() == CodeConfig:
+		entry.Code = CodeConfigName
+	}
+	return ErrorEnvelope{SchemaVersion: EnvelopeSchemaVersion, OK: false, Error: entry}
+}
+
+func (e ErrorEnvelope) JSON() ([]byte, error) { return json.MarshalIndent(e, "", "  ") }

--- a/internal/cli/envelope_test.go
+++ b/internal/cli/envelope_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// fakeCapabilityError stands in for runtime.MissingError so this package stays
+// dependency-free.
+type fakeCapabilityError struct{}
+
+func (fakeCapabilityError) Error() string                 { return `missing capability "docker"` }
+func (fakeCapabilityError) MissingCapability() string     { return "docker" }
+func (fakeCapabilityError) MissingCapabilityHint() string { return "start Docker" }
+
+func TestErrorEnvelopeForMissingCapability(t *testing.T) {
+	err := fmt.Errorf("cannot run %q: %w", "govard env up", fakeCapabilityError{})
+	env := NewErrorEnvelope("govard env up", err)
+	if env.SchemaVersion != EnvelopeSchemaVersion || env.OK {
+		t.Fatalf("envelope = %#v", env)
+	}
+	if env.Error.Code != CodeCapabilityMissingName {
+		t.Fatalf("code = %q, want %q", env.Error.Code, CodeCapabilityMissingName)
+	}
+	if env.Error.Capability != "docker" || env.Error.Hint != "start Docker" {
+		t.Fatalf("envelope error = %#v", env.Error)
+	}
+	raw, marshalErr := env.JSON()
+	if marshalErr != nil {
+		t.Fatalf("JSON() error = %v", marshalErr)
+	}
+	var round map[string]any
+	if unmarshalErr := json.Unmarshal(raw, &round); unmarshalErr != nil {
+		t.Fatalf("round trip error = %v", unmarshalErr)
+	}
+	if round["schema_version"] != float64(1) {
+		t.Fatalf("schema_version = %v, want 1", round["schema_version"])
+	}
+}
+
+func TestErrorEnvelopeForUsageError(t *testing.T) {
+	env := NewErrorEnvelope("govard up", &UsageError{Err: errors.New("unknown flag: --nope")})
+	if env.Error.Code != CodeUsageName {
+		t.Fatalf("code = %q, want %q", env.Error.Code, CodeUsageName)
+	}
+}
+
+func TestErrorEnvelopeForPlainError(t *testing.T) {
+	env := NewErrorEnvelope("govard status", errors.New("boom"))
+	if env.Error.Code != CodeErrorName {
+		t.Fatalf("code = %q, want %q", env.Error.Code, CodeErrorName)
+	}
+}

--- a/internal/cli/exit.go
+++ b/internal/cli/exit.go
@@ -1,0 +1,33 @@
+// Package cli owns process exit codes so an error's shape and the process
+// status can never diverge.
+package cli
+
+import "errors"
+
+const (
+	CodeOK         = 0
+	CodeError      = 1
+	CodeUsage      = 2
+	CodeCapability = 3
+	CodeConfig     = 4
+)
+
+// UsageError marks a flag or argument error.
+type UsageError struct{ Err error }
+
+func (e *UsageError) Error() string { return e.Err.Error() }
+func (e *UsageError) Unwrap() error { return e.Err }
+func (e *UsageError) ExitCode() int { return CodeUsage }
+
+// Code maps an error to its process exit code. Errors carrying an ExitCode
+// method win; anything else is a plain execution error.
+func Code(err error) int {
+	if err == nil {
+		return CodeOK
+	}
+	var coded interface{ ExitCode() int }
+	if errors.As(err, &coded) {
+		return coded.ExitCode()
+	}
+	return CodeError
+}

--- a/internal/cli/exit_test.go
+++ b/internal/cli/exit_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type coded struct{ code int }
+
+func (c coded) Error() string { return "coded" }
+func (c coded) ExitCode() int { return c.code }
+
+func TestCodeDefaultsToExecutionError(t *testing.T) {
+	if got := Code(errors.New("boom")); got != CodeError {
+		t.Fatalf("Code = %d, want %d", got, CodeError)
+	}
+}
+
+func TestCodeIsZeroForNil(t *testing.T) {
+	if got := Code(nil); got != CodeOK {
+		t.Fatalf("Code(nil) = %d, want %d", got, CodeOK)
+	}
+}
+
+func TestCodeReadsWrappedExitCode(t *testing.T) {
+	err := fmt.Errorf("cannot run %q: %w", "env up", coded{code: 3})
+	if got := Code(err); got != 3 {
+		t.Fatalf("Code = %d, want 3", got)
+	}
+}
+
+func TestUsageErrorReportsTwo(t *testing.T) {
+	if got := Code(&UsageError{Err: errors.New("unknown flag")}); got != CodeUsage {
+		t.Fatalf("Code = %d, want %d", got, CodeUsage)
+	}
+}

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -81,6 +81,9 @@ type auditPreparation struct {
 	LintBackendRequired     bool
 	ProfilerRuntimeRequired bool
 	RequireProfilerURL      bool
+	// ContainerRuntimeRequired reports whether the selected checks execute in a
+	// container, which is what a Docker-free host cannot satisfy.
+	ContainerRuntimeRequired bool
 }
 
 type auditCommandDependencies struct {
@@ -186,7 +189,9 @@ func newAuditCommand(dependencies auditCommandDependencies) *cobra.Command {
 	options := &auditCommandOptions{Scope: string(audit.ScopeProject), Checks: []string{"lint"}, Format: "text", LintProvider: audit.GovardLintProvider, LintJobs: engine.AuditRunJobs(), Timeout: "auto"}
 	command := &cobra.Command{
 		Annotations: map[string]string{
-			runtime.AnnotationRequires: string(runtime.CapDocker),
+			// The integrity check runs on a Docker-free host; container-backed
+			// checks are gated by the check selection instead.
+			runtime.AnnotationRequires: string(runtime.CapNone),
 		},
 		Use:   "audit",
 		Short: "Run and inspect persistent project audits",
@@ -244,10 +249,11 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 		lintRequested := auditChecksInclude(options.Checks, "lint")
 		profilerRequested := auditChecksInclude(options.Checks, "profiler")
 		runner, resolvedTarget, err := prepareAudit(cmd, options, dependencies, auditPreparation{
-			ResolvePHPPolicy:        lintRequested,
-			LintBackendRequired:     lintRequested,
-			ProfilerRuntimeRequired: profilerRequested,
-			RequireProfilerURL:      profilerRequested,
+			ResolvePHPPolicy:         lintRequested,
+			LintBackendRequired:      lintRequested,
+			ProfilerRuntimeRequired:  profilerRequested,
+			RequireProfilerURL:       profilerRequested,
+			ContainerRuntimeRequired: lintRequested || profilerRequested,
 		})
 		if err != nil {
 			return err
@@ -304,6 +310,8 @@ func newAuditRunCommand(options *auditCommandOptions, dependencies auditCommandD
 			Environment:         auditTargetEnvironment(resolvedTarget),
 			Source:              resolvedTarget.Source,
 			LintProfile:         lintProfile,
+			IntegrityProfile:    auditIntegrityProfile(resolvedTarget.Definition),
+			StackPHPVersion:     auditStackPHPVersion(resolvedTarget.Config),
 			Target:              resolvedTarget.Target,
 			ProfilerURL:         options.URL,
 			SelectedPHPVersions: resolvedTarget.PHPVersions,
@@ -360,8 +368,9 @@ func newAuditRerunCommand(options *auditCommandOptions, dependencies auditComman
 		lintRequested := auditChecksInclude(effectiveChecks, "lint")
 		profilerRequested := auditChecksInclude(effectiveChecks, "profiler")
 		runner, resolvedTarget, err := prepareAudit(cmd, options, dependencies, auditPreparation{
-			LintBackendRequired:     lintRequested,
-			ProfilerRuntimeRequired: profilerRequested,
+			LintBackendRequired:      lintRequested,
+			ProfilerRuntimeRequired:  profilerRequested,
+			ContainerRuntimeRequired: lintRequested || profilerRequested,
 		})
 		if err != nil {
 			return err
@@ -476,6 +485,15 @@ func prepareAudit(cmd *cobra.Command, options *auditCommandOptions, dependencies
 		mode = types.AuditTargetAuto
 	}
 	resolved := currentAuditDependencies(dependencies)
+	// Container-backed checks need a container runtime. This is evaluated before
+	// target resolution because resolving the PHP policy probes the application
+	// container, and a raw probe failure would bypass the capability contract.
+	// The container-free integrity check never reaches this path.
+	if preparation.ContainerRuntimeRequired {
+		if err := requireContainerRuntime(); err != nil {
+			return nil, resolvedAuditTarget{}, err
+		}
+	}
 	target, err := resolveAuditTarget(cmd.Context(), commandStartDirectory(), mode, options.PHPVersions, resolved.runtimePHPProbe, preparation.ResolvePHPPolicy)
 	if err != nil {
 		return nil, resolvedAuditTarget{}, err
@@ -544,6 +562,11 @@ func auditScope(value string, forceDiff, scopeExplicit bool) (audit.Scope, error
 func validateAuditOptions(options *auditCommandOptions, definition types.FrameworkDefinition) error {
 	if err := validateAuditCommandOptions(options); err != nil {
 		return err
+	}
+	if auditChecksInclude(options.Checks, audit.IntegrityCheck) {
+		if definition.AuditIntegrity == nil {
+			return fmt.Errorf("framework %q does not support integrity audit", definition.Name)
+		}
 	}
 	if auditChecksInclude(options.Checks, "lint") {
 		if definition.AuditLint == nil {
@@ -878,3 +901,47 @@ type auditRunExitError struct {
 
 func (e auditRunExitError) Error() string { return e.cause.Error() }
 func (e auditRunExitError) Unwrap() error { return e.cause }
+
+// requireContainerRuntime fails fast when a container-backed check was selected
+// on a host with no container runtime, pointing at the container-free
+// alternative instead of letting the run die mid-flight.
+func requireContainerRuntime() error {
+	err := runtime.Probe(runtime.CapDocker)
+	if err == nil {
+		return nil
+	}
+	var missing *runtime.MissingError
+	detail := err.Error()
+	if errors.As(err, &missing) {
+		detail = missing.Detail
+	}
+	hint := "run `govard audit run --checks integrity` for container-free analysis on this host"
+	// In machine mode the hint travels inside the JSON envelope, so stdout stays
+	// parseable.
+	if !errorJSON {
+		pterm.Info.Printf("Hint: %s\n", hint)
+	}
+	return &runtime.MissingError{
+		Caps:   []runtime.Capability{runtime.CapDocker},
+		Detail: detail,
+		Hint:   hint,
+	}
+}
+
+// auditIntegrityProfile returns the framework's container-free analyzer set, or
+// an empty profile when the framework declares none.
+func auditIntegrityProfile(definition types.FrameworkDefinition) types.AuditIntegrityProfile {
+	if definition.AuditIntegrity == nil {
+		return types.AuditIntegrityProfile{}
+	}
+	return *definition.AuditIntegrity
+}
+
+// auditStackPHPVersion reads the configured runtime PHP version, which analyzers
+// cross-check against the project manifest.
+func auditStackPHPVersion(config *engine.Config) string {
+	if config == nil {
+		return ""
+	}
+	return config.Stack.PHPVersion
+}

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 type auditCommandOptions struct {
@@ -184,6 +185,9 @@ func currentAuditDependencies(defaults auditCommandDependencies) auditCommandDep
 func newAuditCommand(dependencies auditCommandDependencies) *cobra.Command {
 	options := &auditCommandOptions{Scope: string(audit.ScopeProject), Checks: []string{"lint"}, Format: "text", LintProvider: audit.GovardLintProvider, LintJobs: engine.AuditRunJobs(), Timeout: "auto"}
 	command := &cobra.Command{
+		Annotations: map[string]string{
+			runtime.AnnotationRequires: string(runtime.CapDocker),
+		},
 		Use:   "audit",
 		Short: "Run and inspect persistent project audits",
 	}

--- a/internal/cmd/audit_runtime_gate_test.go
+++ b/internal/cmd/audit_runtime_gate_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"govard/internal/runtime"
+)
+
+func stubMissingDocker(t *testing.T) {
+	t.Helper()
+	restore := runtime.StubProbesForTest(
+		func(context.Context) error { return errors.New("cannot connect to the docker daemon") },
+		func(context.Context) error { return nil },
+	)
+	t.Cleanup(restore)
+}
+
+func TestIntegrityOnlySelectionDoesNotRequireContainerRuntime(t *testing.T) {
+	checks := []string{"integrity"}
+	required := auditChecksInclude(checks, "lint") || auditChecksInclude(checks, "profiler")
+	if required {
+		t.Fatal("an integrity-only selection must not require a container runtime")
+	}
+}
+
+func TestLintSelectionRequiresContainerRuntime(t *testing.T) {
+	checks := []string{"lint"}
+	required := auditChecksInclude(checks, "lint") || auditChecksInclude(checks, "profiler")
+	if !required {
+		t.Fatal("a lint selection must require a container runtime")
+	}
+}
+
+func TestRequireContainerRuntimeBlocksWithoutDocker(t *testing.T) {
+	stubMissingDocker(t)
+	err := requireContainerRuntime()
+	var missing *runtime.MissingError
+	if !errors.As(err, &missing) {
+		t.Fatalf("requireContainerRuntime = %v, want *runtime.MissingError", err)
+	}
+	if !strings.Contains(missing.Hint, "--checks integrity") {
+		t.Fatalf("hint must point at the container-free check, got %q", missing.Hint)
+	}
+	if missing.ExitCode() != runtime.CodeCapabilityMissing {
+		t.Fatalf("exit code = %d, want %d", missing.ExitCode(), runtime.CodeCapabilityMissing)
+	}
+}
+
+func TestRequireContainerRuntimeSatisfiedWithDocker(t *testing.T) {
+	restore := runtime.StubProbesForTest(
+		func(context.Context) error { return nil },
+		func(context.Context) error { return nil },
+	)
+	t.Cleanup(restore)
+	// The docker binary itself must resolve for the capability to be satisfied.
+	restoreLookPath := runtime.StubLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil })
+	t.Cleanup(restoreLookPath)
+
+	if err := requireContainerRuntime(); err != nil {
+		t.Fatalf("requireContainerRuntime = %v, want nil", err)
+	}
+}

--- a/internal/cmd/blueprint.go
+++ b/internal/cmd/blueprint.go
@@ -6,9 +6,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var blueprintCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "blueprint",
 	Short: "Manage blueprint components and registry",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/bootstrap.go
+++ b/internal/cmd/bootstrap.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 const (
@@ -55,6 +56,9 @@ var (
 )
 
 var bootstrapCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:     "bootstrap [flags]",
 	Aliases: []string{"boot"},
 	Short:   "Bootstrap local environment: import DB/media from remote, or full clone with --clone",

--- a/internal/cmd/capabilities.go
+++ b/internal/cmd/capabilities.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"govard/internal/runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// CapabilityRow is one command's declared requirement and its status on this
+// host.
+type CapabilityRow struct {
+	Command   string `json:"command"`
+	Requires  string `json:"requires"`
+	Satisfied bool   `json:"satisfied"`
+}
+
+var capabilitiesJSONFlag bool
+
+var capabilitiesCmd = &cobra.Command{
+	Use:   "capabilities",
+	Short: "List every command's runtime requirements and whether this host meets them",
+	Long: `List every runnable command with the runtime capabilities it declares and
+whether this host satisfies them. The requirement-free commands are the
+Docker-free core: they work on a host with no container runtime at all.`,
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rows := capabilityRows()
+		if capabilitiesJSONFlag {
+			raw, err := capabilitiesJSON(rows)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(raw))
+			return nil
+		}
+		fmt.Print(capabilitiesText(rows))
+		return nil
+	},
+}
+
+func init() {
+	capabilitiesCmd.Flags().BoolVar(&capabilitiesJSONFlag, "json", false, "Print machine-readable output")
+}
+
+// walkCommandTree visits a command and every descendant in registration order.
+func walkCommandTree(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommandTree(child, visit)
+	}
+}
+
+// capabilityRows derives the command manifest: the Docker-free core set is
+// whatever resolves to no requirement, never a hand-written list.
+func capabilityRows() []CapabilityRow {
+	rows := []CapabilityRow{}
+	satisfiedByRequirement := map[string]bool{}
+	walkCommandTree(rootCmd, func(cmd *cobra.Command) {
+		if cmd == rootCmd || (cmd.RunE == nil && cmd.Run == nil) {
+			return
+		}
+		capabilities := runtime.Requires(cmd)
+		names := make([]string, 0, len(capabilities))
+		for _, capability := range capabilities {
+			names = append(names, string(capability))
+		}
+		if len(names) == 0 {
+			names = append(names, string(runtime.CapNone))
+		}
+		requires := strings.Join(names, ",")
+		satisfied, probed := satisfiedByRequirement[requires]
+		if !probed {
+			// One probe per distinct requirement set keeps this fast even
+			// though it covers every command.
+			satisfied = runtime.Probe(capabilities...) == nil
+			satisfiedByRequirement[requires] = satisfied
+		}
+		rows = append(rows, CapabilityRow{Command: cmd.CommandPath(), Requires: requires, Satisfied: satisfied})
+	})
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Command < rows[j].Command })
+	return rows
+}
+
+func capabilitiesText(rows []CapabilityRow) string {
+	var builder strings.Builder
+	for _, row := range rows {
+		status := "ok"
+		if !row.Satisfied {
+			status = "missing"
+		}
+		fmt.Fprintf(&builder, "%s\t%s\t%s\n", row.Command, row.Requires, status)
+	}
+	return builder.String()
+}
+
+func capabilitiesJSON(rows []CapabilityRow) ([]byte, error) {
+	payload := struct {
+		SchemaVersion int             `json:"schema_version"`
+		Commands      []CapabilityRow `json:"commands"`
+	}{SchemaVersion: 1, Commands: rows}
+	return json.MarshalIndent(payload, "", "  ")
+}

--- a/internal/cmd/capabilities_test.go
+++ b/internal/cmd/capabilities_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCapabilitiesTextListsCoreCommands(t *testing.T) {
+	rows := capabilityRows()
+	if len(rows) == 0 {
+		t.Fatal("capabilityRows returned no commands")
+	}
+	found := false
+	for _, row := range rows {
+		if row.Command == "govard version" {
+			found = true
+			if row.Requires != "none" {
+				t.Fatalf("govard version requires %q, want none", row.Requires)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("govard version missing from capability rows")
+	}
+	if !strings.Contains(capabilitiesText(rows), "govard version\tnone\t") {
+		t.Fatalf("text output missing version row:\n%s", capabilitiesText(rows))
+	}
+}
+
+func TestCapabilitiesJSONIsVersioned(t *testing.T) {
+	raw, err := capabilitiesJSON(capabilityRows())
+	if err != nil {
+		t.Fatalf("capabilitiesJSON error = %v", err)
+	}
+	var payload struct {
+		SchemaVersion int `json:"schema_version"`
+		Commands      []struct {
+			Command   string `json:"command"`
+			Requires  string `json:"requires"`
+			Satisfied bool   `json:"satisfied"`
+		} `json:"commands"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal error = %v", err)
+	}
+	if payload.SchemaVersion != 1 || len(payload.Commands) == 0 {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+func TestCapabilitiesCoversEveryRunnableCommand(t *testing.T) {
+	rows := capabilityRows()
+	seen := map[string]bool{}
+	for _, row := range rows {
+		seen[row.Command] = true
+	}
+	missing := []string{}
+	walkCommandTree(rootCmd, func(cmd *cobra.Command) {
+		if cmd == rootCmd || (cmd.RunE == nil && cmd.Run == nil) {
+			return
+		}
+		if !seen[cmd.CommandPath()] {
+			missing = append(missing, cmd.CommandPath())
+		}
+	})
+	if len(missing) > 0 {
+		t.Fatalf("commands missing from capabilities: %v", missing)
+	}
+}
+
+func TestCapabilitiesRowsAreSorted(t *testing.T) {
+	rows := capabilityRows()
+	for i := 1; i < len(rows); i++ {
+		if rows[i-1].Command > rows[i].Command {
+			t.Fatalf("rows not sorted: %q before %q", rows[i-1].Command, rows[i].Command)
+		}
+	}
+}

--- a/internal/cmd/config_manage.go
+++ b/internal/cmd/config_manage.go
@@ -8,9 +8,13 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var configCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:     "config",
 	Aliases: []string{"cfg"},
 	Short:   "Manage .govard.yml configuration from CLI",

--- a/internal/cmd/custom.go
+++ b/internal/cmd/custom.go
@@ -9,9 +9,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var customCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "custom",
 	Short: "Run custom commands from project and global plugin directories",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -24,9 +24,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/term"
+	"govard/internal/runtime"
 )
 
 var dbCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "db [connect|import|dump|query|info|top|clone-volume]",
 	Short: "Interact with the database container",
 	Long: `Manage your project's database. Supports connecting to the container shell,

--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -8,9 +8,13 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"govard/internal/conventions"
+	"govard/internal/runtime"
 )
 
 var debugCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:     "debug [on|off|status|shell] [args...]",
 	Aliases: []string{"dbg"},
 	Short:   "Manage Xdebug for the current environment",

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -13,9 +13,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var deployCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "deploy",
 	Short: "Deploy the application",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/desktop.go
+++ b/internal/cmd/desktop.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"govard/internal/desktop"
+	govardruntime "govard/internal/runtime"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -33,6 +34,9 @@ func desktopBuildTags(isProd bool) string {
 }
 
 var desktopCmd = &cobra.Command{
+	Annotations: map[string]string{
+		govardruntime.AnnotationRequires: string(govardruntime.CapDocker),
+	},
 	Use:     "desktop",
 	Aliases: []string{"gui"},
 	Short:   "Launch the Govard Desktop app",

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -10,12 +10,16 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var doctorCommit bool
 var doctorDryRun bool
 
 var doctorCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:     "doctor",
 	Aliases: []string{"diag"},
 	Short:   "Run system diagnostics",
@@ -135,6 +139,9 @@ func ExecuteDoctor(cmd *cobra.Command, outputJSON bool, fixEnabled bool, packEna
 		}
 	}
 
+	if strict, _ := cmd.Flags().GetBool("strict"); strict && report.Warnings > 0 {
+		return fmt.Errorf("doctor --strict found %d warning(s)", report.Warnings)
+	}
 	if report.HasFailures() {
 		return fmt.Errorf("doctor found %d blocking issue(s)", report.Failures)
 	}
@@ -142,6 +149,9 @@ func ExecuteDoctor(cmd *cobra.Command, outputJSON bool, fixEnabled bool, packEna
 }
 
 var doctorTrustCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "trust",
 	Short: "Trust the local CA for SSL certificates",
 	Args:  cobra.NoArgs,
@@ -193,6 +203,7 @@ func DoctorCommand() *cobra.Command {
 
 func init() {
 	doctorCmd.Flags().Bool("json", false, "Print diagnostics as JSON")
+	doctorCmd.Flags().Bool("strict", false, "Treat optional warnings as failures (stack-ready gate)")
 	doctorCmd.Flags().Bool("fix", false, "Apply safe automatic fixes when available")
 	doctorCmd.Flags().Bool("commit", false, "Commit .govard.yml drift fixes via git (implies --fix)")
 	doctorCmd.Flags().Bool("dry-run", false, "Show what would be fixed without writing files (use with --fix)")

--- a/internal/cmd/domain.go
+++ b/internal/cmd/domain.go
@@ -7,9 +7,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var domainCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "domain",
 	Short: "Manage additional domains for the project",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 type EnvDependenciesForTest struct {
@@ -43,6 +44,9 @@ var envDeps = EnvDependenciesForTest{
 }
 
 var envCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "env [command]",
 	Short: "Control project environment via docker compose",
 	Long: `Manage the lifecycle and services of your project's development environment.

--- a/internal/cmd/extensions.go
+++ b/internal/cmd/extensions.go
@@ -7,11 +7,15 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var extensionForce bool
 
 var extensionsCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:     "extensions",
 	Aliases: []string{"ext"},
 	Short:   "Manage project extension contract in .govard",

--- a/internal/cmd/frameworks.go
+++ b/internal/cmd/frameworks.go
@@ -12,6 +12,7 @@ import (
 	"govard/internal/frameworks"
 
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 type FrameworkCommand struct {
@@ -31,6 +32,9 @@ type commandExecutionTarget struct {
 }
 
 var toolCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "tool [command]",
 	Short: "Run framework/tooling commands inside project containers",
 	Long: `Run framework CLIs and common package manager commands directly inside the project containers.

--- a/internal/cmd/frontend.go
+++ b/internal/cmd/frontend.go
@@ -16,6 +16,7 @@ import (
 	"govard/internal/proxy"
 
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 const frontendReadinessTimeout = 90 * time.Second
@@ -45,6 +46,9 @@ var frontendDeps = FrontendDependenciesForTest{
 }
 
 var frontendCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "frontend",
 	Short: "Control the project-owned frontend development runtime",
 }

--- a/internal/cmd/gate.go
+++ b/internal/cmd/gate.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"govard/internal/runtime"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+// gateError enforces a command's declared runtime requirements before its
+// workflow starts. It returns nil when the command may run.
+func gateError(cmd *cobra.Command) error {
+	if cmd == nil || runtime.AlwaysRunnable(cmd) {
+		return nil
+	}
+	capabilities := runtime.Requires(cmd)
+	if len(capabilities) == 0 {
+		return nil
+	}
+	err := runtime.Probe(capabilities...)
+	if err == nil {
+		return nil
+	}
+	var missing *runtime.MissingError
+	// In machine mode the hint travels inside the JSON envelope, so stdout
+	// stays parseable.
+	if errors.As(err, &missing) && missing.Hint != "" && !errorJSON {
+		pterm.Info.Printf("Hint: %s\n", missing.Hint)
+	}
+	return fmt.Errorf("cannot run %q: %w", cmd.CommandPath(), err)
+}

--- a/internal/cmd/gate_test.go
+++ b/internal/cmd/gate_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"govard/internal/cli"
+	"govard/internal/runtime"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGateSkipsAlwaysRunnableCommands(t *testing.T) {
+	cmd := &cobra.Command{Use: "doctor"}
+	cmd.RunE = func(*cobra.Command, []string) error { return nil }
+	if err := gateError(cmd); err != nil {
+		t.Fatalf("gateError(doctor) = %v, want nil", err)
+	}
+}
+
+func TestGateAllowsRequirementFreeCommand(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:         "init",
+		Annotations: map[string]string{runtime.AnnotationRequires: "none"},
+	}
+	cmd.RunE = func(*cobra.Command, []string) error { return nil }
+	if err := gateError(cmd); err != nil {
+		t.Fatalf("gateError(init) = %v, want nil", err)
+	}
+}
+
+func TestGateReportsMissingDocker(t *testing.T) {
+	restore := runtime.StubProbesForTest(
+		func(context.Context) error { return errors.New("cannot connect to the docker daemon") },
+		func(context.Context) error { return nil },
+	)
+	defer restore()
+
+	cmd := &cobra.Command{
+		Use:         "up",
+		Annotations: map[string]string{runtime.AnnotationRequires: "docker"},
+	}
+	cmd.RunE = func(*cobra.Command, []string) error { return nil }
+
+	err := gateError(cmd)
+	var missing *runtime.MissingError
+	if !errors.As(err, &missing) {
+		t.Fatalf("gateError = %v, want *runtime.MissingError", err)
+	}
+	if got := cli.Code(err); got != runtime.CodeCapabilityMissing {
+		t.Fatalf("exit code = %d, want %d", got, runtime.CodeCapabilityMissing)
+	}
+}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -17,9 +17,13 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+	"govard/internal/runtime"
 )
 
 var initCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "init [flags]",
 	Short: "Initialize a new project configuration",
 	Long: `Initialize a Govard project configuration in the current directory.

--- a/internal/cmd/lock.go
+++ b/internal/cmd/lock.go
@@ -10,11 +10,15 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var lockDependencies = engine.LockDependencies{}
 
 var lockCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "lock",
 	Short: "Manage project lock file",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/manifest_test.go
+++ b/internal/cmd/manifest_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"govard/internal/runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// TestEveryRunnableCommandDeclaresRequirements is the contract guard: every
+// runnable command must state its runtime requirements, so a command can never
+// ship without declaring whether it needs Docker.
+func TestEveryRunnableCommandDeclaresRequirements(t *testing.T) {
+	missing := []string{}
+	walkCommandTree(rootCmd, func(cmd *cobra.Command) {
+		if cmd.RunE == nil && cmd.Run == nil {
+			return
+		}
+		if runtime.AlwaysRunnable(cmd) || runtime.HasDeclaredRequirement(cmd) {
+			return
+		}
+		missing = append(missing, cmd.CommandPath())
+	})
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("commands without a %s annotation (add one, do not extend the allowlist):\n  %s",
+			runtime.AnnotationRequires, strings.Join(missing, "\n  "))
+	}
+}

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"govard/internal/runtime"
 )
 
 const openSupportedTargets = "admin, db, mail, mftf, portainer, shell, sftp, elasticsearch, opensearch"
@@ -15,6 +16,9 @@ var openPma bool
 var openClient bool
 
 var openCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "open [target]",
 	Short: "Open common service URLs",
 	Long: strings.TrimSpace(`

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var (
@@ -51,6 +52,9 @@ type profileOutputPayload struct {
 }
 
 var profileCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "profile",
 	Short: "Manage environment profiles (show, switch, apply, clear)",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -150,6 +154,9 @@ var profileCmd = &cobra.Command{
 }
 
 var profileApplyCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "apply",
 	Short: "Apply the recommended runtime profile to .govard.yml",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -173,6 +180,9 @@ var profileApplyCmd = &cobra.Command{
 }
 
 var profileSwitchCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "switch [profile_name]",
 	Short: "Switch to a different environment profile",
 	Long: `Switches the active environment profile for the current project.
@@ -192,6 +202,9 @@ Use 'govard config profile clear' to reset to default profile.`,
 }
 
 var profileClearCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "clear",
 	Short: "Reset to default profile (clears saved profile)",
 	Long:  `Clears the saved profile, reverting to the default (no profile) behavior.`,

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -9,9 +9,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var projectCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:     "project",
 	Aliases: []string{"prj", "projects", "registry"},
 	Short:   "Browse known projects from registry",

--- a/internal/cmd/rabbitmq.go
+++ b/internal/cmd/rabbitmq.go
@@ -7,9 +7,13 @@ import (
 	"os/exec"
 
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var rabbitmqCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "rabbitmq [command]",
 	Short: "Control the rabbitmq queue service",
 	Long: `Interact with the RabbitMQ queue service.

--- a/internal/cmd/redis.go
+++ b/internal/cmd/redis.go
@@ -6,9 +6,13 @@ import (
 	"os/exec"
 
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var redisCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "redis [command]",
 	Short: "Control the redis cache service",
 	Long: `Interact with the Redis or Valkey cache service. 

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -13,9 +13,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var remoteCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: "ssh,rsync",
+	},
 	Use:     "remote",
 	Aliases: []string{"rmt"},
 	Short:   "Manage remote environments",

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"govard/internal/cli"
 	"govard/internal/engine"
 	_ "govard/internal/frameworks" // registers framework detection/config data via init()
 	"govard/internal/ui"
@@ -16,11 +17,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var Version = "dev"
 
 var verbose bool
+var errorJSON bool
 
 var rootCmd = &cobra.Command{
 	Use:   "govard",
@@ -42,7 +45,7 @@ Documentation: https://github.com/ddtcorex/govard`,
 	},
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if verbose {
 			pterm.EnableDebugMessages()
 			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
@@ -62,10 +65,15 @@ Documentation: https://github.com/ddtcorex/govard`,
 
 		// Cleanup stale compose files in background once a day
 		engine.AutoCleanupComposeFiles()
+
+		return gateError(cmd)
 	},
 }
 
 var versionCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "version",
 	Short: "Print the version number of Govard",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -112,14 +120,35 @@ func GenCompletionForTest(shell string) (string, error) {
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		pterm.Error.Println(err)
-		os.Exit(1)
+	executed, err := rootCmd.ExecuteC()
+	if err == nil {
+		return
 	}
+	// ExecuteC reports the executed command even when it failed before the
+	// pre-run gate (for example on argument validation).
+	command := rootCmd.CommandPath()
+	if executed != nil {
+		command = executed.CommandPath()
+	}
+	err = asUsageIfArgumentError(err)
+	if errorJSON {
+		if raw, marshalErr := cli.NewErrorEnvelope(command, err).JSON(); marshalErr == nil {
+			fmt.Println(string(raw))
+			os.Exit(cli.Code(err))
+		}
+	}
+	pterm.Error.Println(err)
+	os.Exit(cli.Code(err))
 }
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable verbose structured logging")
+	rootCmd.PersistentFlags().BoolVar(&errorJSON, "error-json", false, "Print failures as a machine-readable JSON envelope on stdout")
+
+	// Flag and argument errors are usage errors, not execution failures.
+	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return &cli.UsageError{Err: err}
+	})
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(bootstrapCmd)
@@ -167,4 +196,19 @@ func init() {
 	rootCmd.AddCommand(trustCmd)
 	rootCmd.AddCommand(verifyCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(capabilitiesCmd)
+}
+
+// asUsageIfArgumentError maps cobra's own argument-validation errors to the
+// usage exit code, so callers can tell "you called it wrong" from "it failed".
+// Cobra reports these as plain errors; the markers below are its generated
+// message shapes.
+func asUsageIfArgumentError(err error) error {
+	message := err.Error()
+	for _, marker := range []string{"arg(s), received", "unknown command", "requires at least", "accepts between"} {
+		if strings.Contains(message, marker) {
+			return &cli.UsageError{Err: err}
+		}
+	}
+	return err
 }

--- a/internal/cmd/self_update.go
+++ b/internal/cmd/self_update.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	govardruntime "govard/internal/runtime"
 )
 
 const (
@@ -46,6 +47,9 @@ var selfUpdateChannel string
 var selfUpdateForce bool
 
 var selfUpdateCmd = &cobra.Command{
+	Annotations: map[string]string{
+		govardruntime.AnnotationRequires: string(govardruntime.CapNet),
+	},
 	Use:   "self-update",
 	Short: "Upgrade installed Govard binaries",
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -11,9 +11,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var valkeyCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:                "valkey [command]",
 	Short:              "Control the valkey cache service",
 	Long:               `Interact with the Valkey cache service. Supports standard Docker Compose maintenance commands (ps, logs, stop, start, etc.).`,
@@ -40,6 +44,9 @@ var valkeyCmd = &cobra.Command{
 }
 
 var elasticsearchCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:                "elasticsearch [command|path]",
 	Short:              "Control the elasticsearch service",
 	Long:               `Interact with the Elasticsearch service. Supports custom queries (via path) and standard Docker Compose maintenance commands (ps, logs, stop, start, etc.).`,
@@ -56,6 +63,9 @@ var elasticsearchCmd = &cobra.Command{
 }
 
 var opensearchCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:                "opensearch [command|path]",
 	Short:              "Control the opensearch service",
 	Long:               `Interact with the Opensearch service. Supports custom queries (via path) and standard Docker Compose maintenance commands (ps, logs, stop, start, etc.).`,

--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -9,9 +9,13 @@ import (
 	"govard/internal/engine"
 
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var shellCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:     "shell [-c <command>] [--] [args...]",
 	Aliases: []string{"sh"},
 	Short:   "Enter the application container",

--- a/internal/cmd/shortcuts.go
+++ b/internal/cmd/shortcuts.go
@@ -1,8 +1,15 @@
 package cmd
 
+import (
+	"govard/internal/runtime"
+)
+
 import "github.com/spf13/cobra"
 
 var upShortcutCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:     "up [flags]",
 	Short:   "Shortcut for `govard env up`",
 	Long:    "Start the development environment. This is a root shortcut for `govard env up` and supports the same Govard-specific flags.",
@@ -36,6 +43,9 @@ var logsShortcutCmd = newEnvShortcutCommand(
 
 func newEnvShortcutCommand(use string, short string, long string) *cobra.Command {
 	return &cobra.Command{
+		Annotations: map[string]string{
+			runtime.AnnotationRequires: string(runtime.CapDocker),
+		},
 		Use:                use + " [args]",
 		Short:              short,
 		Long:               long,

--- a/internal/cmd/snapshot.go
+++ b/internal/cmd/snapshot.go
@@ -13,9 +13,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var snapshotCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:     "snapshot",
 	Aliases: []string{"snap"},
 	Short:   "Manage local snapshots for database and media",

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -6,9 +6,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var statusCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "status",
 	Short: "List running Govard project environments across the workspace",
 	Long:  "Workspace-wide environment overview. Use `govard env ps` for the current project only.",

--- a/internal/cmd/svc.go
+++ b/internal/cmd/svc.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 const globalProxyProjectName = "proxy"
@@ -21,6 +22,9 @@ const globalProxyProjectName = "proxy"
 var errGlobalServicesNotInitialized = errors.New("global services are not initialized")
 
 var svcCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "svc",
 	Short: "Manage global services and workspace sleep state",
 	Long: strings.TrimSpace(`

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -14,9 +14,13 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"govard/internal/runtime"
 )
 
 var syncCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: "ssh,rsync",
+	},
 	Use:   "sync [flags]",
 	Short: "Synchronize files, media, and databases between environments",
 	Long: `Synchronize your local development environment with a remote server (e.g., staging, production).

--- a/internal/cmd/test_project.go
+++ b/internal/cmd/test_project.go
@@ -12,9 +12,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var testCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "test [phpunit|phpstan|mftf|unit|integration]",
 	Short: "Run project tests (PHPUnit, PHPStan, etc.)",
 	Long: `Run various test suites directly inside the project containers.

--- a/internal/cmd/trust.go
+++ b/internal/cmd/trust.go
@@ -6,9 +6,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var trustCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapNone),
+	},
 	Use:   "trust",
 	Short: "Trust the local CA for SSL certificates",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 type tunnelCommandDependencies struct {
@@ -38,6 +39,9 @@ type TunnelDependenciesForTest struct {
 }
 
 var tunnelCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapCloudflared),
+	},
 	Use:   "tunnel",
 	Short: "Manage local project tunnels",
 	Long: `Manage public tunnels to your local project. Tunnels allow you to securely

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -18,9 +18,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var upCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "up [flags]",
 	Short: "Start the development environment",
 	Long: `Starts all Docker containers required for the current project.

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var (
@@ -18,6 +19,9 @@ var (
 )
 
 var upgradeCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "upgrade",
 	Short: "Upgrade the framework version",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/usage_exit_test.go
+++ b/internal/cmd/usage_exit_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"govard/internal/cli"
+)
+
+func TestArgumentErrorsExitAsUsage(t *testing.T) {
+	err := asUsageIfArgumentError(errors.New("accepts 1 arg(s), received 0"))
+	if got := cli.Code(err); got != cli.CodeUsage {
+		t.Fatalf("exit code = %d, want %d", got, cli.CodeUsage)
+	}
+}
+
+func TestUnknownCommandExitsAsUsage(t *testing.T) {
+	err := asUsageIfArgumentError(errors.New(`unknown command "bogus" for "govard"`))
+	if got := cli.Code(err); got != cli.CodeUsage {
+		t.Fatalf("exit code = %d, want %d", got, cli.CodeUsage)
+	}
+}
+
+func TestExecutionErrorsStayExecution(t *testing.T) {
+	err := asUsageIfArgumentError(errors.New("failed to load config"))
+	if got := cli.Code(err); got != cli.CodeError {
+		t.Fatalf("exit code = %d, want %d", got, cli.CodeError)
+	}
+}

--- a/internal/cmd/varnish.go
+++ b/internal/cmd/varnish.go
@@ -8,9 +8,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var varnishCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "varnish [command]",
 	Short: "Control the varnish service",
 	Long: `Interact with the Varnish service. 

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -11,9 +11,13 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 var verifyCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "verify",
 	Short: "Run 5-phase Govard checklist (executable)",
 	Long: `Run the 5-phase Govard verify harness (replaces manual checklist tick).

--- a/internal/cmd/vscode.go
+++ b/internal/cmd/vscode.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"govard/internal/runtime"
 )
 
 // vscodeCmd groups PHP tooling entry points meant to be wired into editor
@@ -22,6 +23,9 @@ import (
 // local to this file rather than folded into the shared config loader, so it
 // can't change directory-resolution behavior for any other command.
 var vscodeCmd = &cobra.Command{
+	Annotations: map[string]string{
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "vscode [command]",
 	Short: "Run PHP tooling inside the project container for editor integrations",
 	Long: `Run PHP, Composer, and common PHP tool binaries inside the project's container,

--- a/internal/engine/doctor_diagnostics.go
+++ b/internal/engine/doctor_diagnostics.go
@@ -25,6 +25,9 @@ type DoctorCheck struct {
 	ID               string            `json:"id" yaml:"id"`
 	Title            string            `json:"title" yaml:"title"`
 	Status           DoctorCheckStatus `json:"status" yaml:"status"`
+	Required         bool              `json:"required" yaml:"required"`
+	Severity         string            `json:"severity" yaml:"severity"`
+	Affects          []string          `json:"affects,omitempty" yaml:"affects,omitempty"`
 	Message          string            `json:"message" yaml:"message"`
 	Hint             string            `json:"hint,omitempty" yaml:"hint,omitempty"`
 	SuggestedCommand string            `json:"suggested_command,omitempty" yaml:"suggested_command,omitempty"`
@@ -378,20 +381,38 @@ func RunDoctorDiagnostics(dependencies DoctorDependencies) DoctorReport {
 		})
 	}
 
-	if missing := dependencies.CheckSystemDependencies(); len(missing) > 0 {
+	missingDependencies := dependencies.CheckSystemDependencies()
+	if missing := missingStackDependencies(missingDependencies); len(missing) > 0 {
 		report.Checks = append(report.Checks, DoctorCheck{
-			ID:      "host.system.deps",
-			Title:   "Host system dependencies",
+			ID:      "host.deps.docker",
+			Title:   "Container tooling",
 			Status:  DoctorStatusFail,
-			Message: fmt.Sprintf("Missing required system dependencies: %s", strings.Join(missing, ", ")),
-			Hint:    "Please install the missing tools using your system package manager.",
+			Message: fmt.Sprintf("Missing container tooling: %s", strings.Join(missing, ", ")),
+			Hint:    "Stack commands need it; core commands do not (run `govard capabilities`).",
 		})
 	} else {
 		report.Checks = append(report.Checks, DoctorCheck{
-			ID:      "host.system.deps",
-			Title:   "Host system dependencies",
+			ID:      "host.deps.docker",
+			Title:   "Container tooling",
 			Status:  DoctorStatusPass,
-			Message: "All required system dependencies are installed.",
+			Message: "Container tooling is installed.",
+		})
+	}
+
+	if missing := missingRemoteDependencies(missingDependencies); len(missing) > 0 {
+		report.Checks = append(report.Checks, DoctorCheck{
+			ID:      "host.deps.remote",
+			Title:   "Remote workflow tooling",
+			Status:  DoctorStatusFail,
+			Message: fmt.Sprintf("Missing remote workflow tooling: %s", strings.Join(missing, ", ")),
+			Hint:    "Remote and sync commands need ssh and rsync.",
+		})
+	} else {
+		report.Checks = append(report.Checks, DoctorCheck{
+			ID:      "host.deps.remote",
+			Title:   "Remote workflow tooling",
+			Status:  DoctorStatusPass,
+			Message: "Remote workflow tooling is installed.",
 		})
 	}
 
@@ -420,14 +441,15 @@ func RunDoctorDiagnostics(dependencies DoctorDependencies) DoctorReport {
 		})
 	}
 
+	classifyDoctorChecks(report.Checks)
 	for _, check := range report.Checks {
-		switch check.Status {
-		case DoctorStatusPass:
-			report.Passed++
-		case DoctorStatusWarn:
-			report.Warnings++
-		case DoctorStatusFail:
+		switch {
+		case check.Status == DoctorStatusFail && check.Required:
 			report.Failures++
+		case check.Status == DoctorStatusPass:
+			report.Passed++
+		default:
+			report.Warnings++
 		}
 	}
 	report.IssueCards = buildDoctorIssueCards(report.Checks)
@@ -828,4 +850,59 @@ func checkConfigDrift() error {
 		return fmt.Errorf("configuration drift: %s", strings.Join(warnings, ", "))
 	}
 	return nil
+}
+
+// optionalDoctorChecks are the checks that gate a command group rather than the
+// core itself: a host missing them can still run the Docker-free core, so they
+// report as warnings by default. `doctor --strict` promotes them to failures.
+var optionalDoctorChecks = map[string]struct {
+	severity string
+	affects  []string
+}{
+	"docker.daemon":          {"warning", []string{"env", "svc", "db", "shell", "test", "audit", "frontend", "snapshot", "project"}},
+	"docker.compose":         {"warning", []string{"env", "svc", "db", "shell", "test", "audit", "frontend", "snapshot", "project"}},
+	"host.deps.docker":       {"warning", []string{"env", "svc", "db", "shell", "test", "audit", "frontend", "snapshot"}},
+	"host.deps.remote":       {"warning", []string{"remote", "sync", "bootstrap"}},
+	"host.ssh.agent":         {"warning", []string{"remote", "sync"}},
+	"host.network.outbound":  {"warning", []string{"self-update", "remote", "tunnel"}},
+	"project.runtime.images": {"warning", []string{"env", "audit"}},
+}
+
+// classifyDoctorChecks marks every check as required (core-blocking) unless it
+// only gates a command group, and downgrades optional failures to warnings.
+func classifyDoctorChecks(checks []DoctorCheck) {
+	for index := range checks {
+		optional, isOptional := optionalDoctorChecks[checks[index].ID]
+		if !isOptional {
+			checks[index].Required = true
+			if checks[index].Severity == "" {
+				checks[index].Severity = "error"
+			}
+			continue
+		}
+		checks[index].Required = false
+		checks[index].Severity = optional.severity
+		checks[index].Affects = optional.affects
+		if checks[index].Status == DoctorStatusFail {
+			checks[index].Status = DoctorStatusWarn
+		}
+	}
+}
+
+func missingStackDependencies(missing []string) []string {
+	return filterDependencies(missing, map[string]bool{"docker": true, "docker compose plugin": true})
+}
+
+func missingRemoteDependencies(missing []string) []string {
+	return filterDependencies(missing, map[string]bool{"ssh": true, "rsync": true})
+}
+
+func filterDependencies(missing []string, wanted map[string]bool) []string {
+	filtered := make([]string, 0, len(missing))
+	for _, dependency := range missing {
+		if wanted[dependency] {
+			filtered = append(filtered, dependency)
+		}
+	}
+	return filtered
 }

--- a/internal/engine/doctor_diagnostics_test.go
+++ b/internal/engine/doctor_diagnostics_test.go
@@ -1,0 +1,84 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+)
+
+var errDockerDown = errors.New("cannot connect to the docker daemon")
+
+// stubDoctorDependencies injects every probe so the classification tests never
+// touch the host.
+func stubDoctorDependencies(dockerErr error) DoctorDependencies {
+	return DoctorDependencies{
+		CheckDockerStatus:        func() error { return dockerErr },
+		CheckDockerComposePlugin: func() error { return dockerErr },
+		CheckPortAvailable:       func(string) bool { return true },
+		CheckDiskScratch:         func() error { return nil },
+		CheckGovardHomeWritable:  func() error { return nil },
+		CheckNetworkConnectivity: func() error { return nil },
+		CheckSearchIndexBlock:    func() error { return nil },
+		CheckSSHAgentStatus:      func() (string, error) { return "agent", nil },
+		CheckComposeSpam:         func() error { return nil },
+		CheckGovardRegistry:      func() error { return nil },
+		CheckProfileSync:         func() error { return nil },
+		CheckSystemDependencies:  func() []string { return []string{"docker"} },
+		CheckRuntimeImages:       func() ([]string, error) { return nil, nil },
+		CheckLegacyConfig:        func() error { return nil },
+		CheckConfigDrift:         func() error { return nil },
+	}
+}
+
+func TestDoctorDockerChecksAreOptional(t *testing.T) {
+	report := RunDoctorDiagnostics(stubDoctorDependencies(errDockerDown))
+	seen := map[string]bool{}
+	for _, check := range report.Checks {
+		switch check.ID {
+		case "docker.daemon", "docker.compose", "host.deps.docker", "host.deps.remote":
+			seen[check.ID] = true
+			if check.Required {
+				t.Fatalf("check %s must not be required", check.ID)
+			}
+			if check.Severity != "warning" {
+				t.Fatalf("check %s severity = %q, want warning", check.ID, check.Severity)
+			}
+			if len(check.Affects) == 0 {
+				t.Fatalf("check %s must name the command groups it blocks", check.ID)
+			}
+		}
+	}
+	for _, id := range []string{"docker.daemon", "docker.compose", "host.deps.docker"} {
+		if !seen[id] {
+			t.Fatalf("check %s missing from the report", id)
+		}
+	}
+	if report.Failures != 0 {
+		t.Fatalf("optional failures must not count as blocking: failures=%d", report.Failures)
+	}
+	if report.Warnings == 0 {
+		t.Fatal("optional failures must surface as warnings")
+	}
+}
+
+func TestDoctorCoreChecksStayRequired(t *testing.T) {
+	report := RunDoctorDiagnostics(stubDoctorDependencies(nil))
+	for _, check := range report.Checks {
+		if check.ID == "host.govard.home" && !check.Required {
+			t.Fatal("host.govard.home must stay required")
+		}
+	}
+}
+
+func TestDoctorSplitsSystemDependencies(t *testing.T) {
+	deps := stubDoctorDependencies(nil)
+	deps.CheckSystemDependencies = func() []string { return []string{"ssh", "rsync"} }
+	report := RunDoctorDiagnostics(deps)
+	for _, check := range report.Checks {
+		if check.ID == "host.deps.remote" && check.Status != DoctorStatusWarn {
+			t.Fatalf("host.deps.remote status = %q, want warn", check.Status)
+		}
+		if check.ID == "host.deps.docker" && check.Status != DoctorStatusPass {
+			t.Fatalf("host.deps.docker status = %q, want pass", check.Status)
+		}
+	}
+}

--- a/internal/engine/framework_capabilities.go
+++ b/internal/engine/framework_capabilities.go
@@ -5,9 +5,10 @@ import "strings"
 // FrameworkCapabilities records optional behaviors supplied by a registered
 // framework without making engine depend on the framework registry package.
 type FrameworkCapabilities struct {
-	FrontendSync  bool
-	AuditProfiler bool
-	AuditLint     bool
+	FrontendSync   bool
+	AuditProfiler  bool
+	AuditLint      bool
+	AuditIntegrity bool
 }
 
 var registeredFrameworkCapabilities = map[string]FrameworkCapabilities{}
@@ -27,6 +28,13 @@ func FrameworkSupportsFrontendSync(name string) bool {
 
 // FrameworkSupportsAuditProfiler reports whether the framework registered a
 // stock runtime-profiler capability.
+// FrameworkSupportsAuditIntegrity reports whether the framework declares a
+// container-free integrity analyzer profile.
+func FrameworkSupportsAuditIntegrity(name string) bool {
+	capabilities, ok := registeredFrameworkCapabilities[NormalizeFrameworkAlias(name)]
+	return ok && capabilities.AuditIntegrity
+}
+
 func FrameworkSupportsAuditProfiler(name string) bool {
 	capabilities, ok := registeredFrameworkCapabilities[NormalizeFrameworkAlias(name)]
 	return ok && capabilities.AuditProfiler

--- a/internal/frameworks/magento2/magento2.go
+++ b/internal/frameworks/magento2/magento2.go
@@ -41,6 +41,11 @@ func Definition() types.FrameworkDefinition {
 			PHPStanLevel:          5,
 			PHPStanExtension:      "bitexpert/phpstan-magento",
 		},
+		AuditIntegrity: &types.AuditIntegrityProfile{
+			// Container-free analyzers: the composer manifest/lock and Magento
+			// module registration + DI wiring checks.
+			Analyzers: []string{"composer", "magento-module-di"},
+		},
 		AuditProfiler: &types.AuditProfilerProfile{
 			EnvironmentVariable: "MAGE_PROFILER",
 			EnvironmentValue:    "csvfile",

--- a/internal/frameworks/registry.go
+++ b/internal/frameworks/registry.go
@@ -281,9 +281,10 @@ func registerEngineDefinition(def types.FrameworkDefinition) {
 	engine.RegisterDBDriverCategory(def.Name, def.DBDriverCategory)
 	engine.RegisterDefaultChownDirectories(def.Name, def.DefaultChownDirectories)
 	engine.RegisterFrameworkCapabilities(def.Name, engine.FrameworkCapabilities{
-		FrontendSync:  def.FrontendSyncRenderer != nil,
-		AuditProfiler: def.AuditProfiler != nil,
-		AuditLint:     def.AuditLint != nil,
+		FrontendSync:   def.FrontendSyncRenderer != nil,
+		AuditProfiler:  def.AuditProfiler != nil,
+		AuditLint:      def.AuditLint != nil,
+		AuditIntegrity: def.AuditIntegrity != nil,
 	})
 	for _, migrationType := range def.MigrationTypes.DDEV {
 		engine.RegisterMigrationFramework("ddev", migrationType, def.Name)

--- a/internal/frameworks/types/audit.go
+++ b/internal/frameworks/types/audit.go
@@ -48,6 +48,13 @@ type AuditLintProfile struct {
 	PHPStanExtension      string
 }
 
+// AuditIntegrityProfile declares the container-free analyzers a framework
+// supports. Analyzer IDs are resolved against the audit integrity registry, so
+// this package carries no analyzer implementations.
+type AuditIntegrityProfile struct {
+	Analyzers []string
+}
+
 // AuditProfilerProfile declares the stock runtime profiler contract owned by a
 // framework. The command layer consumes these values through the generic
 // FastCGI adapter without branching on the framework name.
@@ -55,6 +62,15 @@ type AuditProfilerProfile struct {
 	EnvironmentVariable string
 	EnvironmentValue    string
 	OutputPath          string
+}
+
+func cloneAuditIntegrityProfile(profile *AuditIntegrityProfile) *AuditIntegrityProfile {
+	if profile == nil {
+		return nil
+	}
+	cloned := *profile
+	cloned.Analyzers = cloneStrings(profile.Analyzers)
+	return &cloned
 }
 
 func cloneAuditProfilerProfile(profile *AuditProfilerProfile) *AuditProfilerProfile {

--- a/internal/frameworks/types/definition.go
+++ b/internal/frameworks/types/definition.go
@@ -118,7 +118,8 @@ type FrameworkDefinition struct {
 
 	// AuditLint declares exact lint policy for frameworks that support the
 	// generic audit runner. Nil means lint audit is unsupported.
-	AuditLint *AuditLintProfile
+	AuditLint      *AuditLintProfile
+	AuditIntegrity *AuditIntegrityProfile
 	// AuditTargetResolver resolves a framework-specific path into an audit
 	// target. Nil means lint audit target selection is unsupported.
 	AuditTargetResolver AuditTargetResolver

--- a/internal/frameworks/types/spec.go
+++ b/internal/frameworks/types/spec.go
@@ -49,6 +49,7 @@ type FrameworkPatch struct {
 	DefaultChownDirectories                 Override[[]string]
 	PHPStanPaths                            Override[[]string]
 	AuditLint                               Override[*AuditLintProfile]
+	AuditIntegrity                          Override[*AuditIntegrityProfile]
 	AuditProfiler                           Override[*AuditProfilerProfile]
 	AuditTargetResolver                     Override[AuditTargetResolver]
 	ComposerCodingStandard                  Override[ComposerCodingStandard]
@@ -135,6 +136,7 @@ func (s FrameworkSpec) Resolve(parent FrameworkDefinition) FrameworkDefinition {
 	s.Patch.VarnishTemplateFramework.apply(&resolved.VarnishTemplateFramework)
 	s.Patch.PHPStanPaths.apply(&resolved.PHPStanPaths)
 	s.Patch.AuditLint.apply(&resolved.AuditLint)
+	s.Patch.AuditIntegrity.apply(&resolved.AuditIntegrity)
 	s.Patch.AuditProfiler.apply(&resolved.AuditProfiler)
 	s.Patch.AuditTargetResolver.apply(&resolved.AuditTargetResolver)
 	s.Patch.ComposerCodingStandard.apply(&resolved.ComposerCodingStandard)
@@ -204,6 +206,7 @@ func cloneDefinition(def FrameworkDefinition) FrameworkDefinition {
 	cloned.MigrationTypes.Warden = cloneStrings(def.MigrationTypes.Warden)
 	cloned.PHPStanPaths = cloneStrings(def.PHPStanPaths)
 	cloned.AuditLint = cloneAuditLintProfile(def.AuditLint)
+	cloned.AuditIntegrity = cloneAuditIntegrityProfile(def.AuditIntegrity)
 	cloned.AuditProfiler = cloneAuditProfilerProfile(def.AuditProfiler)
 	cloned.DefaultChownDirectories = cloneStrings(def.DefaultChownDirectories)
 	cloned.ToolCommands = cloneToolCommands(def.ToolCommands)

--- a/internal/runtime/annotations.go
+++ b/internal/runtime/annotations.go
@@ -1,0 +1,83 @@
+package runtime
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// AnnotationRequires is the cobra annotation key that declares a command's
+// runtime requirements, e.g. Annotations{AnnotationRequires: "docker"}.
+const AnnotationRequires = "govard.io/requires"
+
+var knownCapabilities = map[Capability]struct{}{
+	CapNone: {}, CapDocker: {}, CapSSH: {}, CapRsync: {}, CapCloudflared: {}, CapNet: {},
+}
+
+// Requires resolves the requirement for a command: the nearest annotation wins,
+// groups without a run function have none, and a runnable command that declares
+// nothing defaults to docker (default-deny).
+func Requires(cmd *cobra.Command) []Capability {
+	if cmd == nil {
+		return nil
+	}
+	for current := cmd; current != nil; current = current.Parent() {
+		raw, ok := current.Annotations[AnnotationRequires]
+		if !ok {
+			continue
+		}
+		capabilities := parseRequirements(raw)
+		if len(capabilities) > 0 {
+			return capabilities
+		}
+	}
+	if cmd.RunE == nil && cmd.Run == nil {
+		return nil
+	}
+	return []Capability{CapDocker}
+}
+
+func parseRequirements(raw string) []Capability {
+	seen := map[Capability]struct{}{}
+	capabilities := make([]Capability, 0, 2)
+	for _, part := range strings.Split(raw, ",") {
+		capability := Capability(strings.ToLower(strings.TrimSpace(part)))
+		if capability == "" {
+			continue
+		}
+		if _, known := knownCapabilities[capability]; !known {
+			// Unknown values must never silently relax the gate.
+			capability = CapDocker
+		}
+		if _, duplicate := seen[capability]; duplicate {
+			continue
+		}
+		seen[capability] = struct{}{}
+		capabilities = append(capabilities, capability)
+	}
+	return capabilities
+}
+
+// alwaysRunnableNames are commands that must work on any host: they are how an
+// operator diagnoses a broken environment or discovers what this host can do.
+var alwaysRunnableNames = map[string]bool{
+	"help": true, "completion": true, "doctor": true, "capabilities": true, "version": true,
+}
+
+// AlwaysRunnable reports whether a command must run regardless of capability
+// state. It is shared by the command gate and the manifest completeness guard.
+func AlwaysRunnable(cmd *cobra.Command) bool {
+	return cmd != nil && alwaysRunnableNames[cmd.Name()]
+}
+
+// HasDeclaredRequirement reports whether the command or one of its ancestors
+// declares requirements. Unlike Requires it never applies the default-deny
+// fallback, so callers can tell "declared none" from "declared nothing".
+func HasDeclaredRequirement(cmd *cobra.Command) bool {
+	for current := cmd; current != nil; current = current.Parent() {
+		if _, ok := current.Annotations[AnnotationRequires]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/annotations_test.go
+++ b/internal/runtime/annotations_test.go
@@ -1,0 +1,64 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newCmd(use string, runnable bool, annotation string) *cobra.Command {
+	cmd := &cobra.Command{Use: use}
+	if runnable {
+		cmd.RunE = func(*cobra.Command, []string) error { return nil }
+	}
+	if annotation != "" {
+		cmd.Annotations = map[string]string{AnnotationRequires: annotation}
+	}
+	return cmd
+}
+
+func TestRequiresReadsOwnAnnotation(t *testing.T) {
+	cmd := newCmd("init", true, "none")
+	if got, want := Requires(cmd), []Capability{CapNone}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Requires = %#v, want %#v", got, want)
+	}
+}
+
+func TestRequiresInheritsNearestParent(t *testing.T) {
+	parent := newCmd("db", false, "docker")
+	child := newCmd("query", true, "")
+	parent.AddCommand(child)
+	if got, want := Requires(child), []Capability{CapDocker}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Requires = %#v, want %#v", got, want)
+	}
+}
+
+func TestRequiresDefaultsToDockerForRunnableCommands(t *testing.T) {
+	cmd := newCmd("mystery", true, "")
+	if got, want := Requires(cmd), []Capability{CapDocker}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Requires = %#v, want %#v", got, want)
+	}
+}
+
+func TestRequiresIsNilForPureGroups(t *testing.T) {
+	cmd := newCmd("group", false, "")
+	if got := Requires(cmd); len(got) != 0 {
+		t.Fatalf("Requires = %#v, want empty", got)
+	}
+}
+
+func TestRequiresSupportsMultipleCapabilities(t *testing.T) {
+	cmd := newCmd("sync", true, "ssh,rsync")
+	want := []Capability{CapSSH, CapRsync}
+	if got := Requires(cmd); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Requires = %#v, want %#v", got, want)
+	}
+}
+
+func TestRequiresTreatsUnknownCapabilityAsDocker(t *testing.T) {
+	cmd := newCmd("odd", true, "bogus")
+	if got, want := Requires(cmd), []Capability{CapDocker}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Requires = %#v, want %#v", got, want)
+	}
+}

--- a/internal/runtime/capability.go
+++ b/internal/runtime/capability.go
@@ -1,0 +1,185 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"govard/internal/engine"
+)
+
+// Capability is one runtime requirement a command can declare.
+type Capability string
+
+const (
+	CapNone        Capability = "none"
+	CapDocker      Capability = "docker"
+	CapSSH         Capability = "ssh"
+	CapRsync       Capability = "rsync"
+	CapCloudflared Capability = "cloudflared"
+	CapNet         Capability = "net"
+)
+
+// CodeCapabilityMissing is both the machine-readable error code and the
+// process exit code for an unsatisfied runtime requirement.
+const CodeCapabilityMissing = 3
+
+// MissingError reports one or more unsatisfied capabilities.
+type MissingError struct {
+	Caps   []Capability
+	Detail string
+	Hint   string
+}
+
+func (e *MissingError) Error() string {
+	names := make([]string, 0, len(e.Caps))
+	for _, capability := range e.Caps {
+		names = append(names, string(capability))
+	}
+	base := fmt.Sprintf("missing capability %q", strings.Join(names, `", "`))
+	if strings.TrimSpace(e.Detail) == "" {
+		return base
+	}
+	return base + ": " + strings.TrimSpace(e.Detail)
+}
+
+// ExitCode makes this error self-describing to internal/cli.Code.
+func (e *MissingError) ExitCode() int { return CodeCapabilityMissing }
+
+// Injection seam: tests replace these to simulate a host with or without a
+// capability. Production always uses the real engine probes.
+var (
+	lookPath            = exec.LookPath
+	dockerStatus        = engine.CheckDockerStatus
+	dockerCompose       = engine.CheckDockerComposePlugin
+	networkConnectivity = engine.CheckNetworkConnectivity
+)
+
+// forcedSatisfied is a test-only override: capabilities listed here always
+// probe as available.
+var forcedSatisfied map[Capability]bool
+
+var capabilityHints = map[Capability]string{
+	CapDocker:      "start Docker Desktop/daemon and ensure the current user can reach the Docker socket; commands that need no containers are listed by `govard capabilities`",
+	CapSSH:         "install an SSH client (openssh-client) and retry",
+	CapRsync:       "install rsync and retry",
+	CapCloudflared: "install cloudflared (see the Govard tunnel documentation) and retry",
+	CapNet:         "check outbound network connectivity and retry",
+}
+
+// Probe reports the unsatisfied capabilities, or nil when all are met.
+func Probe(caps ...Capability) error {
+	missing := make([]Capability, 0, len(caps))
+	details := make([]string, 0, len(caps))
+	prefixed := make([]string, 0, len(caps))
+	var hint string
+	for _, capability := range caps {
+		detail := probeOne(capability)
+		if detail == "" {
+			continue
+		}
+		missing = append(missing, capability)
+		details = append(details, detail)
+		prefixed = append(prefixed, fmt.Sprintf("%s: %s", capability, detail))
+		if hint == "" {
+			hint = capabilityHints[capability]
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	// A single failure reads best without repeating the capability name.
+	detail := details[0]
+	if len(missing) > 1 {
+		detail = strings.Join(prefixed, "; ")
+	}
+	return &MissingError{Caps: missing, Detail: detail, Hint: hint}
+}
+
+// probeOne returns an empty string when the capability is satisfied.
+func probeOne(capability Capability) string {
+	if forcedSatisfied[capability] {
+		return ""
+	}
+	ctx := context.Background()
+	switch capability {
+	case CapNone:
+		return ""
+	case CapDocker:
+		if _, err := lookPath("docker"); err != nil {
+			return err.Error()
+		}
+		if err := dockerStatus(ctx); err != nil {
+			return err.Error()
+		}
+		if err := dockerCompose(ctx); err != nil {
+			return err.Error()
+		}
+		return ""
+	case CapSSH:
+		if _, err := lookPath("ssh"); err != nil {
+			return err.Error()
+		}
+		return ""
+	case CapRsync:
+		if _, err := lookPath("rsync"); err != nil {
+			return err.Error()
+		}
+		return ""
+	case CapCloudflared:
+		if _, err := lookPath("cloudflared"); err != nil {
+			return err.Error()
+		}
+		return ""
+	case CapNet:
+		if err := networkConnectivity(); err != nil {
+			return err.Error()
+		}
+		return ""
+	default:
+		return fmt.Sprintf("unknown capability %q", capability)
+	}
+}
+
+// StubProbesForTest replaces the docker probes for the duration of a test and
+// returns a restore function. It is exported because tests outside this package
+// (internal/cmd's gate test) need it; production code never calls it.
+func StubProbesForTest(status, compose func(context.Context) error) func() {
+	previousStatus, previousCompose := dockerStatus, dockerCompose
+	if status != nil {
+		dockerStatus = status
+	}
+	if compose != nil {
+		dockerCompose = compose
+	}
+	return func() {
+		dockerStatus, dockerCompose = previousStatus, previousCompose
+	}
+}
+
+// MissingCapability names the first unsatisfied capability. It lets
+// internal/cli build the machine-readable error envelope without importing
+// this package.
+func (e *MissingError) MissingCapability() string {
+	if len(e.Caps) == 0 {
+		return ""
+	}
+	return string(e.Caps[0])
+}
+
+// MissingCapabilityHint returns the operator-facing remediation hint.
+func (e *MissingError) MissingCapabilityHint() string { return e.Hint }
+
+// StubSatisfiedCapabilitiesForTest forces the listed capabilities to probe as
+// available for the duration of a test and returns a restore function. Command
+// tests use it when they exercise command logic, not capability detection.
+func StubSatisfiedCapabilitiesForTest(satisfied ...Capability) func() {
+	previous := forcedSatisfied
+	forced := make(map[Capability]bool, len(satisfied))
+	for _, capability := range satisfied {
+		forced[capability] = true
+	}
+	forcedSatisfied = forced
+	return func() { forcedSatisfied = previous }
+}

--- a/internal/runtime/capability.go
+++ b/internal/runtime/capability.go
@@ -183,3 +183,13 @@ func StubSatisfiedCapabilitiesForTest(satisfied ...Capability) func() {
 	forcedSatisfied = forced
 	return func() { forcedSatisfied = previous }
 }
+
+// StubLookPathForTest replaces the executable lookup for the duration of a test
+// and returns a restore function.
+func StubLookPathForTest(lookup func(string) (string, error)) func() {
+	previous := lookPath
+	if lookup != nil {
+		lookPath = lookup
+	}
+	return func() { lookPath = previous }
+}

--- a/internal/runtime/capability_test.go
+++ b/internal/runtime/capability_test.go
@@ -1,0 +1,84 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestProbeDockerReportsMissingCapability(t *testing.T) {
+	restore := stubProbes()
+	defer restore()
+	dockerStatus = func(context.Context) error { return errors.New("Cannot connect to the Docker daemon") }
+
+	err := Probe(CapDocker)
+	var missing *MissingError
+	if !errors.As(err, &missing) {
+		t.Fatalf("Probe error = %v, want *MissingError", err)
+	}
+	if len(missing.Caps) != 1 || missing.Caps[0] != CapDocker {
+		t.Fatalf("missing caps = %#v, want [docker]", missing.Caps)
+	}
+	if missing.ExitCode() != CodeCapabilityMissing {
+		t.Fatalf("ExitCode() = %d, want %d", missing.ExitCode(), CodeCapabilityMissing)
+	}
+	if want := `missing capability "docker": Cannot connect to the Docker daemon`; missing.Error() != want {
+		t.Fatalf("Error() = %q, want %q", missing.Error(), want)
+	}
+}
+
+func TestProbeDockerSatisfiedIsNil(t *testing.T) {
+	restore := stubProbes()
+	defer restore()
+	dockerStatus = func(context.Context) error { return nil }
+	dockerCompose = func(context.Context) error { return nil }
+	lookPath = func(string) (string, error) { return "/usr/bin/docker", nil }
+	if err := Probe(CapDocker); err != nil {
+		t.Fatalf("Probe(CapDocker) = %v, want nil", err)
+	}
+}
+
+func TestProbeDockerRequiresCLIAndComposePlugin(t *testing.T) {
+	restore := stubProbes()
+	defer restore()
+	dockerStatus = func(context.Context) error { return nil }
+	dockerCompose = func(context.Context) error { return errors.New(`exec: "docker": executable file not found in $PATH`) }
+	lookPath = func(string) (string, error) { return "/usr/bin/docker", nil }
+
+	err := Probe(CapDocker)
+	var missing *MissingError
+	if !errors.As(err, &missing) {
+		t.Fatalf("Probe error = %v, want *MissingError", err)
+	}
+	if missing.Hint == "" {
+		t.Fatal("MissingError.Hint is empty")
+	}
+}
+
+func TestProbeNoneIsAlwaysSatisfied(t *testing.T) {
+	if err := Probe(CapNone); err != nil {
+		t.Fatalf("Probe(CapNone) = %v, want nil", err)
+	}
+}
+
+func stubProbes() func() {
+	prevStatus, prevCompose, prevNet, prevLook := dockerStatus, dockerCompose, networkConnectivity, lookPath
+	return func() {
+		dockerStatus, dockerCompose, networkConnectivity, lookPath = prevStatus, prevCompose, prevNet, prevLook
+	}
+}
+
+func TestStubSatisfiedCapabilitiesForTest(t *testing.T) {
+	restoreProbes := stubProbes()
+	defer restoreProbes()
+	dockerStatus = func(context.Context) error { return errors.New("cannot connect to the docker daemon") }
+
+	restoreCapabilities := StubSatisfiedCapabilitiesForTest(CapDocker)
+	if err := Probe(CapDocker); err != nil {
+		t.Fatalf("Probe(CapDocker) with forced capability = %v, want nil", err)
+	}
+	restoreCapabilities()
+	if err := Probe(CapDocker); err == nil {
+		t.Fatal("Probe(CapDocker) after restore = nil, want the stubbed failure")
+	}
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -7,6 +7,10 @@ checksum, and exposes it as the `govard` bin.
 
 CLI only — the Desktop app is distributed via `.deb` / `.pkg` releases.
 
+The package installs and runs without Docker. Stack commands (`govard env up`,
+`svc`, `db`, `shell`, `test`, `audit`) need it; run `govard capabilities` for the
+list of commands that work without a container runtime.
+
 ## Usage
 
 ```sh

--- a/scripts/core-contract.sh
+++ b/scripts/core-contract.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Proves the Docker-free core contract inside an environment that has neither a
+# docker binary nor a docker socket. The only input is the govard binary path.
+#
+# Contract (see the Docker-free core design):
+#   1. A host with no container runtime can run every requirement-free command.
+#   2. A command whose requirement is unmet fails fast with exit 3 and a
+#      CAPABILITY_MISSING envelope instead of leaking a raw runtime error.
+#   3. `govard doctor` reports without failing; `--strict` is the hard gate.
+set -euo pipefail
+
+BIN="${1:-./govard}"
+if [ ! -x "$BIN" ]; then
+  echo "core-contract: binary not executable: $BIN" >&2
+  exit 1
+fi
+if command -v docker >/dev/null 2>&1; then
+  echo "core-contract: docker is present; this environment is not Docker-free" >&2
+  exit 1
+fi
+if [ -S /var/run/docker.sock ]; then
+  echo "core-contract: docker socket is mounted; this environment is not Docker-free" >&2
+  exit 1
+fi
+echo "core-contract: environment is Docker-free"
+
+failures=0
+
+# 1. Diagnostics must report on a host without a container runtime, and
+#    --strict must remain the explicit hard gate.
+if ! "$BIN" doctor >/dev/null 2>&1; then
+  echo "core-contract: FAIL govard doctor exited non-zero without docker" >&2
+  failures=$((failures + 1))
+fi
+if "$BIN" doctor --strict >/dev/null 2>&1; then
+  echo "core-contract: FAIL govard doctor --strict must fail without docker" >&2
+  failures=$((failures + 1))
+fi
+
+# 2. The manifest must exist and the core set must be derived from it.
+if ! "$BIN" capabilities | grep -q "$(printf '^govard version\tnone\t')"; then
+  echo "core-contract: FAIL govard version is not a requirement-free command" >&2
+  failures=$((failures + 1))
+fi
+if ! "$BIN" capabilities --json | grep -q '"schema_version": 1'; then
+  echo "core-contract: FAIL govard capabilities --json is not versioned" >&2
+  failures=$((failures + 1))
+fi
+
+# 3. Every requirement-free command must run, and no command may leak a raw
+#    container-runtime error: the gate must own that message.
+while IFS=$'\t' read -r command requires status; do
+  [ -n "${command:-}" ] || continue
+  args="${command#govard }"
+  if [ "$requires" = "none" ]; then
+    # A requirement-free command must work on this host. Commands that forward
+    # their arguments cannot be probed with --help, so only their invocation
+    # (below, via the gate branch) is asserted.
+    if ! "$BIN" $args --help >/dev/null 2>&1; then
+      echo "core-contract: FAIL $command --help exited non-zero" >&2
+      failures=$((failures + 1))
+    fi
+    continue
+  fi
+  set +e
+  out="$("$BIN" $args --error-json 2>&1)"
+  code=$?
+  set -e
+  case "$code" in
+    0|2|3) ;;
+    *)
+      echo "core-contract: FAIL $command exited $code, want 0, 2 or 3" >&2
+      failures=$((failures + 1))
+      continue
+      ;;
+  esac
+  if printf '%s' "$out" | grep -q "Cannot connect to the Docker daemon" &&
+     ! printf '%s' "$out" | grep -q "missing capability"; then
+    echo "core-contract: FAIL $command leaked a raw container-runtime error" >&2
+    failures=$((failures + 1))
+  fi
+done < <("$BIN" capabilities)
+
+# 4. Representative gate checks: one command per requirement that can be
+#    invoked without arguments and without side effects.
+check_gate() {
+  local command="$1" expected="$2"
+  set +e
+  out="$("$BIN" $command --error-json 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -ne 3 ]; then
+    echo "core-contract: FAIL govard $command exited $code, want 3" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if ! printf '%s' "$out" | grep -q '"schema_version"'; then
+    echo "core-contract: FAIL govard $command did not emit the error envelope" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if ! printf '%s' "$out" | grep -q "\"capability\": \"$expected\""; then
+    echo "core-contract: FAIL govard $command did not name capability $expected" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+check_gate "env up" docker
+check_gate "tunnel status" cloudflared
+
+if [ "$failures" -ne 0 ]; then
+  echo "core-contract: $failures failure(s)" >&2
+  exit 1
+fi
+echo "core-contract: OK"

--- a/scripts/core-contract.sh
+++ b/scripts/core-contract.sh
@@ -7,6 +7,8 @@
 #   2. A command whose requirement is unmet fails fast with exit 3 and a
 #      CAPABILITY_MISSING envelope instead of leaking a raw runtime error.
 #   3. `govard doctor` reports without failing; `--strict` is the hard gate.
+#   4. The container-free analysis check runs here, and the container-backed
+#      check fails with the capability contract instead of a raw runtime error.
 set -euo pipefail
 
 BIN="${1:-./govard}"
@@ -107,6 +109,72 @@ check_gate() {
 
 check_gate "env up" docker
 check_gate "tunnel status" cloudflared
+
+# 5. Container-free analysis. The integrity check reads the checkout directly;
+#    the container-backed lint check must refuse with exit 3 and point here.
+fixture_dir="/tmp/govard-integrity-fixture"
+govard_home="/tmp/govard-contract-home"
+rm -rf "$fixture_dir" "$govard_home"
+mkdir -p "$fixture_dir/app/code/Acme/Demo/etc" "$fixture_dir/bin"
+cat > "$fixture_dir/composer.json" <<'JSON'
+{"name":"acme/demo","require":{"php":">=8.1 <8.4","magento/product-community-edition":"2.4.7"}}
+JSON
+cat > "$fixture_dir/composer.lock" <<'JSON'
+{"content-hash":"fixture","packages":[{"name":"magento/product-community-edition","version":"2.4.7"}],"packages-dev":[]}
+JSON
+printf '#!/usr/bin/env php\n<?php\n' > "$fixture_dir/bin/magento"
+chmod +x "$fixture_dir/bin/magento"
+cat > "$fixture_dir/app/code/Acme/Demo/registration.php" <<'PHP'
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(\Magento\Framework\Component\ComponentRegistrar::MODULE, 'Acme_Demo', __DIR__);
+PHP
+cat > "$fixture_dir/app/code/Acme/Demo/etc/module.xml" <<'XML'
+<?xml version="1.0"?>
+<config>
+    <module name="Acme_Demo"/>
+</config>
+XML
+cat > "$fixture_dir/.govard.yml" <<'YAML'
+project_name: integrity-fixture
+domain: integrity-fixture.test
+framework: magento2
+stack:
+  php_version: "8.3"
+YAML
+
+set +e
+integrity_out="$(cd "$fixture_dir" && GOVARD_HOME_DIR="$govard_home" "$BIN" audit run --checks integrity --format json 2>&1)"
+integrity_code=$?
+set -e
+case "$integrity_code" in
+  0|1) ;;
+  *)
+    echo "core-contract: FAIL govard audit run --checks integrity exited $integrity_code" >&2
+    failures=$((failures + 1))
+    ;;
+esac
+if printf '%s' "$integrity_out" | grep -q "Cannot connect to the Docker daemon"; then
+  echo "core-contract: FAIL the integrity check touched the container runtime" >&2
+  failures=$((failures + 1))
+fi
+if ! printf '%s' "$integrity_out" | grep -q '"id":"integrity"'; then
+  echo "core-contract: FAIL the integrity job did not run:" >&2
+  printf '%s\n' "$integrity_out" >&2
+  failures=$((failures + 1))
+fi
+
+set +e
+lint_out="$(cd "$fixture_dir" && GOVARD_HOME_DIR="$govard_home" "$BIN" audit run --checks lint 2>&1)"
+lint_code=$?
+set -e
+if [ "$lint_code" -ne 3 ]; then
+  echo "core-contract: FAIL govard audit run --checks lint exited $lint_code, want 3" >&2
+  failures=$((failures + 1))
+fi
+if ! printf '%s' "$lint_out" | grep -q -- "--checks integrity"; then
+  echo "core-contract: FAIL the lint gate did not point at the container-free check" >&2
+  failures=$((failures + 1))
+fi
 
 if [ "$failures" -ne 0 ]; then
   echo "core-contract: $failures failure(s)" >&2

--- a/tests/audit_integrity_composer_test.go
+++ b/tests/audit_integrity_composer_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"govard/internal/audit"
+)
+
+func analyzeComposerFixture(t *testing.T, name string, stackPHP string) []audit.LintFinding {
+	t.Helper()
+	analyzers, err := audit.IntegrityAnalyzers([]string{"composer"})
+	if err != nil {
+		t.Fatalf("IntegrityAnalyzers: %v", err)
+	}
+	root := filepath.Join("fixtures", "integrity", name)
+	findings, err := analyzers[0].Analyze(audit.IntegrityRequest{
+		ProjectRoot:     root,
+		TargetPath:      root,
+		Framework:       "magento2",
+		StackPHPVersion: stackPHP,
+	})
+	if err != nil {
+		t.Fatalf("Analyze(%s): %v", name, err)
+	}
+	return findings
+}
+
+func rulesOf(findings []audit.LintFinding) []string {
+	rules := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		rules = append(rules, finding.Rule)
+	}
+	return rules
+}
+
+func assertRule(t *testing.T, findings []audit.LintFinding, rule string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Rule == rule {
+			if finding.Tool != "govard-integrity" {
+				t.Fatalf("finding tool = %q, want govard-integrity", finding.Tool)
+			}
+			if strings.TrimSpace(finding.Message) == "" {
+				t.Fatalf("finding %s has no message", rule)
+			}
+			return
+		}
+	}
+	t.Fatalf("rule %s not reported; got %v", rule, rulesOf(findings))
+}
+
+func assertNoRule(t *testing.T, findings []audit.LintFinding, rule string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Rule == rule {
+			t.Fatalf("rule %s must not be reported for this fixture", rule)
+		}
+	}
+}
+
+func TestComposerIntegrityValidProjectIsClean(t *testing.T) {
+	findings := analyzeComposerFixture(t, "composer-valid", "8.3")
+	if len(findings) != 0 {
+		t.Fatalf("expected a clean project, got %v", rulesOf(findings))
+	}
+}
+
+func TestComposerIntegrityMissingLock(t *testing.T) {
+	findings := analyzeComposerFixture(t, "composer-missing-lock", "8.3")
+	assertRule(t, findings, "COMPOSER_LOCK_MISSING")
+}
+
+func TestComposerIntegrityRequirementNotLocked(t *testing.T) {
+	findings := analyzeComposerFixture(t, "composer-not-locked", "8.3")
+	assertRule(t, findings, "COMPOSER_REQUIREMENT_NOT_LOCKED")
+}
+
+func TestComposerIntegrityDuplicatePackage(t *testing.T) {
+	findings := analyzeComposerFixture(t, "composer-duplicate", "8.3")
+	assertRule(t, findings, "COMPOSER_DUPLICATE_PACKAGE")
+}
+
+func TestComposerIntegrityPHPConstraintMatchesStack(t *testing.T) {
+	findings := analyzeComposerFixture(t, "composer-valid", "8.3")
+	assertNoRule(t, findings, "COMPOSER_PHP_CONSTRAINT_MISMATCH")
+}
+
+func TestComposerIntegrityPHPConstraintMismatch(t *testing.T) {
+	findings := analyzeComposerFixture(t, "composer-php-mismatch", "8.4")
+	assertRule(t, findings, "COMPOSER_PHP_CONSTRAINT_MISMATCH")
+}

--- a/tests/audit_integrity_magento_test.go
+++ b/tests/audit_integrity_magento_test.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"govard/internal/audit"
+)
+
+func analyzeMagentoFixture(t *testing.T, name string) []audit.LintFinding {
+	t.Helper()
+	analyzers, err := audit.IntegrityAnalyzers([]string{"magento-module-di"})
+	if err != nil {
+		t.Fatalf("IntegrityAnalyzers: %v", err)
+	}
+	root := filepath.Join("fixtures", "integrity", name)
+	findings, err := analyzers[0].Analyze(audit.IntegrityRequest{
+		ProjectRoot: root,
+		TargetPath:  root,
+		Framework:   "magento2",
+	})
+	if err != nil {
+		t.Fatalf("Analyze(%s): %v", name, err)
+	}
+	return findings
+}
+
+func TestMagentoIntegrityValidModuleIsClean(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "magento-valid")
+	if len(findings) != 0 {
+		t.Fatalf("expected a clean module, got %v", rulesOf(findings))
+	}
+}
+
+func TestMagentoIntegrityModuleNameMismatch(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "magento-name-mismatch")
+	assertRule(t, findings, "MAGENTO_MODULE_NAME_MISMATCH")
+}
+
+func TestMagentoIntegrityMalformedXML(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "magento-xml-invalid")
+	assertRule(t, findings, "MAGENTO_XML_INVALID")
+}
+
+func TestMagentoIntegrityDuplicateDITarget(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "magento-di-duplicate")
+	assertRule(t, findings, "MAGENTO_DI_DUPLICATE_TARGET")
+}
+
+func TestMagentoIntegritySequenceUnknownModule(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "magento-sequence-unknown")
+	assertRule(t, findings, "MAGENTO_SEQUENCE_UNKNOWN_MODULE")
+}
+
+func TestMagentoIntegrityIgnoresNonModuleTrees(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "composer-valid")
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings outside a Magento tree, got %v", rulesOf(findings))
+	}
+}

--- a/tests/audit_integrity_profile_test.go
+++ b/tests/audit_integrity_profile_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"testing"
+
+	"govard/internal/engine"
+	"govard/internal/frameworks"
+)
+
+func TestMagentoDeclaresIntegrityAnalyzers(t *testing.T) {
+	definition, ok := frameworks.Get("magento2")
+	if !ok {
+		t.Fatal("magento2 definition is not registered")
+	}
+	if definition.AuditIntegrity == nil {
+		t.Fatal("magento2 must declare an AuditIntegrity profile")
+	}
+	want := map[string]bool{"composer": true, "magento-module-di": true}
+	if len(definition.AuditIntegrity.Analyzers) != len(want) {
+		t.Fatalf("analyzers = %v, want %v", definition.AuditIntegrity.Analyzers, want)
+	}
+	for _, analyzer := range definition.AuditIntegrity.Analyzers {
+		if !want[analyzer] {
+			t.Fatalf("unexpected analyzer %q", analyzer)
+		}
+	}
+}
+
+func TestIntegrityCapabilityMirrorsProfile(t *testing.T) {
+	if !engine.FrameworkSupportsAuditIntegrity("magento2") {
+		t.Fatal("magento2 must report the integrity capability")
+	}
+	if engine.FrameworkSupportsAuditIntegrity("laravel") {
+		t.Fatal("laravel does not declare an integrity profile and must not report the capability")
+	}
+}

--- a/tests/audit_integrity_runner_test.go
+++ b/tests/audit_integrity_runner_test.go
@@ -1,0 +1,90 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"govard/internal/audit"
+	"govard/internal/frameworks/types"
+)
+
+type stubIntegrityAnalyzer struct {
+	id       string
+	findings []audit.LintFinding
+}
+
+func (stub stubIntegrityAnalyzer) ID() string { return stub.id }
+
+func (stub stubIntegrityAnalyzer) Analyze(audit.IntegrityRequest) ([]audit.LintFinding, error) {
+	return stub.findings, nil
+}
+
+func integrityRunRequest(analyzerID string) audit.RunRequest {
+	return audit.RunRequest{
+		ProjectRoot:      "/work/shop",
+		ProjectID:        "project-aabbccdd",
+		Scope:            audit.ScopeProject,
+		Checks:           []string{"integrity"},
+		Environment:      audit.EnvironmentFingerprint{Framework: "magento2", GovardVersion: "test"},
+		Source:           audit.SourceFingerprint{Digest: "sha256:source"},
+		Target:           types.AuditTarget{Framework: "magento2", ProjectRoot: "/work/shop", TargetPath: "/work/shop", Mode: types.AuditTargetProject},
+		IntegrityProfile: types.AuditIntegrityProfile{Analyzers: []string{analyzerID}},
+		StackPHPVersion:  "8.3",
+	}
+}
+
+func TestIntegrityJobRunsWithoutALintBackend(t *testing.T) {
+	audit.RegisterIntegrityAnalyzer(stubIntegrityAnalyzer{id: "stub-clean-analyzer"})
+	runner := audit.NewRunner(audit.RunnerOptions{
+		Store:     newDeterministicAuditStore(t),
+		Resources: audit.Resources{CPU: 2, MemoryMB: 1024},
+	})
+
+	result, err := runner.Run(context.Background(), integrityRunRequest("stub-clean-analyzer"))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(result.Jobs) != 1 || result.Jobs[0].ID != "integrity" || result.Jobs[0].Kind != "host-analysis" {
+		t.Fatalf("jobs = %#v", result.Jobs)
+	}
+	if result.Jobs[0].Status != audit.StatusPassed {
+		t.Fatalf("job status = %s, want passed", result.Jobs[0].Status)
+	}
+	if result.Status != audit.StatusPassed {
+		t.Fatalf("run status = %s, want passed", result.Status)
+	}
+	if len(result.Artifacts) != 1 || result.Artifacts[0].Kind != "integrity-report" {
+		t.Fatalf("artifacts = %#v", result.Artifacts)
+	}
+}
+
+func TestIntegrityJobFailsOnFindings(t *testing.T) {
+	audit.RegisterIntegrityAnalyzer(stubIntegrityAnalyzer{
+		id:       "stub-finding-analyzer",
+		findings: []audit.LintFinding{{Tool: "govard-integrity", Rule: "COMPOSER_LOCK_MISSING", Message: "composer.lock is missing"}},
+	})
+	runner := audit.NewRunner(audit.RunnerOptions{
+		Store:     newDeterministicAuditStore(t),
+		Resources: audit.Resources{CPU: 2, MemoryMB: 1024},
+	})
+
+	result, err := runner.Run(context.Background(), integrityRunRequest("stub-finding-analyzer"))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Status != audit.StatusFailed {
+		t.Fatalf("run status = %s, want failed", result.Status)
+	}
+	if result.Jobs[0].Status != audit.StatusFailed {
+		t.Fatalf("job status = %s, want failed", result.Jobs[0].Status)
+	}
+	findings, ok := result.Jobs[0].Evidence["findings"].([]audit.LintFinding)
+	if !ok || len(findings) != 1 || findings[0].Rule != "COMPOSER_LOCK_MISSING" {
+		t.Fatalf("findings evidence = %#v", result.Jobs[0].Evidence["findings"])
+	}
+	for _, auditError := range result.Errors {
+		if auditError.Code == "infrastructure" {
+			t.Fatalf("findings must not be reported as an infrastructure error: %#v", result.Errors)
+		}
+	}
+}

--- a/tests/audit_integrity_test.go
+++ b/tests/audit_integrity_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"govard/internal/audit"
+)
+
+type fakeIntegrityAnalyzer struct{ id string }
+
+func (f fakeIntegrityAnalyzer) ID() string { return f.id }
+
+func (f fakeIntegrityAnalyzer) Analyze(audit.IntegrityRequest) ([]audit.LintFinding, error) {
+	return []audit.LintFinding{{Tool: "govard-integrity", Rule: "FAKE", Message: "fake"}}, nil
+}
+
+func TestNormalizeChecksAcceptsIntegrity(t *testing.T) {
+	got, err := audit.NormalizeChecks([]string{"integrity"})
+	if err != nil {
+		t.Fatalf("NormalizeChecks returned error: %v", err)
+	}
+	if want := []string{"integrity"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized checks = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeChecksAcceptsIntegrityAlongsideContainerChecks(t *testing.T) {
+	got, err := audit.NormalizeChecks([]string{"lint", "integrity"})
+	if err != nil {
+		t.Fatalf("NormalizeChecks returned error: %v", err)
+	}
+	if want := []string{"lint", "integrity"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized checks = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeChecksStillRejectsUnknownCheck(t *testing.T) {
+	if _, err := audit.NormalizeChecks([]string{"bogus"}); err == nil {
+		t.Fatal("expected an error for an unknown check")
+	}
+}
+
+func TestIntegrityAnalyzersResolveRegisteredIDs(t *testing.T) {
+	audit.RegisterIntegrityAnalyzer(fakeIntegrityAnalyzer{id: "fake-test-analyzer"})
+
+	analyzers, err := audit.IntegrityAnalyzers([]string{"fake-test-analyzer"})
+	if err != nil {
+		t.Fatalf("IntegrityAnalyzers returned error: %v", err)
+	}
+	if len(analyzers) != 1 || analyzers[0].ID() != "fake-test-analyzer" {
+		t.Fatalf("analyzers = %#v", analyzers)
+	}
+}
+
+func TestIntegrityAnalyzersRejectUnknownID(t *testing.T) {
+	_, err := audit.IntegrityAnalyzers([]string{"not-registered"})
+	if err == nil {
+		t.Fatal("expected an error for an unregistered analyzer")
+	}
+	if !strings.Contains(err.Error(), "not-registered") {
+		t.Fatalf("error should name the missing analyzer, got: %v", err)
+	}
+}

--- a/tests/doctor_diagnostics_test.go
+++ b/tests/doctor_diagnostics_test.go
@@ -45,14 +45,16 @@ func TestRunDoctorDiagnosticsComposeFailure(t *testing.T) {
 		CheckSSHAgentStatus:      func() (string, error) { return "ok", nil },
 	})
 
-	if report.Failures != 1 {
-		t.Fatalf("expected 1 failure, got %d", report.Failures)
+	// The Compose plugin gates the stack commands, not the core, so its absence
+	// is a warning rather than a blocking failure.
+	if report.Failures != 0 {
+		t.Fatalf("expected compose failure to be optional, got %d failure(s)", report.Failures)
+	}
+	if report.Warnings == 0 {
+		t.Fatal("expected the compose failure to surface as a warning")
 	}
 	if len(report.IssueCards) == 0 {
-		t.Fatal("expected issue cards for failure report")
-	}
-	if report.IssueCards[0].Severity != "error" {
-		t.Fatalf("expected first issue card severity error, got %s", report.IssueCards[0].Severity)
+		t.Fatal("expected issue cards for the warning report")
 	}
 
 	found := false
@@ -61,8 +63,17 @@ func TestRunDoctorDiagnosticsComposeFailure(t *testing.T) {
 			continue
 		}
 		found = true
-		if check.Status != engine.DoctorStatusFail {
-			t.Fatalf("expected docker.compose fail status, got %s", check.Status)
+		if check.Status != engine.DoctorStatusWarn {
+			t.Fatalf("expected docker.compose warn status, got %s", check.Status)
+		}
+		if check.Required {
+			t.Fatal("docker.compose must not be required")
+		}
+		if check.Severity != "warning" {
+			t.Fatalf("expected warning severity, got %s", check.Severity)
+		}
+		if len(check.Affects) == 0 {
+			t.Fatal("docker.compose must name the command groups it blocks")
 		}
 		if check.SuggestedCommand != "docker compose version" {
 			t.Fatalf("expected suggested command docker compose version, got %s", check.SuggestedCommand)

--- a/tests/fixtures/integrity/composer-duplicate/composer.json
+++ b/tests/fixtures/integrity/composer-duplicate/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "acme/sample-project",
+  "require": {
+    "php": ">=8.1 <8.4",
+    "monolog/monolog": "^2.9"
+  }
+}

--- a/tests/fixtures/integrity/composer-duplicate/composer.lock
+++ b/tests/fixtures/integrity/composer-duplicate/composer.lock
@@ -1,0 +1,8 @@
+{
+  "content-hash": "fixture",
+  "packages": [
+    { "name": "monolog/monolog", "version": "2.9.1" },
+    { "name": "monolog/monolog", "version": "2.9.0" }
+  ],
+  "packages-dev": []
+}

--- a/tests/fixtures/integrity/composer-missing-lock/composer.json
+++ b/tests/fixtures/integrity/composer-missing-lock/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "acme/sample-project",
+  "require": {
+    "php": ">=8.1 <8.4",
+    "monolog/monolog": "^2.9"
+  }
+}

--- a/tests/fixtures/integrity/composer-not-locked/composer.json
+++ b/tests/fixtures/integrity/composer-not-locked/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "acme/sample-project",
+  "require": {
+    "php": ">=8.1 <8.4",
+    "monolog/monolog": "^2.9"
+  }
+}

--- a/tests/fixtures/integrity/composer-not-locked/composer.lock
+++ b/tests/fixtures/integrity/composer-not-locked/composer.lock
@@ -1,0 +1,7 @@
+{
+  "content-hash": "fixture",
+  "packages": [
+    { "name": "psr/log", "version": "3.0.0" }
+  ],
+  "packages-dev": []
+}

--- a/tests/fixtures/integrity/composer-php-mismatch/composer.json
+++ b/tests/fixtures/integrity/composer-php-mismatch/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "acme/sample-project",
+  "require": {
+    "php": "~7.4",
+    "monolog/monolog": "^2.9"
+  }
+}

--- a/tests/fixtures/integrity/composer-php-mismatch/composer.lock
+++ b/tests/fixtures/integrity/composer-php-mismatch/composer.lock
@@ -1,0 +1,8 @@
+{
+  "_readme": ["fixture"],
+  "content-hash": "fixture",
+  "packages": [
+    { "name": "monolog/monolog", "version": "2.9.1" }
+  ],
+  "packages-dev": []
+}

--- a/tests/fixtures/integrity/composer-valid/composer.json
+++ b/tests/fixtures/integrity/composer-valid/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "acme/sample-project",
+  "require": {
+    "php": ">=8.1 <8.4",
+    "monolog/monolog": "^2.9"
+  }
+}

--- a/tests/fixtures/integrity/composer-valid/composer.lock
+++ b/tests/fixtures/integrity/composer-valid/composer.lock
@@ -1,0 +1,8 @@
+{
+  "_readme": ["fixture"],
+  "content-hash": "fixture",
+  "packages": [
+    { "name": "monolog/monolog", "version": "2.9.1" }
+  ],
+  "packages-dev": []
+}

--- a/tests/fixtures/integrity/magento-di-duplicate/app/code/Acme/Dup/etc/di.xml
+++ b/tests/fixtures/integrity/magento-di-duplicate/app/code/Acme/Dup/etc/di.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Acme\Dup\Api\ThingInterface" type="Acme\Dup\Model\Thing"/>
+    <preference for="Acme\Dup\Api\ThingInterface" type="Acme\Dup\Model\OtherThing"/>
+</config>

--- a/tests/fixtures/integrity/magento-di-duplicate/app/code/Acme/Dup/etc/module.xml
+++ b/tests/fixtures/integrity/magento-di-duplicate/app/code/Acme/Dup/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Acme_Dup">
+    </module>
+</config>

--- a/tests/fixtures/integrity/magento-di-duplicate/app/code/Acme/Dup/registration.php
+++ b/tests/fixtures/integrity/magento-di-duplicate/app/code/Acme/Dup/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Acme_Dup',
+    __DIR__
+);

--- a/tests/fixtures/integrity/magento-name-mismatch/app/code/Acme/Mismatch/etc/module.xml
+++ b/tests/fixtures/integrity/magento-name-mismatch/app/code/Acme/Mismatch/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Acme_Other">
+    </module>
+</config>

--- a/tests/fixtures/integrity/magento-name-mismatch/app/code/Acme/Mismatch/registration.php
+++ b/tests/fixtures/integrity/magento-name-mismatch/app/code/Acme/Mismatch/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Acme_Mismatch',
+    __DIR__
+);

--- a/tests/fixtures/integrity/magento-sequence-unknown/app/code/Acme/Seq/etc/module.xml
+++ b/tests/fixtures/integrity/magento-sequence-unknown/app/code/Acme/Seq/etc/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Acme_Seq">
+        <sequence>
+            <module name="Acme_Missing"/>
+        </sequence>
+    </module>
+</config>

--- a/tests/fixtures/integrity/magento-sequence-unknown/app/code/Acme/Seq/registration.php
+++ b/tests/fixtures/integrity/magento-sequence-unknown/app/code/Acme/Seq/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Acme_Seq',
+    __DIR__
+);

--- a/tests/fixtures/integrity/magento-valid/app/code/Acme/Valid/etc/module.xml
+++ b/tests/fixtures/integrity/magento-valid/app/code/Acme/Valid/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Acme_Valid">
+    </module>
+</config>

--- a/tests/fixtures/integrity/magento-valid/app/code/Acme/Valid/registration.php
+++ b/tests/fixtures/integrity/magento-valid/app/code/Acme/Valid/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Acme_Valid',
+    __DIR__
+);

--- a/tests/fixtures/integrity/magento-xml-invalid/app/code/Acme/Broken/etc/module.xml
+++ b/tests/fixtures/integrity/magento-xml-invalid/app/code/Acme/Broken/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config>
+    <module name="Acme_Broken">
+</config>

--- a/tests/fixtures/integrity/magento-xml-invalid/app/code/Acme/Broken/registration.php
+++ b/tests/fixtures/integrity/magento-xml-invalid/app/code/Acme/Broken/registration.php
@@ -1,0 +1,2 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(\Magento\Framework\Component\ComponentRegistrar::MODULE, 'Acme_Broken', __DIR__);

--- a/tests/integration/doctor_trust_test.go
+++ b/tests/integration/doctor_trust_test.go
@@ -20,7 +20,9 @@ func TestDoctorJSONWithShims(t *testing.T) {
 		t.Fatalf("expected doctor exit code 0 or 1, got %d\nstderr=%s", doctorResult.ExitCode, doctorResult.Stderr)
 	}
 	assertContains(t, doctorResult.Stdout, `"checks":`)
-	assertContains(t, doctorResult.Stdout, `"host.system.deps"`)
+	// System dependencies are split by the command group they gate.
+	assertContains(t, doctorResult.Stdout, `"host.deps.docker"`)
+	assertContains(t, doctorResult.Stdout, `"host.deps.remote"`)
 }
 
 func TestTrustCommandWithShims(t *testing.T) {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -249,6 +249,7 @@ func (env *TestEnvironment) SetupRuntimeShims(t *testing.T, exitCodes map[string
 
 func runtimeShimScript(name string, exitCode int) string {
 	exitVar := "GOVARD_TEST_EXIT_" + strings.ToUpper(name)
+	matchVar := "GOVARD_TEST_FAIL_MATCH_" + strings.ToUpper(name)
 
 	sshBehavior := ""
 	if name == "ssh" {
@@ -294,6 +295,17 @@ fi
 
 current_exit="${%s:-%d}"
 
+# A match-scoped one-shot failure applies only to invocations whose arguments
+# contain the pattern, so the caller can target the call it means to fail
+# instead of whichever invocation happens to run first (the capability probe).
+fail_match="${%s:-}"
+if [ -n "$fail_match" ]; then
+  case "$*" in
+    *"$fail_match"*) ;;
+    *) current_exit=0 ;;
+  esac
+fi
+
 # Support for one-shot failure testing (good for fallbacks)
 if [ "$current_exit" = "127" ] || [ "$current_exit" = "126" ]; then
   state_file="$(dirname "$log")/.shim_state_%s"
@@ -311,7 +323,7 @@ if [ ! -t 0 ]; then
   cat >/dev/null 2>&1 || true
 fi
 exit "$current_exit"
-`, name, exitVar, exitCode, name, sshBehavior, dockerBehavior)
+`, name, exitVar, exitCode, matchVar, name, sshBehavior, dockerBehavior)
 }
 
 // Env returns additional environment variables required to use the runtime shims.

--- a/tests/integration/magento_cli_runtime_paths_test.go
+++ b/tests/integration/magento_cli_runtime_paths_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"govard/internal/engine"
@@ -63,7 +62,7 @@ hooks:
 	}
 }
 
-func TestStatusHandlesDockerConnectionErrors(t *testing.T) {
+func TestStatusFailsFastWhenDockerDaemonUnreachable(t *testing.T) {
 	env := NewTestEnvironment(t)
 	projectDir := env.CreateProjectFromFixture(t, "magento2/options-local", "status-m2")
 
@@ -73,12 +72,15 @@ func TestStatusHandlesDockerConnectionErrors(t *testing.T) {
 		[]string{"DOCKER_HOST=unix:///tmp/govard-int-status-missing.sock"},
 		"status",
 	)
-	result.AssertSuccess(t)
 
-	output := result.Stdout + result.Stderr
-	if !strings.Contains(output, "failed to connect to Docker") && !strings.Contains(output, "failed to list containers") {
-		t.Fatalf("expected docker connection error output, got:\n%s", output)
+	// An unreachable daemon is a missing capability: the command must fail
+	// before its workflow starts rather than mid-way through listing containers.
+	if result.ExitCode != 3 {
+		t.Fatalf("expected exit code 3 (missing capability), got %d\nstdout=%s\nstderr=%s",
+			result.ExitCode, result.Stdout, result.Stderr)
 	}
+	output := result.Stdout + result.Stderr
+	assertContains(t, output, `missing capability "docker"`)
 }
 
 func TestShellFallsBackToShWhenBashFails(t *testing.T) {
@@ -86,7 +88,11 @@ func TestShellFallsBackToShWhenBashFails(t *testing.T) {
 	projectDir := env.CreateProjectFromFixture(t, "magento2/options-local", "shell-fallback-m2")
 	shim := env.SetupRuntimeShims(t, map[string]int{"docker": 127, "ssh": 0, "rsync": 0})
 
-	result := env.RunGovardWithEnv(t, projectDir, shim.Env(), "shell")
+	// The one-shot failure must target the in-container bash attempt, not the
+	// capability probe's `docker compose version` call.
+	shellEnv := append(shim.Env(), "GOVARD_TEST_FAIL_MATCH_DOCKER=bash")
+
+	result := env.RunGovardWithEnv(t, projectDir, shellEnv, "shell")
 	result.AssertSuccess(t)
 
 	logs := shim.ReadLog(t)

--- a/tests/tunnel_command_test.go
+++ b/tests/tunnel_command_test.go
@@ -12,6 +12,7 @@ import (
 	"govard/internal/cmd"
 	"govard/internal/engine"
 	"govard/internal/engine/tunnel"
+	"govard/internal/runtime"
 )
 
 type fakeTunnelProvider struct {
@@ -82,6 +83,9 @@ func TestCloudflareTunnelProviderBuildStartPlan(t *testing.T) {
 }
 
 func TestTunnelStartPlanUsesConfigDomainByDefault(t *testing.T) {
+	restoreCapabilities := runtime.StubSatisfiedCapabilitiesForTest(runtime.CapCloudflared)
+	defer restoreCapabilities()
+
 	tempDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tempDir, ".govard.yml"), []byte(`project_name: demo
 domain: demo.test
@@ -149,6 +153,9 @@ framework: laravel
 }
 
 func TestTunnelStartRejectsConflictingURLInputs(t *testing.T) {
+	restoreCapabilities := runtime.StubSatisfiedCapabilitiesForTest(runtime.CapCloudflared)
+	defer restoreCapabilities()
+
 	tempDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tempDir, ".govard.yml"), []byte(`project_name: demo
 domain: demo.test


### PR DESCRIPTION
Closes #287

## Summary

Govard already installed and ran without Docker — no package channel depends on it — but the installer, the docs and `doctor` all implied otherwise, and nothing gated container commands. This makes the boundary explicit, tested and reported.

**Contract.** Every runnable command declares its runtime requirements inline via the cobra annotation `govard.io/requires`. A runnable command that declares nothing defaults to `docker` (default-deny), and a completeness test walks the command tree and fails the build when one is missing. The Docker-free core set is therefore *derived*: it is exactly the commands that resolve to no requirement (22 today), and `govard capabilities`, the docs and the CI contract script all read that same source.

**Fail fast.** `rootCmd.PersistentPreRunE` gates commands before their workflow starts. Exit codes are frozen: `3` missing capability, `4` configuration, `2` usage (flag errors and cobra's argument-validation errors alike). `--error-json` prints one versioned envelope, so a machine never parses text; the remediation hint travels inside the envelope and stdout stays clean.

**Diagnosis.** `govard capabilities [--json]` reports every command, its requirements and whether this host meets them. `doctor` now marks only core-blocking checks as required; Docker, ssh, rsync, cloudflared and runtime images report as warnings that name the command groups they block (`affects`), and `govard doctor --strict` restores the previous hard gate.

**Installer and docs.** `install.sh` no longer starts global services when Docker is unusable — it reports core readiness instead. README and installation docs (EN + VI) move Docker out of prerequisites into a per-command-group runtime requirement.

## Rationale

- **Capability annotations over a side manifest or a central table**: they live where commands are defined, so they cannot drift; the completeness test is what stops the contract from rotting as commands are added.
- **`doctor` semantics**: a diagnostic must run and report on a broken host, and its exit code must not depend on cwd or project config. No CI depended on the old behaviour, which made this the cheapest moment to fix it. `--strict` is the explicit gate for bootstrap scripts.
- **`--error-json` rather than a persistent `--json`**: 14 command files already define a local `--json`; a persistent flag of the same name panics at cobra registration. Commands that forward their arguments (`govard tool php ...`) cannot parse it — their exit codes still hold, which is documented.
- **No abstraction layer**: the probe package returns a typed error and stays thin; the 27 existing Docker call sites are untouched. Promoting it to a full runtime registry later is a change in one package.

## Test plan

- [x] `go test ./... -short` clean (unit packages + `tests/`), `go vet ./...` clean, `gofmt -s -l` clean.
- [x] `go vet -tags integration ./tests/integration/...` compiles (integration containers not started locally, to avoid disturbing running project environments; CI runs them).
- [x] `make lint` (golangci-lint) clean.
- [x] Updated `tests/doctor_diagnostics_test.go` for the new optional-capability semantics, and gave the tunnel command tests a capability stub (`runtime.StubSatisfiedCapabilitiesForTest`) because they execute through the root command and CI has no `cloudflared`. The suite caught both changes, which is the intended signal.
- [x] `scripts/core-contract.sh` run inside `debian:bookworm-slim` with no `docker` binary and no socket: every requirement-free command runs, gated commands exit `3` with the `CAPABILITY_MISSING` envelope, `doctor` exits `0` while `doctor --strict` exits non-zero, and no command leaks a raw runtime error.
- [x] Manual: `govard env up` on a Docker-less shell exits `3` with `cannot run "govard env up": missing capability "docker"` instead of reaching step 2/10; `govard version` still exits `0`.
- [x] New CI job `core_sans_docker`, wired into the `verify` gate `needs` and result loop; `actionlint` clean on the workflow.

## Breaking changes

- Exit codes `3` and `4` are new; `2` also covers argument-validation errors.
- Gated commands fail before their workflow starts rather than midway.
- `govard doctor` exits `0` when only optional capabilities are missing; `--strict` restores the previous behaviour.
- `install.sh` no longer starts global services when Docker is unusable.

No flag was removed and no durable schema changed, so this ships as a minor.

## Follow-ups (separate PRs)

- `integrity` audit check: a container-free static-analysis check (composer integrity, Magento module/DI integrity) built on the existing generic audit job model.
- Cross-repo sync: `maestro-skills` (`govard-toolbox`, the four framework skills, `review-in-worktree` gaining a real tool path for reviewers with no container rights) and `packages/dsh-maestro-govard` (`checks` parameter, exit-3 mapping) — released after this lands.

Design record: `maestro-harness/docs/specs/2026-09-11-govard-docker-free-core-design.md`.

## Also in this PR: container-free analysis (`integrity`)

The contract alone would be a boundary with nothing valuable behind it, so the same branch adds the first analysis feature that runs without Docker:

- `govard audit run --checks integrity` runs Go analyzers on the checkout — no container, no PHP, no toolchain. It is a new audit check id on the existing job model (kind `host-analysis`), not a lint provider: the lint report schema is PHP-version-matrix shaped and a host analyzer has neither a PHP version nor an image.
- Analyzers are registry-driven and framework-declared (`AuditIntegrityProfile`); magento2 selects `composer` and `magento-module-di`. Composer covers manifest/lock validity, requirements missing from the lock, duplicate locked packages, and a major-version-level PHP constraint check against the configured stack. The Magento analyzer covers `registration.php` ↔ `module.xml` identity, XML well-formedness, duplicate DI targets, and `<sequence>` entries naming absent modules.
- Findings reuse the normalized `LintFinding` shape; the job writes an `integrity.json` artifact and persists the settings a rerun needs.
- The audit command no longer declares docker unconditionally: container-backed checks probe the runtime when selected and fail with exit `3` plus a hint pointing at `--checks integrity`, evaluated before target resolution because resolving the PHP policy itself probes the container.
- `scripts/core-contract.sh` now proves both halves inside a Docker-free container, and the CI job covers it.

Known limitation: target resolution still requires an `AuditLint` profile, so an integrity-only framework must also declare lint today.
