### PR TITLE
fix(audit): resolve sequence modules against installed vendor packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@
 
 # Dependencies and caches
 **/vendor/
+# Integrity fixtures model an installed Composer package tree: their vendor/
+# directories are test data, and the analyzer tests fail without them.
+!tests/fixtures/integrity/**/vendor/
+!tests/fixtures/integrity/**/vendor/**
 **/node_modules/
 **/.next/
 **/var/

--- a/internal/audit/integrity_magento.go
+++ b/internal/audit/integrity_magento.go
@@ -142,11 +142,18 @@ func (magentoModuleDIAnalyzer) Analyze(request IntegrityRequest) ([]LintFinding,
 		}
 	}
 
+	// The known-module set spans first-party modules and installed Composer
+	// modules: a <sequence> entry routinely names a Magento core module that
+	// lives under vendor/. Vendor code is read for names only — it is never the
+	// subject of the DI or identity checks below.
 	known := map[string]bool{}
 	for _, module := range modules {
 		if module.name != "" {
 			known[module.name] = true
 		}
+	}
+	for _, name := range vendorModuleNames(root) {
+		known[name] = true
 	}
 	for _, module := range modules {
 		for _, dependency := range module.sequence {
@@ -240,4 +247,40 @@ func relativeTo(root string, path string) string {
 		return filepath.ToSlash(path)
 	}
 	return filepath.ToSlash(relative)
+}
+
+// vendorModuleNames reads module names declared by installed Composer packages.
+// Both package layouts are covered explicitly — `etc/module.xml` at the package
+// root and the `src/etc/module.xml` variant — instead of walking vendor/ deeply,
+// which keeps the scan bounded and fast on a real Magento install. Vendor code
+// is read for names only; it is never the subject of the checks themselves.
+func vendorModuleNames(root string) []string {
+	vendorRoot := filepath.Join(root, "vendor")
+	if info, err := os.Stat(vendorRoot); err != nil || !info.IsDir() {
+		return nil
+	}
+	names := []string{}
+	for _, pattern := range []string{
+		filepath.Join(vendorRoot, "*", "*", "etc", "module.xml"),
+		filepath.Join(vendorRoot, "*", "*", "src", "etc", "module.xml"),
+	} {
+		matches, globErr := filepath.Glob(pattern)
+		if globErr != nil {
+			continue
+		}
+		for _, path := range matches {
+			raw, readErr := os.ReadFile(path)
+			if readErr != nil {
+				continue
+			}
+			var parsed magentoModuleXML
+			if xmlErr := xml.Unmarshal(raw, &parsed); xmlErr != nil {
+				continue
+			}
+			if name := strings.TrimSpace(parsed.Module.Name); name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
 }

--- a/tests/audit_integrity_magento_test.go
+++ b/tests/audit_integrity_magento_test.go
@@ -58,3 +58,21 @@ func TestMagentoIntegrityIgnoresNonModuleTrees(t *testing.T) {
 		t.Fatalf("expected no findings outside a Magento tree, got %v", rulesOf(findings))
 	}
 }
+
+func TestMagentoIntegritySequenceAcceptsVendorModules(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "magento-sequence-vendor")
+	// Magento core modules live under vendor/: a <sequence> entry naming one is
+	// not an unknown module, and vendor code is not itself reviewed.
+	assertNoRule(t, findings, "MAGENTO_SEQUENCE_UNKNOWN_MODULE")
+	if len(findings) != 0 {
+		t.Fatalf("expected a clean module, got %v", rulesOf(findings))
+	}
+}
+
+func TestMagentoIntegritySequenceAcceptsVendorSrcLayout(t *testing.T) {
+	findings := analyzeMagentoFixture(t, "magento-sequence-vendor-src")
+	assertNoRule(t, findings, "MAGENTO_SEQUENCE_UNKNOWN_MODULE")
+	if len(findings) != 0 {
+		t.Fatalf("expected a clean module, got %v", rulesOf(findings))
+	}
+}

--- a/tests/fixtures/integrity/magento-sequence-vendor-src/app/code/Acme/SrcSeq/etc/module.xml
+++ b/tests/fixtures/integrity/magento-sequence-vendor-src/app/code/Acme/SrcSeq/etc/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config>
+    <module name="Acme_SrcSeq">
+        <sequence>
+            <module name="Sutunam_ModuleDemo"/>
+        </sequence>
+    </module>
+</config>

--- a/tests/fixtures/integrity/magento-sequence-vendor-src/app/code/Acme/SrcSeq/registration.php
+++ b/tests/fixtures/integrity/magento-sequence-vendor-src/app/code/Acme/SrcSeq/registration.php
@@ -1,0 +1,2 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(\Magento\Framework\Component\ComponentRegistrar::MODULE, 'Acme_SrcSeq', __DIR__);

--- a/tests/fixtures/integrity/magento-sequence-vendor-src/vendor/sutunam/module-demo/src/etc/module.xml
+++ b/tests/fixtures/integrity/magento-sequence-vendor-src/vendor/sutunam/module-demo/src/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config>
+    <module name="Sutunam_ModuleDemo"/>
+</config>

--- a/tests/fixtures/integrity/magento-sequence-vendor/app/code/Acme/VendorSeq/etc/module.xml
+++ b/tests/fixtures/integrity/magento-sequence-vendor/app/code/Acme/VendorSeq/etc/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config>
+    <module name="Acme_VendorSeq">
+        <sequence>
+            <module name="Magento_Catalog"/>
+        </sequence>
+    </module>
+</config>

--- a/tests/fixtures/integrity/magento-sequence-vendor/app/code/Acme/VendorSeq/registration.php
+++ b/tests/fixtures/integrity/magento-sequence-vendor/app/code/Acme/VendorSeq/registration.php
@@ -1,0 +1,2 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(\Magento\Framework\Component\ComponentRegistrar::MODULE, 'Acme_VendorSeq', __DIR__);

--- a/tests/fixtures/integrity/magento-sequence-vendor/vendor/magento/module-catalog/etc/module.xml
+++ b/tests/fixtures/integrity/magento-sequence-vendor/vendor/magento/module-catalog/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config>
+    <module name="Magento_Catalog"/>
+</config>


### PR DESCRIPTION
Refs: #287

## Problem

Found by running the new container-free check against a **real project** (a 2.4.8 Magento install) instead of fixtures: the Magento integrity analyzer built its known-module set from first-party modules only, since `vendor/` is deliberately out of review scope. Every `<sequence>` entry naming a Magento core or third-party module was therefore reported as an unknown module — **66 findings, 64 of them false** (`BeBe9_Catalog depends on "Magento_Catalog"`, and so on).

Two later false positives had a different cause: some packages ship the module under `src/etc/module.xml` instead of `etc/module.xml`, which the depth-bounded walk also skipped.

## Fix

- Read module names from installed Composer manifests for **both package layouts** (`etc/module.xml` and `src/etc/module.xml`), while vendor code stays out of the DI and identity checks.
- Explicit globs replace the directory walk: bounded, no deep traversal, and faster (356 ms → 141 ms on the same project).

## Evidence on the real project

| | findings |
|---|---|
| before | 66 (64 false) |
| after | **4, each verified by hand** |

- `COMPOSER_REQUIREMENT_NOT_LOCKED` — `allure-framework/allure-phpunit` is in `require-dev` and absent from `composer.lock` (confirmed against both files).
- `MAGENTO_DI_DUPLICATE_TARGET` — a third-party `di.xml` declares the same `<type name="Magento\Framework\EntityManager\MetadataPool">` twice (lines 8 and 74).
- `MAGENTO_SEQUENCE_UNKNOWN_MODULE` ×2 — `Amasty_Gpdr` and `Mirasvit_Core` are referenced but present in neither `app/code` nor `vendor`.

Also verified: two consecutive runs produce an identical finding set; the check reports the same findings with Docker available and with it hidden; artifact `integrity.json` (schema 1) parses with the matching finding list; no container was created and the project tree stayed clean.

## Test plan

- [x] Two new fixtures cover the vendor layouts (`vendor/<v>/<p>/etc/module.xml` and `.../src/etc/module.xml`); the unknown-module fixture still fails as expected.
- [x] `make test` locally — generate, golangci-lint, gofmt check, vet, frontend, unit and integration all green.