### PR TITLE
fix(audit): gate the toolchain commands behind docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,12 @@ govard capabilities          # every command, its requirements, and host status
 govard capabilities --json   # same, machine-readable
 ```
 
-Docker is required only for stack commands. When it is missing, those commands
-exit `3` with `CAPABILITY_MISSING` instead of failing midway through their
-workflow, and `--error-json` prints the failure as a machine-readable envelope.
+Docker is required only for container-backed commands: the stack commands and
+`govard audit toolchain`, plus `govard audit run --checks lint|profiler`. When it
+is missing, those commands exit `3` with `CAPABILITY_MISSING` instead of failing
+midway through their workflow, and `--error-json` prints the failure as a
+machine-readable envelope. Container-free analysis (`govard audit run --checks
+integrity`) runs on the host and needs no Docker.
 `govard doctor` reports Docker as an optional capability (exit `0`); use
 `govard doctor --strict` when a script needs the old hard gate.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -135,10 +135,14 @@ govard capabilities          # command, requirement, and whether this host meets
 govard capabilities --json   # machine-readable
 ```
 
-Stack commands (`govard env up`, `svc`, `db`, `shell`, `test`, `audit`) need
-Docker; without it they exit `3` with `CAPABILITY_MISSING` before doing any work.
-`govard doctor` treats Docker as optional and exits `0`; `govard doctor --strict`
-restores the hard gate for bootstrap scripts.
+Stack commands (`govard env up`, `svc`, `db`, `shell`, `test`) need Docker;
+without it they exit `3` with `CAPABILITY_MISSING` before doing any work.
+`govard audit` is gated per check instead: `--checks lint` and `--checks
+profiler` need Docker, `--checks integrity` analyses the checkout on the host,
+and the `govard audit toolchain` commands always need Docker because they
+inspect, pull, and build a container image. `govard doctor` treats Docker as
+optional and exits `0`; `govard doctor --strict` restores the hard gate for
+bootstrap scripts.
 
 ## 🐳 Docker Images
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -290,7 +290,10 @@ analyzes the full target; result evidence therefore reports
 ### `govard audit toolchain`
 
 Manage the machine-wide Govard lint image. These commands do not need to run
-inside a Govard project and never invoke an external lint provider.
+inside a Govard project and never invoke an external lint provider. They do
+require a container runtime — without one they exit `3` with
+`CAPABILITY_MISSING` before touching Docker, like every other command whose
+manifest requirement is `docker` ([Runs Without Docker](/getting-started/installation#runs-without-docker)).
 
 ```bash
 govard audit toolchain status

--- a/docs/vi/reference/cli-commands.md
+++ b/docs/vi/reference/cli-commands.md
@@ -254,7 +254,11 @@ evidence vì thế báo `effective_scope: project`.
 ### `govard audit toolchain`
 
 Quản lý lint image dùng chung cho cả máy. Các lệnh này không cần chạy bên trong
-một Govard project và không bao giờ gọi external lint provider.
+một Govard project và không bao giờ gọi external lint provider. Chúng cần
+container runtime — trên host không có Docker, chúng thoát với mã `3` kèm
+`CAPABILITY_MISSING` trước khi chạm vào Docker, giống mọi lệnh khác có yêu cầu
+trong manifest là `docker`. Phân tích không cần container vẫn dùng được:
+`govard audit run --checks integrity`.
 
 ```bash
 govard audit toolchain status

--- a/docs/vi/workflows/audit.md
+++ b/docs/vi/workflows/audit.md
@@ -15,6 +15,9 @@ Govard lưu mỗi lần audit như một session bất biến tại `~/.govard/a
 # Lint toàn project (tự dò mode)
 govard audit run
 
+# Phân tích không cần container (Magento 2 / Mage-OS) — chạy trên host, không cần Docker
+govard audit run --checks integrity
+
 # Lint + profiler trên một URL (lần đầu cần --url)
 govard audit run --checks lint,profiler --url 'https://shop.test/category.html?product_list_limit=48'
 
@@ -42,6 +45,7 @@ Exit code: `0` khi mọi check pass, khác `0` sau summary khi có check fail/ca
 | Check | Chức năng |
 | :--- | :--- |
 | `lint` | Phân tích tĩnh qua backend native (`phpcs` + `phpstan` + media guard). |
+| `integrity` | Magento 2 / Mage-OS: phân tích không cần container, đọc trực tiếp checkout — Composer manifest/lock có khớp nhau, và tính nhất quán module/DI/sequence. Chạy trên host nên dùng được cả khi máy không có Docker. |
 | `profiler` | Capture `MAGE_PROFILER=csvfile` stock của Magento qua include web-server có lease, một `GET` có giới hạn tới `--url`, rồi khôi phục. |
 
 `profiler` yêu cầu:
@@ -115,6 +119,13 @@ govard audit toolchain status  # chỉ local — nên chạy gì tiếp
 govard audit toolchain pull    # chỉ image official đã ghim, không build
 govard audit toolchain build   # chỉ context nhúng, không pull
 ```
+
+Các lệnh này cần container runtime: `status` kiểm tra image local, `pull` tải
+một image, `build` build một image. Trên host không có Docker, chúng thoát với
+mã `3` kèm `CAPABILITY_MISSING` trước khi chạm vào bất cứ thứ gì, giống mọi lệnh
+cần Docker khác ([Runs Without Docker](/vi/getting-started/installation)). Phân
+tích không cần container không bị ảnh hưởng — `govard audit run --checks
+integrity` không hề chạm tới container.
 
 ---
 

--- a/docs/workflows/audit.md
+++ b/docs/workflows/audit.md
@@ -16,6 +16,9 @@ Govard persists every audit as an immutable session under `~/.govard/audit/<proj
 govard audit run --checks lint               # Magento2
 govard audit run --checks lint --mode project # Laravel/Symfony/WordPress (auto resolves)
 
+# Container-free analysis (Magento 2 / Mage-OS) — runs on the host, needs no Docker
+govard audit run --checks integrity
+
 # Lint + profiler on one URL (first run needs --url) — profiler is Magento-only
 govard audit run --checks lint,profiler --url 'https://shop.test/category.html?product_list_limit=48'
 
@@ -44,6 +47,7 @@ Exit code: `0` when all checks pass, non-zero after the summary when any check f
 | Check | What it does |
 | :--- | :--- |
 | `lint` | Static analysis via the Govard-native backend (`phpcs` + `phpstan` + media guard). |
+| `integrity` | Magento 2 / Mage-OS: container-free analysis of the checkout itself — Composer manifest/lock agreement and module/DI/sequence consistency. Runs on the host, so it works on a machine with no Docker. |
 | `profiler` | Captures Magento's stock `MAGE_PROFILER=csvfile` via a lease-protected web-server include, one bounded `GET` to `--url`, then restores everything. |
 
 `profiler` requires:
@@ -154,6 +158,13 @@ govard audit toolchain status  # local only — what to run next
 govard audit toolchain pull    # only pinned official image, never builds
 govard audit toolchain build   # only embedded context, never pulls
 ```
+
+These commands are container-backed: `status` inspects local images, `pull`
+fetches one, and `build` builds one. On a host without a container runtime they
+exit `3` with `CAPABILITY_MISSING` before touching anything, like every other
+Docker-requiring command ([Runs Without Docker](/getting-started/installation#runs-without-docker)).
+Container-free analysis is unaffected — `govard audit run --checks integrity`
+never touches a container.
 
 ---
 

--- a/internal/cmd/audit_runtime_gate_test.go
+++ b/internal/cmd/audit_runtime_gate_test.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"govard/internal/cli"
 	"govard/internal/runtime"
+
+	"github.com/spf13/cobra"
 )
 
 func stubMissingDocker(t *testing.T) {
@@ -61,5 +64,64 @@ func TestRequireContainerRuntimeSatisfiedWithDocker(t *testing.T) {
 
 	if err := requireContainerRuntime(); err != nil {
 		t.Fatalf("requireContainerRuntime = %v, want nil", err)
+	}
+}
+
+// auditToolchainCommand resolves one audit toolchain command path from the live
+// command tree.
+func auditToolchainCommand(t *testing.T, path string) *cobra.Command {
+	t.Helper()
+	command, _, err := rootCmd.Find(strings.Fields(path))
+	if err != nil {
+		t.Fatalf("resolve %q: %v", path, err)
+	}
+	want := "govard " + path
+	if command.CommandPath() != want {
+		t.Fatalf("resolve %q = %q, want %q", path, command.CommandPath(), want)
+	}
+	return command
+}
+
+// TestAuditToolchainCommandsDeclareContainerRuntime pins the requirement the
+// audit parent's "none" annotation would otherwise mask. Every descendant of
+// `audit` inherits the nearest annotation, and the audit group declares none so
+// the container-free integrity check stays runnable without Docker — so the
+// toolchain commands have to declare docker themselves to sit on the right side
+// of the gate.
+func TestAuditToolchainCommandsDeclareContainerRuntime(t *testing.T) {
+	for _, path := range []string{
+		"audit toolchain",
+		"audit toolchain status",
+		"audit toolchain pull",
+		"audit toolchain build",
+	} {
+		command := auditToolchainCommand(t, path)
+		requires := runtime.Requires(command)
+		if len(requires) != 1 || requires[0] != runtime.CapDocker {
+			t.Errorf("%s requires %v, want [docker]", command.CommandPath(), requires)
+		}
+	}
+}
+
+// TestAuditToolchainGateExitsCapabilityMissingWithoutDocker asserts the frozen
+// exit-code contract for the three commands that inspect, pull, and build the
+// lint image: without a container runtime they must fail through the gate with
+// CAPABILITY_MISSING instead of leaking a raw docker error.
+func TestAuditToolchainGateExitsCapabilityMissingWithoutDocker(t *testing.T) {
+	stubMissingDocker(t)
+	for _, path := range []string{
+		"audit toolchain status",
+		"audit toolchain pull",
+		"audit toolchain build",
+	} {
+		command := auditToolchainCommand(t, path)
+		gateErr := gateError(command)
+		var missing *runtime.MissingError
+		if !errors.As(gateErr, &missing) {
+			t.Fatalf("gateError(%s) = %v, want *runtime.MissingError", path, gateErr)
+		}
+		if code := cli.Code(gateErr); code != runtime.CodeCapabilityMissing {
+			t.Errorf("gateError(%s) exit code = %d, want %d", path, code, runtime.CodeCapabilityMissing)
+		}
 	}
 }

--- a/internal/cmd/audit_toolchain.go
+++ b/internal/cmd/audit_toolchain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"govard/internal/audit"
+	"govard/internal/runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -54,11 +55,21 @@ type auditToolchainStatusReport struct {
 // never resolve an audit target and work outside a Govard project.
 func newAuditToolchainCommand(options *auditCommandOptions, dependencies auditCommandDependencies) *cobra.Command {
 	command := &cobra.Command{
+		Annotations: map[string]string{
+			// The audit group declares "none" so the container-free integrity
+			// check stays runnable on a host without Docker, and the nearest
+			// annotation wins when requirements are resolved. These commands
+			// inspect, pull, and build a Docker image, so the group re-declares
+			// the requirement its children would otherwise inherit as "none".
+			runtime.AnnotationRequires: string(runtime.CapDocker),
+		},
 		Use:   "toolchain",
 		Short: "Inspect, pull, or build the Govard lint toolchain image",
 		Long: "Manage the Govard-owned Magento lint image.\n\n" +
 			"These commands act on a machine-wide image and do not need to run inside a\n" +
-			"Govard project. They never run an externally configured lint provider.",
+			"Govard project. They never run an externally configured lint provider.\n\n" +
+			"They do require a container runtime: without one they exit 3 with\n" +
+			"CAPABILITY_MISSING before touching Docker.",
 	}
 	command.AddCommand(
 		newAuditToolchainStatusCommand(options, dependencies),

--- a/internal/cmd/gate_test.go
+++ b/internal/cmd/gate_test.go
@@ -52,3 +52,79 @@ func TestGateReportsMissingDocker(t *testing.T) {
 		t.Fatalf("exit code = %d, want %d", got, runtime.CodeCapabilityMissing)
 	}
 }
+
+// TestGateBlocksNestedDoctorCommand pins the always-runnable set to TOP-LEVEL
+// commands. `doctor` is the diagnostic entry point that must survive a host
+// without Docker, but `desktop doctor` is a different, container-backed command:
+// matching the leaf name let it through the gate on a Docker-free host even
+// though its manifest requirement is docker.
+func TestGateBlocksNestedDoctorCommand(t *testing.T) {
+	stubMissingDocker(t)
+	root := &cobra.Command{Use: "govard"}
+	desktop := &cobra.Command{
+		Use:         "desktop",
+		Annotations: map[string]string{runtime.AnnotationRequires: "docker"},
+	}
+	desktop.RunE = func(*cobra.Command, []string) error { return nil }
+	doctor := &cobra.Command{Use: "doctor"}
+	doctor.RunE = func(*cobra.Command, []string) error { return nil }
+	root.AddCommand(desktop)
+	desktop.AddCommand(doctor)
+
+	err := gateError(doctor)
+	var missing *runtime.MissingError
+	if !errors.As(err, &missing) {
+		t.Fatalf("gateError(desktop doctor) = %v, want *runtime.MissingError", err)
+	}
+	if got := cli.Code(err); got != runtime.CodeCapabilityMissing {
+		t.Fatalf("exit code = %d, want %d", got, runtime.CodeCapabilityMissing)
+	}
+}
+
+// TestGateSkipsAlwaysRunnableSubcommands is the mirror case: the always-runnable
+// groups carry subcommands (`completion bash`, ...) that are part of the same
+// operator-facing surface, so blocking them on a host without Docker denies
+// shell setup for exactly the reason the set exists.
+func TestGateSkipsAlwaysRunnableSubcommands(t *testing.T) {
+	stubMissingDocker(t)
+	root := &cobra.Command{Use: "govard"}
+	completion := &cobra.Command{Use: "completion"}
+	completion.RunE = func(*cobra.Command, []string) error { return nil }
+	bash := &cobra.Command{Use: "bash"}
+	bash.RunE = func(*cobra.Command, []string) error { return nil }
+	root.AddCommand(completion)
+	completion.AddCommand(bash)
+
+	if err := gateError(bash); err != nil {
+		t.Fatalf("gateError(completion bash) = %v, want nil", err)
+	}
+}
+
+// TestRealTreeAlwaysRunnableSet covers the shipped command tree rather than a
+// synthetic one, because the defect it guards against is a name collision that
+// only exists in the real tree.
+func TestRealTreeAlwaysRunnableSet(t *testing.T) {
+	// The help command is added lazily by cobra, exactly as the first Execute
+	// would; the completion children are only registered by Execute, which is
+	// why their case is covered by the synthetic test above.
+	rootCmd.InitDefaultHelpCmd()
+	byName := map[string]bool{}
+	walkCommandTree(rootCmd, func(cmd *cobra.Command) {
+		if cmd != rootCmd && runtime.AlwaysRunnable(cmd) {
+			byName[cmd.CommandPath()] = true
+		}
+	})
+	for _, path := range []string{
+		"govard doctor",
+		"govard version",
+		"govard capabilities",
+		"govard help",
+	} {
+		if !byName[path] {
+			t.Errorf("%s must stay runnable on any host", path)
+		}
+	}
+	if byName["govard desktop doctor"] {
+		t.Error("govard desktop doctor declares docker, so it must not be always-runnable")
+	}
+}

--- a/internal/runtime/annotations.go
+++ b/internal/runtime/annotations.go
@@ -17,9 +17,17 @@ var knownCapabilities = map[Capability]struct{}{
 // Requires resolves the requirement for a command: the nearest annotation wins,
 // groups without a run function have none, and a runnable command that declares
 // nothing defaults to docker (default-deny).
+//
+// A command that must run on any host has no requirement at all, so the
+// always-runnable entry points and their subcommands resolve to none. The gate
+// short-circuits those commands before consulting this, and reporting docker for
+// them made `govard capabilities` claim a requirement the gate never enforced.
 func Requires(cmd *cobra.Command) []Capability {
 	if cmd == nil {
 		return nil
+	}
+	if AlwaysRunnable(cmd) {
+		return []Capability{CapNone}
 	}
 	for current := cmd; current != nil; current = current.Parent() {
 		raw, ok := current.Annotations[AnnotationRequires]
@@ -66,8 +74,25 @@ var alwaysRunnableNames = map[string]bool{
 
 // AlwaysRunnable reports whether a command must run regardless of capability
 // state. It is shared by the command gate and the manifest completeness guard.
+//
+// The match is on the command's TOP-LEVEL name, never on its leaf name: the
+// entry point is what carries the guarantee, and its subcommands are part of the
+// same operator-facing surface (a host with no container runtime must still be
+// able to print `completion bash`). Matching leaf names broke the contract in
+// both directions — `desktop doctor` skipped the gate despite declaring docker,
+// while `completion bash` was gated to docker even though `completion` is on
+// this list.
 func AlwaysRunnable(cmd *cobra.Command) bool {
-	return cmd != nil && alwaysRunnableNames[cmd.Name()]
+	return cmd != nil && alwaysRunnableNames[topLevelName(cmd)]
+}
+
+// topLevelName returns the name of the command one level below the root.
+func topLevelName(cmd *cobra.Command) string {
+	name := cmd.Name()
+	for parent := cmd.Parent(); parent != nil && parent.Parent() != nil; parent = parent.Parent() {
+		name = parent.Name()
+	}
+	return name
 }
 
 // HasDeclaredRequirement reports whether the command or one of its ancestors

--- a/internal/runtime/annotations_test.go
+++ b/internal/runtime/annotations_test.go
@@ -62,3 +62,46 @@ func TestRequiresTreatsUnknownCapabilityAsDocker(t *testing.T) {
 		t.Fatalf("Requires = %#v, want %#v", got, want)
 	}
 }
+
+// TestAlwaysRunnableMatchesTopLevelCommand pins the always-runnable set to the
+// top-level entry points. Matching the leaf name let `desktop doctor` skip the
+// gate although it declares docker, and gated `completion bash` although
+// `completion` is on the list.
+func TestAlwaysRunnableMatchesTopLevelCommand(t *testing.T) {
+	root := newCmd("govard", false, "")
+	desktop := newCmd("desktop", true, "docker")
+	doctor := newCmd("doctor", true, "")
+	completion := newCmd("completion", true, "")
+	bash := newCmd("bash", true, "")
+	root.AddCommand(desktop, completion)
+	desktop.AddCommand(doctor)
+	completion.AddCommand(bash)
+
+	if AlwaysRunnable(doctor) {
+		t.Error("desktop doctor must not be always-runnable")
+	}
+	if !AlwaysRunnable(bash) {
+		t.Error("completion bash must be always-runnable")
+	}
+	if !AlwaysRunnable(newCmd("doctor", true, "")) {
+		t.Error("the top-level doctor must be always-runnable")
+	}
+}
+
+// TestRequiresReportsNoneForAlwaysRunnableCommands keeps the manifest honest:
+// these commands carry no runtime requirement, so `govard capabilities` must not
+// report one the gate never enforces.
+func TestRequiresReportsNoneForAlwaysRunnableCommands(t *testing.T) {
+	root := newCmd("govard", false, "")
+	completion := newCmd("completion", true, "")
+	bash := newCmd("bash", true, "")
+	root.AddCommand(completion)
+	completion.AddCommand(bash)
+
+	if got, want := Requires(bash), []Capability{CapNone}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Requires(completion bash) = %#v, want %#v", got, want)
+	}
+	if got, want := Requires(root), []Capability(nil); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Requires(govard) = %#v, want %#v", got, want)
+	}
+}

--- a/scripts/core-contract.sh
+++ b/scripts/core-contract.sh
@@ -109,6 +109,12 @@ check_gate() {
 
 check_gate "env up" docker
 check_gate "tunnel status" cloudflared
+# The toolchain commands inspect, pull, and build a Docker image. They live
+# under `audit`, which declares no requirement so the container-free integrity
+# check stays runnable here, so the group re-declares docker itself.
+check_gate "audit toolchain status" docker
+check_gate "audit toolchain pull" docker
+check_gate "audit toolchain build" docker
 
 # 5. Container-free analysis. The integrity check reads the checkout directly;
 #    the container-backed lint check must refuse with exit 3 and point here.


### PR DESCRIPTION
Closes #290

### Summary

`govard audit` declares no runtime requirement so the container-free integrity
check runs on a host without Docker, and requirements resolve to the nearest
annotation — so every child inherited `none`, including the three
container-backed `audit toolchain` commands. Two commits, both in the same
capability contract:

1. `fix(audit): gate the toolchain commands behind docker` — declare `docker` on
   the `audit toolchain` group, so the standard gate fails fast with exit 3 and
   the `CAPABILITY_MISSING` envelope instead of a raw docker error (`build`) or
   a silently wrong answer (`status`, which swallowed the inspection failure).
2. `fix(runtime): match always-runnable by top-level command` — match one level
   below the root instead of the leaf name, so `desktop doctor` (declares
   docker) stops skipping the gate and `completion bash` stops being gated to
   docker; `Requires` reports `none` for those commands so
   `govard capabilities` no longer claims a requirement the gate never enforced.

### Rationale

The manifest is the single source of truth for the Docker-free contract, so a
command that needs Docker must be declared where `Requires` resolves it, not
gated ad hoc in each `RunE`. Declaring on the group keeps the whole subtree
consistent with the children's own inheritance rule and needs no second hint
vocabulary.

Matching the always-runnable set by top-level command also fixes the mirror
failure: an operator on a Docker-free host could not generate shell
completions, which is precisely the discovery/setup case that set exists for.

### Test plan

- [x] TDD: new gate tests were RED first (`audit toolchain requires [none]`,
      `gateError = <nil>`; `completion bash` gated) before implementation.
- [x] `make test` — full local gate (generate + golangci-lint + fmt-check + vet
      + frontend + unit + integration), exit 0.
- [x] `scripts/core-contract.sh` end to end in a Docker-free mount + network
      namespace with no docker/ssh/rsync/cloudflared on `PATH`
      (`unshare -rmn`), exit 0 — including the three new
      `check_gate "audit toolchain …" docker` assertions.
- [x] Live before/after with the docker binary removed from `PATH`:
      `audit toolchain status|pull|build` → exit 3 with
      `"capability": "docker"` in the envelope; with Docker present
      `toolchain status` still exits 0.
- [x] Live: `desktop doctor` → exit 3 `CAPABILITY_MISSING`; `completion bash`
      prints the script; `govard capabilities` lists `help`/`completion *` as
      `none`.
- [x] Docs updated (`README.md`, installation, audit workflow EN + VI,
      cli-commands EN + VI), including the stale "Docker is required only for
      stack commands" claim and the previously undocumented `--checks
      integrity` check.

### Notes

`CHANGELOG.md` is intentionally untouched — per repo policy it belongs to the
release commit.