### PR TITLE
docs: document the development binary workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,32 @@ go vet ./...                    # static analysis
 gofmt -s -w .                   # format
 ```
 
+### Local binary for development testing
+
+`make build` writes `bin/govard`, stamped by `git describe` (e.g.
+`v1.72.0-5-gfd88cb4`; a `-dirty` suffix means uncommitted changes). `bin/` is
+gitignored, so the binary itself is never committed. To exercise a change
+before it is released:
+
+```bash
+make build                                        # from the branch you changed
+./bin/govard <command>                            # explicit path, never a bare `govard`
+install -m0755 bin/govard ~/.local/bin/govard     # only to test PATH consumers (plugin, skills)
+```
+
+- Always call the built binary **by path**. A bare `govard` resolves through
+  `PATH`, which can hold several copies (user install, `/usr/local/bin`, a stale
+  shim directory); a probe that silently ran an older one has already produced a
+  bogus result.
+- `~/.local/bin` precedes `/usr/local/bin`, so a user-level copy shadows the
+  installed CLI without sudo. Confirm what is actually in effect with
+  `which -a govard && govard version`.
+- **Delete the binary when the testing is done**:
+  `rm -f ~/.local/bin/govard bin/govard`. A leftover outlives the branch it came
+  from — the next session then reads a version that matches no commit, and a
+  shadowing copy keeps answering for the installed CLI. Rebuilding takes
+  seconds, so never keep one "just in case".
+
 ## Code Standards
 
 - Run `gofmt` after Go edits


### PR DESCRIPTION
Closes #292

### Summary

Adds a **Local binary for development testing** subsection to `AGENTS.md`
under `Build & Test`:

- `make build` writes `bin/govard`, stamped by `git describe` (`-dirty` means
  uncommitted changes); `bin/` is gitignored, so the artifact is never
  committed.
- Probe with the **explicit path** (`./bin/govard …`). A bare `govard` resolves
  through `PATH`, which can hold several copies — during the capability-gate
  work a Docker-free probe silently ran the older installed binary and reported
  a bogus result.
- `install -m0755 bin/govard ~/.local/bin/govard` only to exercise consumers
  that resolve `govard` from `PATH` (plugin, skills). `~/.local/bin` precedes
  `/usr/local/bin`, so it shadows the installed CLI without sudo; confirm what
  is in effect with `which -a govard && govard version`.
- **Delete the binary when the testing is done**
  (`rm -f ~/.local/bin/govard bin/govard`): a leftover outlives its branch, so
  the next session reads a version matching no commit and a shadowing copy keeps
  answering for the installed CLI.

### Applied in this session

The workflow was used and then cleaned up as documented: `bin/govard`
(`v1.72.0-5-gfd88cb4`) and `bin/govard-test` removed, `~/.local/bin/govard`
removed — `which -a govard` now resolves only `/usr/local/bin/govard`
(`v1.71.2`), the released CLI.

### Test plan

- [x] `make test` — full local gate (generate + golangci-lint + fmt-check + vet
      + frontend + unit + integration), exit 0. Docs-only change.
- [x] `git status` clean on the branch; only `AGENTS.md` modified.
- [x] Cleanup verified: `which -a govard && govard version` → `/usr/local/bin/govard`,
      `v1.71.2`.