### PR TITLE
fix(cli): declare docker for the commands that need it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,9 +185,9 @@ inheriting `docker`. The bar, by kind of work:
 
 - host discovery and diagnostics: `capabilities`, `doctor`, `version`, `help`,
   `completion`, `desktop doctor`;
-- project configuration, the registry, and local caches: `config get|set|auto`,
-  `config profile`, `lock *`, `blueprint cache *`, `init`, `custom list`,
-  `project list`, `project open`, `domain list`, `vscode setup`;
+- project configuration, the registry, and local caches: `config get|set`,
+  `config profile`, `blueprint cache *`, `init`, `custom list`, `project list`,
+  `project open`, `domain list`, `vscode setup`;
 - static analysis of the checkout: `audit run --checks integrity` plus the
   host-side audit lifecycle (`status`, `result`, `diff`, `cleanup`);
 - direct host or network work: `remote *` (SSH), `sync` (rsync), `tunnel *`

--- a/docs/reference/docker-free.md
+++ b/docs/reference/docker-free.md
@@ -35,7 +35,6 @@ govard capabilities --json   # machine-readable (schema_version 1)
 | `govard completion powershell` | `none` |
 | `govard completion zsh` | `none` |
 | `govard config` | `none` |
-| `govard config auto` | `none` |
 | `govard config get` | `none` |
 | `govard config profile` | `none` |
 | `govard config profile clear` | `none` |
@@ -48,10 +47,6 @@ govard capabilities --json   # machine-readable (schema_version 1)
 | `govard domain list` | `none` |
 | `govard help` | `none` |
 | `govard init` | `none` |
-| `govard lock` | `none` |
-| `govard lock check` | `none` |
-| `govard lock diff` | `none` |
-| `govard lock generate` | `none` |
 | `govard project list` | `none` |
 | `govard project open` | `none` |
 | `govard remote add` | `ssh,rsync` |
@@ -99,11 +94,13 @@ the `vscode <tool>` wrappers, `deploy`, `bootstrap`, `debug`, launching
   and its absence does not fail the command (`--strict` restores the hard gate
   for bootstrap scripts). `govard trust` installs the local CA into the host
   trust store.
-- **Configuration.** `govard config get|set|auto` and `govard config profile`
-  read and write project configuration; `govard config profile clear`,
-  `govard lock check|diff|generate`, and `govard blueprint cache list|clear`
-  work on files and the local cache. Applying a profile to a running stack
-  (`config profile apply|switch`) is container work.
+- **Configuration.** `govard config get|set` and `govard config profile`
+  read and write project configuration; `govard config profile clear` and
+  `govard blueprint cache list|clear` work on files and the local cache.
+  Applying a profile to a running stack (`config profile apply|switch`),
+  `govard config auto` (it configures the framework inside the container), and
+  every `govard lock` command are container work: the lock file records the
+  resolved docker/compose versions and service image digests.
 - **Project scaffolding.** `govard init` and `govard custom list`.
 - **Registry and domains.** `project list` and `project open` read the registry;
   `domain list` prints the project's domains; `vscode setup` derives the editor

--- a/docs/vi/reference/docker-free.md
+++ b/docs/vi/reference/docker-free.md
@@ -35,7 +35,6 @@ govard capabilities --json   # machine-readable (schema_version 1)
 | `govard completion powershell` | `none` |
 | `govard completion zsh` | `none` |
 | `govard config` | `none` |
-| `govard config auto` | `none` |
 | `govard config get` | `none` |
 | `govard config profile` | `none` |
 | `govard config profile clear` | `none` |
@@ -48,10 +47,6 @@ govard capabilities --json   # machine-readable (schema_version 1)
 | `govard domain list` | `none` |
 | `govard help` | `none` |
 | `govard init` | `none` |
-| `govard lock` | `none` |
-| `govard lock check` | `none` |
-| `govard lock diff` | `none` |
-| `govard lock generate` | `none` |
 | `govard project list` | `none` |
 | `govard project open` | `none` |
 | `govard remote add` | `ssh,rsync` |
@@ -98,11 +93,13 @@ Những lệnh có yêu cầu bao gồm `docker` thì đi qua gate: vòng đời
 - **Chẩn đoán.** `govard doctor` chạy ở mọi nơi; Docker chỉ là một check tùy
   chọn và thiếu nó không làm lệnh fail (`--strict` khôi phục hard gate cho
   script bootstrap). `govard trust` cài CA nội bộ vào trust store của máy.
-- **Cấu hình.** `govard config get|set|auto` và `govard config profile` đọc/ghi
-  cấu hình project; `govard config profile clear`, `govard lock
-  check|diff|generate`, `govard blueprint cache list|clear` làm việc trên file
-  và cache local. Áp profile vào stack đang chạy (`config profile apply|switch`)
-  là việc của container.
+- **Cấu hình.** `govard config get|set` và `govard config profile` đọc/ghi
+  cấu hình project; `govard config profile clear` và
+  `govard blueprint cache list|clear` làm việc trên file và cache local. Áp
+  profile vào stack đang chạy (`config profile apply|switch`), `govard config
+  auto` (nó cấu hình framework bên trong container) và mọi lệnh `govard lock` là
+  việc của container: lock file ghi lại version docker/compose đã phân giải và
+  digest image của từng service.
 - **Khởi tạo project.** `govard init` và `govard custom list`.
 - **Registry và domain.** `project list` và `project open` đọc registry;
   `domain list` in ra domain của project; `vscode setup` suy ra cấu hình editor từ

--- a/internal/cmd/config_auto.go
+++ b/internal/cmd/config_auto.go
@@ -5,6 +5,7 @@ import (
 	"govard/internal/engine"
 	"govard/internal/frameworks"
 	"govard/internal/frameworks/types"
+	"govard/internal/runtime"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -17,6 +18,13 @@ import (
 var frameworkLookupForAutoConfigure = frameworks.Get
 
 var configAutoCmd = &cobra.Command{
+	Annotations: map[string]string{
+		// "Auto-configure runtime files" is done inside the project's container:
+		// it runs composer install, prepares the Magento writable dirs, and
+		// enables developer mode. Declaring none only moved the failure past the
+		// gate and surfaced it as `exec: "docker"` mid-run.
+		runtime.AnnotationRequires: string(runtime.CapDocker),
+	},
 	Use:   "auto",
 	Short: "Auto-configure framework runtime files",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/docker_free_surface_test.go
+++ b/internal/cmd/docker_free_surface_test.go
@@ -55,6 +55,14 @@ func TestContainerBackedSiblingsKeepDocker(t *testing.T) {
 		"domain remove",
 		"project delete",
 		"project orphans",
+		// The lock file records the resolved runtime environment — docker and
+		// compose versions plus every service image digest — so all three lock
+		// commands read the container runtime.
+		"config auto",
+		"lock",
+		"lock generate",
+		"lock check",
+		"lock diff",
 	} {
 		command := resolveCommandForTest(t, path)
 		if got, want := runtime.Requires(command), []runtime.Capability{runtime.CapDocker}; !reflect.DeepEqual(got, want) {

--- a/internal/cmd/lock.go
+++ b/internal/cmd/lock.go
@@ -17,7 +17,12 @@ var lockDependencies = engine.LockDependencies{}
 
 var lockCmd = &cobra.Command{
 	Annotations: map[string]string{
-		runtime.AnnotationRequires: string(runtime.CapNone),
+		// The lock file records the resolved runtime environment: docker and
+		// compose versions plus the digest of every service image. Generating,
+		// checking, and diffing all read that environment through
+		// BuildLockFileFromConfig, so every lock command needs the container
+		// runtime — declaring none here only moved the failure past the gate.
+		runtime.AnnotationRequires: string(runtime.CapDocker),
 	},
 	Use:   "lock",
 	Short: "Manage project lock file",

--- a/scripts/core-contract.sh
+++ b/scripts/core-contract.sh
@@ -201,12 +201,31 @@ check_runs() {
     echo "core-contract: FAIL govard $command is gated on a capability it must not need" >&2
     failures=$((failures + 1))
   fi
+  # The gate can only own a failure the command declares. A requirement-free
+  # command that still reaches for the container runtime fails here instead of
+  # surfacing as a raw runtime error on a user's host — the way `lock generate`
+  # and `config auto` did before they declared docker.
+  if printf '%s' "$out" | grep -qE 'exec: "docker"|Cannot connect to the Docker daemon|resolve docker version|resolve docker compose version|resolve service images'; then
+    echo "core-contract: FAIL govard $command declared no requirement but reached for the container runtime" >&2
+    printf '%s\n' "$out" >&2
+    failures=$((failures + 1))
+  fi
 }
 
 check_runs "project list" "$fixture_dir" "registry listing"
 check_runs "desktop doctor" "$fixture_dir" "desktop diagnostics"
 check_runs "domain list" "$fixture_dir" "domain listing"
 check_runs "vscode setup" "$fixture_dir" "editor setup"
+check_runs "config get domain" "$fixture_dir" "config read"
+check_runs "custom list" "$fixture_dir" "custom command listing"
+check_runs "blueprint cache list" "$fixture_dir" "blueprint cache listing"
+
+# 7. Commands that resolve the runtime environment must be gated, not fail with a
+#    raw docker error: the lock file records the docker/compose versions and
+#    service image digests, and `config auto` configures the framework inside the
+#    container.
+check_gate "lock generate" docker
+check_gate "config auto" docker
 
 if [ "$failures" -ne 0 ]; then
   echo "core-contract: $failures failure(s)" >&2


### PR DESCRIPTION
Closes #297

### Summary

Ran the Docker-free surface in **both** environments — a container with no
container runtime (`debian:bookworm-slim`, no docker CLI, no socket) and this
host, which has docker — and found two families declared `none` whose work goes
through the container runtime anyway. On a Docker-free host they failed *past*
the gate with a raw runtime error instead of exit `3`:

| Command | Without docker |
| --- | --- |
| `govard lock generate` | `ERROR resolve docker version: exec: "docker"` (exit 1) |
| `govard lock check` / `lock diff` | same, once a lock file exists |
| `govard config auto` | `ERROR configuration failed: … Enable Developer Mode exec: "docker"` (exit 1) |

`BuildLockFileFromConfig` records the resolved docker/compose versions and every
service image digest; `config auto` configures the framework inside the
container. Both genuinely need the runtime, so they now declare `docker` and the
gate owns the failure (exit 3 + `CAPABILITY_MISSING`). The reference pages
(EN + VI) and the AGENTS.md support rule drop them in the same change.

### The guard this adds

`scripts/core-contract.sh` now fails the Docker-free job when a
requirement-free command reaches for the container runtime
(`exec: "docker"`, `Cannot connect to the Docker daemon`, `resolve docker
version`, …) — the assertion that would have caught both families — and asserts
`lock generate` / `config auto` as gates. It also runs three more Docker-free
commands for real (`config get domain`, `custom list`, `blueprint cache list`).

### Verification — both environments, same command surface

A harness drove the surface in each environment: every Docker-free command from
`capabilities`, the ones that only read local state executed for real, the
network/tunnel ones either executed (container: nothing live to reach) or
asserted from the manifest (host: they would touch live infrastructure), and the
container-backed commands asserted to gate with exit 3.

| Environment | Before this change | After |
| --- | --- | --- |
| container, no docker (`debian:bookworm-slim`) | 3 failures (`lock generate`, `config auto`, plus a wrong harness expectation) | **95 pass / 0 fail** |
| host with docker | clean | **85 pass / 0 fail** |
| `core-contract.sh` inside the container | OK | **OK** (with the new assertions) |

- [x] TDD: `lock` and `config auto` added to the container-backed surface test
      before the annotations changed.
- [x] `make test` — full local gate, exit 0.
- [x] Raw-docker detection distinguishes a real failure from `govard doctor`
      reporting docker as a missing *optional* check (WARNING/INFO, exit 0).
- [x] Docs guard still green: the reference pages and `capabilities --json`
      agree after dropping the four rows.

### Noted, not changed

`govard doctor` and `desktop doctor` were verified as Docker-free in both
environments. `db` exits 2 for a missing argument: cobra validates args before
`PersistentPreRunE`, so usage errors win over the capability gate — frozen
behaviour, not a regression (the contract script uses argument-free commands for
gate assertions).