### PR TITLE
fix(deploy): install ext-curl in the Magento sandbox

### DIFF
--- a/internal/frameworks/magento2/deploy_recipe.go
+++ b/internal/frameworks/magento2/deploy_recipe.go
@@ -212,8 +212,12 @@ func DeployRecipe() deploy.Recipe {
 	// the application's, not govard's: a different framework asks for a
 	// different set, and nothing here is interpreted by the core.
 	recipe.Sandbox = deploy.SandboxRequirements{
-		Packages:   []string{"libxslt1-dev", "libzip-dev", "libpng-dev", "libjpeg-dev", "libfreetype6-dev", "default-mysql-client"},
-		Extensions: []string{"bcmath", "gd", "intl", "mysql", "soap", "sockets", "xsl", "zip"},
+		Packages: []string{"libxslt1-dev", "libzip-dev", "libpng-dev", "libjpeg-dev", "libfreetype6-dev", "default-mysql-client"},
+		// `curl` is not optional: Magento's own composer platform check requires
+		// ext-curl, so without it a real project stops at build:vendors — a first
+		// trial against a real project failed exactly there, and the rest of this
+		// list was already satisfied (composer check-platform-reqs).
+		Extensions: []string{"bcmath", "curl", "gd", "intl", "mysql", "soap", "sockets", "xsl", "zip"},
 		Services:   []string{"mariadb"},
 	}
 	return recipe

--- a/tests/deploy_recipe_magento2_test.go
+++ b/tests/deploy_recipe_magento2_test.go
@@ -747,3 +747,33 @@ func TestMagento2UnsetRuntimeReloadIsANoOp(t *testing.T) {
 		t.Fatalf("the cache step must run with no reload configured: %v\n%s", err, stub)
 	}
 }
+
+// The sandbox image the recipe asks for has to satisfy the platform check a real
+// project's `composer install` performs. A first trial of the deploy sandbox against
+// a real Magento project stopped at build:vendors with "magento/framework requires
+// ext-curl * -> it is missing from your system"; installing php-curl in the running
+// container moved it to the next (project-side) failure, and `composer
+// check-platform-reqs` there then reported every other extension as satisfied — so
+// `curl` was the one gap in this list.
+func TestMagento2SandboxRequirementsCoverThePlatformCheck(t *testing.T) {
+	requirements := magento2.DeployRecipe().Sandbox
+
+	extensions := map[string]bool{}
+	for _, extension := range requirements.Extensions {
+		extensions[extension] = true
+	}
+	// Every extension Magento's own composer platform check names and Debian does not
+	// ship in php-cli. `curl` was the missing one.
+	for _, want := range []string{"curl", "bcmath", "gd", "intl", "mysql", "soap", "sockets", "xsl", "zip"} {
+		if !extensions[want] {
+			t.Errorf("sandbox requirements do not install ext-%s, so a real composer install cannot pass its platform check", want)
+		}
+	}
+
+	// The services the recipe's own commands need: setup:upgrade and setup:db:status
+	// talk to a database.
+	services := strings.Join(requirements.Services, " ")
+	if !strings.Contains(services, "mariadb") {
+		t.Errorf("sandbox services = %q, want a database for the recipe's own commands", services)
+	}
+}


### PR DESCRIPTION
A first trial of the sandbox deploy against a real Magento 2.4.7 project (Apache,
MariaDB, PHP 8.2, private Composer repositories) stopped at `build:vendors`:

```
magento/framework 103.0.9 requires ext-curl * -> it is missing from your system.
```

Magento's own Composer platform check requires `ext-curl`, and the recipe's sandbox
requirements did not install it — so no project with Magento's dependencies could
install in the sandbox at all. The recipe already asks for `bcmath`, `gd`, `intl`,
`mysql`, `soap`, `sockets`, `xsl` and `zip`; `curl` was the one gap.

**How the trial established that it is the only gap.** The pipeline itself ran
cleanly over real SSH (preflight, lock, release, code from the git mirror, shared,
writable), and the new `--verbose` streaming showed Composer's own output live,
indented under the failing task. After `apt-get install php-curl` in the running
container, `composer check-platform-reqs` against the project's lock reported every
other extension satisfied — `mbstring` and `ctype` arrive through Composer
polyfills — leaving a single failure that is the *project's* to fix: PHP 8.2 on the
target against a lock whose Magento 2.4.8-era packages require 8.3+ (`symfony/… v8.1.4`
wants 8.4.1+).

**Validation:** `TestMagento2SandboxRequirementsCoverThePlatformCheck` fails on
"do not install ext-curl" before the change, and `make test` (lint, fmt, vet, unit,
integration) is green with it. The trial itself was run with a binary built from
`master` at the merge commit, by path, and deleted afterwards.\n\nNot in this PR: making the sandbox's PHP version selectable. The base image is
pinned Debian with PHP 8.2, so a project whose dependencies need 8.3+ cannot be
rehearsed there yet; that is a separate decision (a `--php` option on
`sandbox up`, or a documented limitation plus the artifact build mode where the
version already matches).